### PR TITLE
Change spelling of error message to match corresponding PostgreSQL message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 620)
+set(GPORCA_VERSION_MINOR 621)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.620
+LIB_VERSION = 1.621
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/libnaucrates/src/exception.cpp
+++ b/libnaucrates/src/exception.cpp
@@ -149,9 +149,9 @@ gpdxl::EresExceptionInit
 
 			CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLNotNullViolation),
 					CException::ExsevError,
-					GPOS_WSZ_WSZLEN("NULL value in column \"%ls\" violates not-null constraint"),
+					GPOS_WSZ_WSZLEN("null value in column \"%ls\" violates not-null constraint"),
 					1, //
-					GPOS_WSZ_WSZLEN("NULL value in column violates not-null constraint")),
+					GPOS_WSZ_WSZLEN("null value in column violates not-null constraint")),
 
 			CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLDuplicateRTE),
 					CException::ExsevError,


### PR DESCRIPTION
This eliminates the unnecessary difference in output depending on whether
a query is planned with ORCA or the Postgres planner. Which is good for
keeping regression tests simple.