### PR TITLE
Change spelling of error message to match corresponding PostgreSQL message.

### DIFF
--- a/libnaucrates/src/exception.cpp
+++ b/libnaucrates/src/exception.cpp
@@ -149,9 +149,9 @@ gpdxl::EresExceptionInit
 
 			CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation),
 					CException::ExsevError,
-					GPOS_WSZ_WSZLEN("NULL value in column \"%ls\" violates not-null constraint"),
+					GPOS_WSZ_WSZLEN("null value in column \"%ls\" violates not-null constraint"),
 					1, //
-					GPOS_WSZ_WSZLEN("NULL value in column violates not-null constraint")),
+					GPOS_WSZ_WSZLEN("null value in column violates not-null constraint")),
 
 			CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLDuplicateRTE),
 					CException::ExsevError,


### PR DESCRIPTION
This eliminates the unnecessary difference in output depending on whether a query is planned with ORCA or the Postgres planner. Which is good for keeping regression tests simple.

This doesn't include any changes to expected output. Can someone run this through whatever tests you usually run, and merge, please? There are a few tests in GPDB's installcheck-good that need to have their expected output changed because of this, and I can take care of that, but I don't know what else is impacted.