### PR TITLE
Add inputSorted attribute to CPhysicalDML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 622)
+set(GPORCA_VERSION_MINOR 623)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.622
+LIB_VERSION = 1.623
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
+++ b/data/dxl/minidump/Insert-AO-Partitioned-SortDisabled.mdp
@@ -399,7 +399,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.417092" Rows="20.000000" Width="8"/>
         </dxl:Properties>

--- a/data/dxl/minidump/Insert-AO-Partitioned.mdp
+++ b/data/dxl/minidump/Insert-AO-Partitioned.mdp
@@ -411,7 +411,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="true">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.418333" Rows="20.000000" Width="8"/>
         </dxl:Properties>

--- a/data/dxl/minidump/Insert-AO.mdp
+++ b/data/dxl/minidump/Insert-AO.mdp
@@ -363,7 +363,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="2">
-      <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0">
+      <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.417012" Rows="20.000000" Width="8"/>
         </dxl:Properties>

--- a/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -240,7 +240,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
 <dxl:Plan Id="0" SpaceSize="2">
-  <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0">
+  <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="false">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="3.074219" Rows="1.000000" Width="16"/>
     </dxl:Properties>

--- a/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
+++ b/data/dxl/minidump/Insert-Parquet-Partitioned.mdp
@@ -240,7 +240,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
 <dxl:Plan Id="0" SpaceSize="2">
-  <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0">
+  <dxl:DMLInsert Columns="0,1" ActionCol="10" OidCol="9" CtidCol="0" SegmentIdCol="0" InputSorted="true">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="4.074219" Rows="1.000000" Width="16"/>
     </dxl:Properties>

--- a/data/dxl/minidump/Insert-Parquet.mdp
+++ b/data/dxl/minidump/Insert-Parquet.mdp
@@ -209,7 +209,7 @@
       </dxl:LogicalInsert>
     </dxl:Query>
 <dxl:Plan Id="0" SpaceSize="2">
-  <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0">
+  <dxl:DMLInsert Columns="0,1" ActionCol="9" OidCol="10" CtidCol="0" SegmentIdCol="0" InputSorted="false">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="2.054688" Rows="1.000000" Width="16"/>
     </dxl:Properties>

--- a/data/dxl/parse_tests/q57-DMLDelete.xml
+++ b/data/dxl/parse_tests/q57-DMLDelete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Plan Id="0" SpaceSize="0">
-    <dxl:DMLDelete Columns="0,1,2" ActionCol="10" OidCol="11" CtidCol="3" SegmentIdCol="9">
+    <dxl:DMLDelete Columns="0,1,2" ActionCol="10" OidCol="11" CtidCol="3" SegmentIdCol="9" InputSorted="false">
       <dxl:Properties>
         <dxl:Cost StartupCost="0" TotalCost="100.000000" Rows="1" Width="1"/>
       </dxl:Properties>

--- a/data/dxl/parse_tests/q58-DMLInsert.xml
+++ b/data/dxl/parse_tests/q58-DMLInsert.xml
@@ -23,7 +23,7 @@
             <dxl:Ident ColId="2" ColName="s3" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:DMLInsert Columns="0,1,2" ActionCol="10" OidCol="11" CtidCol="0" SegmentIdCol="0">
+        <dxl:DMLInsert Columns="0,1,2" ActionCol="10" OidCol="11" CtidCol="0" SegmentIdCol="0" InputSorted="false">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="100.000000" Rows="1.000000" Width="24"/>
           </dxl:Properties>

--- a/data/dxl/parse_tests/q60-DMLUpdate.xml
+++ b/data/dxl/parse_tests/q60-DMLUpdate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Plan Id="0" SpaceSize="0">
-    <dxl:DMLUpdate Columns="0,10,2" ActionCol="11" OidCol="12" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+    <dxl:DMLUpdate Columns="0,10,2" ActionCol="11" OidCol="12" CtidCol="3" SegmentIdCol="9" InputSorted="false" PreserveOids="false">
       <dxl:Properties>
         <dxl:Cost StartupCost="0" TotalCost="100.000000" Rows="0" Width="1"/>
       </dxl:Properties>

--- a/libgpopt/include/gpopt/operators/CPhysicalDML.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalDML.h
@@ -77,13 +77,15 @@ namespace gpopt
 			// required columns by local members
 			CColRefSet *m_pcrsRequiredLocal;
 
+			// needs the data to be sorted or not
+			BOOL m_fInputSorted;
+
 			// compute required order spec
 			COrderSpec *PosComputeRequired
 				(
 				IMemoryPool *pmp, 
 				CTableDescriptor *ptabdesc
-				)
-				const;
+				);
 			
 			// compute local required columns
 			void ComputeRequiredLocalColumns(IMemoryPool *pmp);
@@ -188,6 +190,13 @@ namespace gpopt
 			BOOL FInputOrderSensitive() const
 			{
 				return false;
+			}
+
+			// needs the data to be sorted or not
+			virtual
+			BOOL FInputSorted() const
+			{
+				return m_fInputSorted;
 			}
 					
 			//-------------------------------------------------------------------------------------

--- a/libgpopt/src/operators/CPhysicalDML.cpp
+++ b/libgpopt/src/operators/CPhysicalDML.cpp
@@ -65,7 +65,8 @@ CPhysicalDML::CPhysicalDML
 	m_pcrTupleOid(pcrTupleOid),
 	m_pds(NULL),
 	m_pos(NULL),
-	m_pcrsRequiredLocal(NULL)
+	m_pcrsRequiredLocal(NULL),
+	m_fInputSorted(false)
 {
 	GPOS_ASSERT(CLogicalDML::EdmlSentinel != edmlop);
 	GPOS_ASSERT(NULL != ptabdesc);
@@ -520,7 +521,6 @@ CPhysicalDML::PosComputeRequired
 	IMemoryPool *pmp,
 	CTableDescriptor *ptabdesc
 	)
-	const
 {
 	COrderSpec *pos = GPOS_NEW(pmp) COrderSpec(pmp);
 
@@ -561,7 +561,7 @@ CPhysicalDML::PosComputeRequired
 		if (fInsertSortOnParquet || fInsertSortOnRows)
 		{
 			GPOS_ASSERT(CLogicalDML::EdmlInsert == m_edmlop);
-
+			m_fInputSorted = true;
 			// if this is an INSERT over a partitioned Parquet or Row-oriented table,
 			// sort tuples by their table oid
 			IMDId *pmdid = m_pcrTableOid->Pmdtype()->PmdidCmp(IMDType::EcmptL);

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -4940,7 +4940,8 @@ CTranslatorExprToDXL::PdxlnDML
 									ulSegmentId, 
 									fPreserveOids, 
 									ulTupleOid,
-									pdxlddinfo
+									pdxlddinfo,
+									popDML->FInputSorted()
 									);
 	
 	// project list

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDML.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDML.h
@@ -80,6 +80,9 @@ namespace gpdxl
 			// direct dispatch info for insert statements 
 			CDXLDirectDispatchInfo *m_pdxlddinfo;
 			
+			// needs the data to be sorted or not
+			BOOL m_fInputSorted;
+
 			// private copy ctor
 			CDXLPhysicalDML(const CDXLPhysicalDML &);
 			
@@ -98,7 +101,8 @@ namespace gpdxl
 				ULONG ulSegmentId,
 				BOOL fPreserveOids,
 				ULONG ulTupleOid,
-				CDXLDirectDispatchInfo *pdxlddinfo
+				CDXLDirectDispatchInfo *pdxlddinfo,
+				BOOL fInputSorted
 				);
 
 			// dtor
@@ -171,6 +175,12 @@ namespace gpdxl
 				return m_pdxlddinfo;
 			}
 			
+			// needs the data to be sorted or not
+			BOOL FInputSorted() const
+			{
+				return m_fInputSorted;
+			}
+
 #ifdef GPOS_DEBUG
 			// checks whether the operator has valid structure, i.e. number and
 			// types of child nodes

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPhysicalDML.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPhysicalDML.h
@@ -65,6 +65,9 @@ namespace gpdxl
 			// tuple oid column id
 			ULONG m_ulTupleOidColId;
 
+			// needs data to be sorted
+			BOOL m_fInputSorted;
+
 			// private copy ctor
 			CParseHandlerPhysicalDML(const CParseHandlerPhysicalDML &);
 

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -345,6 +345,7 @@ namespace gpdxl
 		EdxltokenGpSegmentIdColId,
 		EdxltokenTupleOidColId,
 		EdxltokenUpdatePreservesOids,
+		EdxltokenInputSorted,
 		
 		EdxltokenInputSegments,
 		EdxltokenOutputSegments,

--- a/libnaucrates/src/operators/CDXLPhysicalDML.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalDML.cpp
@@ -46,7 +46,8 @@ CDXLPhysicalDML::CDXLPhysicalDML
 	ULONG ulSegmentId,
 	BOOL fPreserveOids,
 	ULONG ulTupleOid,
-	CDXLDirectDispatchInfo *pdxlddinfo
+	CDXLDirectDispatchInfo *pdxlddinfo,
+	BOOL fInputSorted
 	)
 	:
 	CDXLPhysical(pmp),
@@ -59,7 +60,8 @@ CDXLPhysicalDML::CDXLPhysicalDML
 	m_ulSegmentId(ulSegmentId),
 	m_fPreserveOids(fPreserveOids),
 	m_ulTupleOid(ulTupleOid),
-	m_pdxlddinfo(pdxlddinfo)
+	m_pdxlddinfo(pdxlddinfo),
+	m_fInputSorted(fInputSorted)
 {
 	GPOS_ASSERT(EdxldmlSentinel > edxldmltype);
 	GPOS_ASSERT(NULL != pdxltabdesc);
@@ -146,6 +148,7 @@ CDXLPhysicalDML::SerializeToDXL
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenOidColId), m_ulOid);
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCtidColId), m_ulCtid);
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenGpSegmentIdColId), m_ulSegmentId);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenInputSorted), m_fInputSorted);
 	
 	if (Edxldmlupdate == m_edxldmltype)
 	{

--- a/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
+++ b/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
@@ -56,7 +56,8 @@ CParseHandlerPhysicalDML::CParseHandlerPhysicalDML
 	m_ulCtid(0),
 	m_ulSegmentId(0),	
 	m_fPreserveOids(false),
-	m_ulTupleOidColId(0)
+	m_ulTupleOidColId(0),
+	m_fInputSorted(false)
 {
 }
 
@@ -120,6 +121,18 @@ CParseHandlerPhysicalDML::StartElement
 	if (m_fPreserveOids)
 	{
 		m_ulTupleOidColId = CDXLOperatorFactory::UlValueFromAttrs(m_pphm->Pmm(), attrs, EdxltokenTupleOidColId, EdxltokenPhysicalDMLUpdate);
+	}
+
+	const XMLCh *xmlszInputSorted = attrs.getValue(CDXLTokens::XmlstrToken(EdxltokenInputSorted));
+	if (NULL != xmlszInputSorted)
+	{
+		m_fInputSorted = CDXLOperatorFactory::FValueFromXmlstr
+											(
+											m_pphm->Pmm(),
+											xmlszInputSorted,
+											EdxltokenInputSorted,
+											EdxltokenPhysicalDMLInsert
+											);
 	}
 
 	// parse handler for physical operator
@@ -195,7 +208,7 @@ CParseHandlerPhysicalDML::EndElement
 
 	CDXLDirectDispatchInfo *pdxlddinfo = pphDirectDispatch->Pdxlddinfo();
 	pdxlddinfo->AddRef();
-	CDXLPhysicalDML *pdxlop = GPOS_NEW(m_pmp) CDXLPhysicalDML(m_pmp, m_edxldmltype, pdxltabdesc, m_pdrgpul, m_ulAction, m_ulOid, m_ulCtid, m_ulSegmentId, m_fPreserveOids, m_ulTupleOidColId, pdxlddinfo);
+	CDXLPhysicalDML *pdxlop = GPOS_NEW(m_pmp) CDXLPhysicalDML(m_pmp, m_edxldmltype, pdxltabdesc, m_pdrgpul, m_ulAction, m_ulOid, m_ulCtid, m_ulSegmentId, m_fPreserveOids, m_ulTupleOidColId, pdxlddinfo, m_fInputSorted);
 	m_pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
 	
 	// set statistics and physical properties

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -385,6 +385,7 @@ CDXLTokens::Init
 			{EdxltokenGpSegmentIdColId, GPOS_WSZ_LIT("SegmentIdCol")},
 			{EdxltokenTupleOidColId, GPOS_WSZ_LIT("TupleOidCol")},
 			{EdxltokenUpdatePreservesOids, GPOS_WSZ_LIT("PreserveOids")},
+			{EdxltokenInputSorted, GPOS_WSZ_LIT("InputSorted")},
 
 			{EdxltokenInputSegments, GPOS_WSZ_LIT("InputSegments")},
 			{EdxltokenOutputSegments, GPOS_WSZ_LIT("OutputSegments")},


### PR DESCRIPTION
In this PR, optimizer adds a field (NeedsSort) in the DMLInsert node indicating if the operator expects the data to be sorted on the partition id or not. 

@vraghavan78 @xinzweb @oarap 
Please take a look.