### PR TITLE
IMDRelation Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 634)
+set(GPORCA_VERSION_MINOR 635)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.634
+LIB_VERSION = 1.635
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(naucrates SHARED
             src/md/CMDTypeInt4GPDB.cpp
             src/md/CMDTypeInt8GPDB.cpp
             src/md/CMDTypeOidGPDB.cpp
+            src/md/CMDUtilsGPDB.cpp
             src/md/CSystemId.cpp
             src/md/IMDCacheObject.cpp
             src/md/IMDIndex.cpp

--- a/libnaucrates/include/naucrates/md/CMDColumn.h
+++ b/libnaucrates/include/naucrates/md/CMDColumn.h
@@ -122,19 +122,15 @@ namespace gpmd
 			BOOL FDropped() const;
 		
 			// serialize metadata object in DXL format given a serializer object
-			virtual	
+			virtual
 			void Serialize(gpdxl::CXMLSerializer *) const;
-			
+
 #ifdef GPOS_DEBUG
 			// debug print of the column
 			virtual
 			void DebugPrint(IOstream &os) const;
 #endif
 	};
-
-	// array of metadata column descriptor
-	typedef CDynamicPtrArray<CMDColumn, CleanupRelease> DrgPmdcol;
-
 }
 
 #endif // !GPMD_CDXLColumn_H

--- a/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
@@ -86,9 +86,6 @@ namespace gpmd
 			
 			// array of key sets
 			DrgPdrgPul *m_pdrgpdrgpulKeys;
-
-			// number of system columns
-			ULONG m_ulSystemColumns;
 			
 			// mapping of attribute number in the system catalog to the positions of
 			// the non dropped column in the metadata object
@@ -205,10 +202,6 @@ namespace gpmd
 			{
 				return m_pdrgpulNonDroppedCols;
 			}
-
-			// number of system columns
-			virtual
-			ULONG UlSystemColumns() const;
 
 			// retrieve the column at the given position
 			virtual

--- a/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
@@ -93,7 +93,7 @@ namespace gpmd
 
 			// the original positions of all the non-dropped columns
 			DrgPul *m_pdrgpulNonDroppedCols;
-			
+
 			// storage options
 			CDXLCtasStorageOptions *m_pdxlctasopt;
 

--- a/libnaucrates/include/naucrates/md/CMDRelationExternalGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationExternalGPDB.h
@@ -97,9 +97,6 @@ namespace gpmd
 			// format error table mdid
 			IMDId *m_pmdidFmtErrRel;
 
-			// number of system columns
-			ULONG m_ulSystemColumns;
-
 			// mapping of column position to positions excluding dropped columns
 			HMUlUl *m_phmululNonDroppedCols;
 			
@@ -175,10 +172,6 @@ namespace gpmd
 			// return the original positions of all the non-dropped columns
 			virtual
 			DrgPul *PdrgpulNonDroppedCols() const;
-
-			// number of system columns
-			virtual
-			ULONG UlSystemColumns() const;
 
 			// return true if a hash distributed table needs to be considered as random
 			virtual

--- a/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
@@ -108,9 +108,6 @@ namespace gpmd
 			// does this table have oids
 			BOOL m_fHasOids;
 
-			// number of system columns
-			ULONG m_ulSystemColumns;
-			
 			// mapping of column position to positions excluding dropped columns
 			HMUlUl *m_phmululNonDroppedCols;
 		
@@ -202,10 +199,6 @@ namespace gpmd
 			// return the original positions of all the non-dropped columns
 			virtual
 			DrgPul *PdrgpulNonDroppedCols() const;
-
-			// number of system columns
-			virtual
-			ULONG UlSystemColumns() const;
 
 			// retrieve the column at the given position
 			virtual 

--- a/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
@@ -35,11 +35,12 @@ namespace gpmd
 
 			// initialize the attribute number to column array position mapping
 			static
-			void InitializeAttrNumToArrayPositionMap
+			void InitializeMDColInfo
 				(
 				IMemoryPool *pmp,
 				DrgPmdcol *pdrgpmdcol,
-				HMIUl *phmiulAttno2Pos
+				HMIUl *phmiulAttno2Pos,
+				HMUlUl *phmululNonDroppedCols
 				);
 
 	};

--- a/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
@@ -6,7 +6,7 @@
 //		CMDUtilsGPDB.h
 //
 //	@doc:
-//		Utils function that are used by GPDB related metadata
+//		Utility functions that are used by GPDB related metadata
 //
 //---------------------------------------------------------------------------
 
@@ -26,22 +26,22 @@ namespace gpmd
 	//		CMDUtilsGPDB
 	//
 	//	@doc:
-	//		Utils function that are used by GPDB related metadata
+	//		Utility functions that are used by GPDB related metadata
 	//
 	//---------------------------------------------------------------------------
 	class CMDUtilsGPDB
 	{
 		public:
 
-			// initialize the attribute number to column array position mapping
+			// initialize the output arguments based on the array of column metadata
 			static
 			void InitializeMDColInfo
 				(
 				IMemoryPool *pmp,
 				DrgPmdcol *pdrgpmdcol,
-				HMIUl *phmiulAttno2Pos,
-				DrgPul *pdrgpulNonDroppedCols,
-				HMUlUl *phmululNonDroppedCols
+				HMIUl *phmiulAttno2Pos, // output hash map of column attribute number to position in array of column metadata
+				DrgPul *pdrgpulNonDroppedCols, // output array of non-dropped columns
+				HMUlUl *phmululNonDroppedCols // output hash map of column array position mapping to position array of non-dropped columns
 				);
 
 	};

--- a/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
@@ -40,6 +40,7 @@ namespace gpmd
 				IMemoryPool *pmp,
 				DrgPmdcol *pdrgpmdcol,
 				HMIUl *phmiulAttno2Pos,
+				DrgPul *pdrgpulNonDroppedCols,
 				HMUlUl *phmululNonDroppedCols
 				);
 

--- a/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDUtilsGPDB.h
@@ -1,0 +1,51 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Inc.
+//
+//	@filename:
+//		CMDUtilsGPDB.h
+//
+//	@doc:
+//		Utils function that are used by GPDB related metadata
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPMD_CMDUtilsGPDB_H
+#define GPMD_CMDUtilsGPDB_H
+
+#include "gpos/base.h"
+
+#include "naucrates/md/IMDRelation.h"
+
+namespace gpmd
+{
+	using namespace gpos;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CMDUtilsGPDB
+	//
+	//	@doc:
+	//		Utils function that are used by GPDB related metadata
+	//
+	//---------------------------------------------------------------------------
+	class CMDUtilsGPDB
+	{
+		public:
+
+			// initialize the attribute number to column array position mapping
+			static
+			void InitializeAttrNumToArrayPositionMap
+				(
+				IMemoryPool *pmp,
+				DrgPmdcol *pdrgpmdcol,
+				HMIUl *phmiulAttno2Pos
+				);
+
+	};
+
+}
+
+#endif // !GPMD_CMDUtilsGPDB_H
+
+// EOF

--- a/libnaucrates/include/naucrates/md/IMDColumn.h
+++ b/libnaucrates/include/naucrates/md/IMDColumn.h
@@ -71,6 +71,10 @@ namespace gpmd
 			// length of the column
 			virtual ULONG UlLength() const = 0;
 
+			// serialize metadata object in DXL format given a serializer object
+			virtual
+			void Serialize(gpdxl::CXMLSerializer *) const = 0;
+
 #ifdef GPOS_DEBUG
 			// debug print of the column
 			virtual 
@@ -79,11 +83,8 @@ namespace gpmd
 	};
 
 	// IMDColumn array
-//	typedef CDynamicPtrArray<IMDColumn, CleanupRelease> DrgPmdcol;
-
+	typedef CDynamicPtrArray<IMDColumn, CleanupRelease> DrgPmdcol;
 }
-
-
 
 #endif // !GPMD_IMDColumn_H
 

--- a/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -209,16 +209,6 @@ namespace gpmd
 			// name of storage type
 			static
 			const CWStringConst *PstrStorageType(IMDRelation::Erelstoragetype erelstorage);
-
-			// initialize the attribute number to column array position mapping
-			static
-			void InitializeAttrNumToArrayPositionMap
-				(
-				IMemoryPool *pmp,
-				DrgPmdcol *pdrgpmdcol,
-				HMIUl *phmiulAttno2Pos
-				);
-
 	};
 	
 }

--- a/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -126,10 +126,6 @@ namespace gpmd
 			virtual
 			DrgPul *PdrgpulNonDroppedCols() const = 0;
 
-			// number of system columns
-			virtual
-			ULONG UlSystemColumns() const = 0;
-			
 			// retrieve the column at the given position
 			virtual 
 			const IMDColumn *Pmdcol(ULONG ulPos) const = 0;

--- a/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -209,6 +209,16 @@ namespace gpmd
 			// name of storage type
 			static
 			const CWStringConst *PstrStorageType(IMDRelation::Erelstoragetype erelstorage);
+
+			// initialize the attribute number to column array position mapping
+			static
+			void InitializeAttrNumToArrayPositionMap
+				(
+				IMemoryPool *pmp,
+				DrgPmdcol *pdrgpmdcol,
+				HMIUl *phmiulAttno2Pos
+				);
+
 	};
 	
 }

--- a/libnaucrates/src/md/CMDCheckConstraintGPDB.cpp
+++ b/libnaucrates/src/md/CMDCheckConstraintGPDB.cpp
@@ -100,8 +100,7 @@ CMDCheckConstraintGPDB::Pexpr
 	const ULONG ulLen = pdrgpcr->UlLength();
 	GPOS_ASSERT(ulLen > 0);
 
-	//const ULONG ulArity = pmdrel->UlNonDroppedCols() - pmdrel->UlSystemColumns();
-	//GPOS_ASSERT(ulArity == ulLen);
+	GPOS_ASSERT(pmdrel->UlNonDroppedCols() == ulLen);
 #endif // GPOS_DEBUG
 
 	// translate the DXL representation of the check constraint expression

--- a/libnaucrates/src/md/CMDCheckConstraintGPDB.cpp
+++ b/libnaucrates/src/md/CMDCheckConstraintGPDB.cpp
@@ -100,8 +100,8 @@ CMDCheckConstraintGPDB::Pexpr
 	const ULONG ulLen = pdrgpcr->UlLength();
 	GPOS_ASSERT(ulLen > 0);
 
-	const ULONG ulArity = pmdrel->UlNonDroppedCols() - pmdrel->UlSystemColumns();
-	GPOS_ASSERT(ulArity == ulLen);
+	//const ULONG ulArity = pmdrel->UlNonDroppedCols() - pmdrel->UlSystemColumns();
+	//GPOS_ASSERT(ulArity == ulLen);
 #endif // GPOS_DEBUG
 
 	// translate the DXL representation of the check constraint expression

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -63,7 +63,6 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 	m_pdrgpmdcol(pdrgpmdcol),
 	m_pdrgpulDistrColumns(pdrgpulDistrColumns),
 	m_pdrgpdrgpulKeys(pdrgpdrgpulKeys),
-	m_ulSystemColumns(0),
 	m_pdrgpulNonDroppedCols(NULL),
 	m_pdxlctasopt(pdxlctasopt),
 	m_pdrgpiVarTypeMod(pdrgpiVarTypeMod)
@@ -85,11 +84,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 		GPOS_ASSERT(!pmdcol->FDropped() && "Cannot create a table with dropped columns");
 
 		BOOL fSystemCol = pmdcol->FSystemColumn();
-		if (fSystemCol)
-		{
-			m_ulSystemColumns++;
-		}
-		else
+		if (!fSystemCol)
 		{
 			m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
 		}
@@ -193,21 +188,6 @@ CMDRelationCtasGPDB::UlColumns() const
 	GPOS_ASSERT(NULL != m_pdrgpmdcol);
 
 	return m_pdrgpmdcol->UlLength();
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CMDRelationCtasGPDB::UlSystemColumns
-//
-//	@doc:
-//		Returns the number of system columns of this relation
-//
-//---------------------------------------------------------------------------
-ULONG
-CMDRelationCtasGPDB::UlSystemColumns() const
-{
-	return m_ulSystemColumns;
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -91,13 +91,10 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 		{
 			m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
 		}
-
-		(void) m_phmiulAttno2Pos->FInsert
-									(
-									GPOS_NEW(m_pmp) INT(pmdcol->IAttno()),
-									GPOS_NEW(m_pmp) ULONG(ul)
-									);
 	}
+
+	IMDRelation::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }
 

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -17,6 +17,8 @@
 //---------------------------------------------------------------------------
 
 #include "naucrates/md/CMDRelationCtasGPDB.h"
+#include "naucrates/md/CMDUtilsGPDB.h"
+
 #include "naucrates/dxl/xml/CXMLSerializer.h"
 #include "naucrates/dxl/operators/CDXLCtasStorageOptions.h"
 
@@ -93,7 +95,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 		}
 	}
 
-	IMDRelation::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+	CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -90,7 +90,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 		}
 	}
 
-	CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, NULL /* m_phmululNonDroppedCols */);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -77,20 +77,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 	m_phmiulAttno2Pos = GPOS_NEW(m_pmp) HMIUl(m_pmp);
 	m_pdrgpulNonDroppedCols = GPOS_NEW(m_pmp) DrgPul(m_pmp);
 	
-	const ULONG ulArity = pdrgpmdcol->UlLength();
-	for (ULONG ul = 0; ul < ulArity; ul++)
-	{
-		IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-		GPOS_ASSERT(!pmdcol->FDropped() && "Cannot create a table with dropped columns");
-
-		BOOL fSystemCol = pmdcol->FSystemColumn();
-		if (!fSystemCol)
-		{
-			m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
-		}
-	}
-
-	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, NULL /* m_phmululNonDroppedCols */);
+	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_pdrgpulNonDroppedCols, NULL /* m_phmululNonDroppedCols */);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -90,7 +90,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 		else
 		{
 			m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
-		}		
+		}
 
 		(void) m_phmiulAttno2Pos->FInsert
 									(
@@ -340,7 +340,7 @@ CMDRelationCtasGPDB::Serialize
 	const ULONG ulCols = m_pdrgpmdcol->UlLength();
 	for (ULONG ul = 0; ul < ulCols; ul++)
 	{
-		CMDColumn *pmdcol = (*m_pdrgpmdcol)[ul];
+		IMDColumn *pmdcol = (*m_pdrgpmdcol)[ul];
 		pmdcol->Serialize(pxmlser);
 	}
 

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -108,13 +108,10 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 			(void) m_phmululNonDroppedCols->FInsert(GPOS_NEW(m_pmp) ULONG(ul), GPOS_NEW(m_pmp) ULONG(ulPosNonDropped));
 			ulPosNonDropped++;
 		}
-
-		(void) m_phmiulAttno2Pos->FInsert
-									(
-									GPOS_NEW(m_pmp) INT(pmdcol->IAttno()),
-									GPOS_NEW(m_pmp) ULONG(ul)
-									);
 	}
+
+	IMDRelation::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }
 

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -17,6 +17,7 @@
 //---------------------------------------------------------------------------
 
 #include "naucrates/md/CMDRelationExternalGPDB.h"
+#include "naucrates/md/CMDUtilsGPDB.h"
 #include "naucrates/dxl/xml/CXMLSerializer.h"
 #include "naucrates/dxl/CDXLUtils.h"
 
@@ -110,7 +111,7 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 		}
 	}
 
-	IMDRelation::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+	CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -82,25 +82,8 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 	m_phmiulAttno2Pos = GPOS_NEW(m_pmp) HMIUl(m_pmp);
 	m_pdrgpulNonDroppedCols = GPOS_NEW(m_pmp) DrgPul(m_pmp);
 	
-	const ULONG ulArity = pdrgpmdcol->UlLength();
-	for (ULONG ul = 0; ul < ulArity; ul++)
-	{
-		IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-
-		if (pmdcol->FDropped())
-		{
-			m_ulDroppedCols++;
-		}
-		else		
-		{
-			if (!pmdcol->FSystemColumn())
-			{
-				m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
-			}
-		}
-	}
-
-	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_phmululNonDroppedCols);
+	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_pdrgpulNonDroppedCols, m_phmululNonDroppedCols);
+	m_ulDroppedCols = m_pdrgpulNonDroppedCols->UlLength();
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -65,7 +65,6 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 	m_iRejectLimit(iRejectLimit),
 	m_fRejLimitInRows(fRejLimitInRows),
 	m_pmdidFmtErrRel(pmdidFmtErrRel),
-	m_ulSystemColumns(0),
 	m_phmululNonDroppedCols(NULL),
 	m_phmiulAttno2Pos(NULL),
 	m_pdrgpulNonDroppedCols(NULL)
@@ -89,19 +88,13 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 	{
 		IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
 
-		BOOL fSystemCol = pmdcol->FSystemColumn();
-		if (fSystemCol)
-		{
-			m_ulSystemColumns++;
-		}
-		
 		if (pmdcol->FDropped())
 		{
 			m_ulDroppedCols++;
 		}
 		else		
 		{
-			if (!fSystemCol)
+			if (!pmdcol->FSystemColumn())
 			{
 				m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
 			}
@@ -226,20 +219,6 @@ ULONG
 CMDRelationExternalGPDB::UlNonDroppedCols() const
 {	
 	return UlColumns() - m_ulDroppedCols;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CMDRelationExternalGPDB::UlSystemColumns
-//
-//	@doc:
-//		Returns the number of system columns of this relation
-//
-//---------------------------------------------------------------------------
-ULONG
-CMDRelationExternalGPDB::UlSystemColumns() const
-{
-	return m_ulSystemColumns;
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -82,7 +82,6 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 	m_phmiulAttno2Pos = GPOS_NEW(m_pmp) HMIUl(m_pmp);
 	m_pdrgpulNonDroppedCols = GPOS_NEW(m_pmp) DrgPul(m_pmp);
 	
-	ULONG ulPosNonDropped = 0;
 	const ULONG ulArity = pdrgpmdcol->UlLength();
 	for (ULONG ul = 0; ul < ulArity; ul++)
 	{
@@ -98,13 +97,10 @@ CMDRelationExternalGPDB::CMDRelationExternalGPDB
 			{
 				m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
 			}
-
-			(void) m_phmululNonDroppedCols->FInsert(GPOS_NEW(m_pmp) ULONG(ul), GPOS_NEW(m_pmp) ULONG(ulPosNonDropped));
-			ulPosNonDropped++;
 		}
 	}
 
-	CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_phmululNonDroppedCols);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -612,7 +612,7 @@ CMDRelationExternalGPDB::Serialize
 						CDXLTokens::PstrToken(EdxltokenColumns));
 	for (ULONG ul = 0; ul < m_pdrgpmdcol->UlLength(); ul++)
 	{
-		CMDColumn *pmdcol = (*m_pdrgpmdcol)[ul];
+		IMDColumn *pmdcol = (*m_pdrgpmdcol)[ul];
 		pmdcol->Serialize(pxmlser);
 	}
 

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -74,7 +74,6 @@ CMDRelationGPDB::CMDRelationGPDB
 	m_pdrgpmdidCheckConstraint(pdrgpmdidCheckConstraint),
 	m_pmdpartcnstr(pmdpartcnstr),
 	m_fHasOids(fHasOids),
-	m_ulSystemColumns(0),
 	m_phmululNonDroppedCols(NULL),
 	m_phmiulAttno2Pos(NULL),
 	m_pdrgpulNonDroppedCols(NULL)
@@ -97,11 +96,6 @@ CMDRelationGPDB::CMDRelationGPDB
 	for (ULONG ul = 0; ul < ulArity; ul++)
 	{
 		IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-		BOOL fSystemCol = pmdcol->FSystemColumn();
-		if (fSystemCol)
-		{
-			m_ulSystemColumns++;
-		}
 
 		if (pmdcol->FDropped())
 		{
@@ -109,7 +103,7 @@ CMDRelationGPDB::CMDRelationGPDB
 		}
 		else
 		{
-			if (!fSystemCol)
+			if (!pmdcol->FSystemColumn())
 			{
 				m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
 			}
@@ -325,20 +319,6 @@ DrgPul *
 CMDRelationGPDB::PdrgpulNonDroppedCols() const
 {
 	return m_pdrgpulNonDroppedCols;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CMDRelationGPDB::UlSystemColumns
-//
-//	@doc:
-//		Returns the number of system columns of this relation
-//
-//---------------------------------------------------------------------------
-ULONG
-CMDRelationGPDB::UlSystemColumns() const
-{
-	return m_ulSystemColumns;
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -92,7 +92,6 @@ CMDRelationGPDB::CMDRelationGPDB
 	m_pdrgpulNonDroppedCols = GPOS_NEW(m_pmp) DrgPul(m_pmp);
 	
 	const ULONG ulArity = pdrgpmdcol->UlLength();
-	ULONG ulPosNonDropped = 0;
 	for (ULONG ul = 0; ul < ulArity; ul++)
 	{
 		IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
@@ -107,12 +106,10 @@ CMDRelationGPDB::CMDRelationGPDB
 			{
 				m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
 			}
-			(void) m_phmululNonDroppedCols->FInsert(GPOS_NEW(m_pmp) ULONG(ul), GPOS_NEW(m_pmp) ULONG(ulPosNonDropped));
-			ulPosNonDropped++;
 		}
 	}
 
-	CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_phmululNonDroppedCols);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -20,6 +20,7 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDRelationGPDB.h"
+#include "naucrates/md/CMDUtilsGPDB.h"
 #include "naucrates/dxl/xml/CXMLSerializer.h"
 #include "naucrates/dxl/CDXLUtils.h"
 
@@ -117,7 +118,7 @@ CMDRelationGPDB::CMDRelationGPDB
 		}
 	}
 
-	IMDRelation::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+	CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -90,26 +90,9 @@ CMDRelationGPDB::CMDRelationGPDB
 	m_phmululNonDroppedCols = GPOS_NEW(m_pmp) HMUlUl(m_pmp);
 	m_phmiulAttno2Pos = GPOS_NEW(m_pmp) HMIUl(m_pmp);
 	m_pdrgpulNonDroppedCols = GPOS_NEW(m_pmp) DrgPul(m_pmp);
-	
-	const ULONG ulArity = pdrgpmdcol->UlLength();
-	for (ULONG ul = 0; ul < ulArity; ul++)
-	{
-		IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
 
-		if (pmdcol->FDropped())
-		{
-			m_ulDroppedCols++;
-		}
-		else
-		{
-			if (!pmdcol->FSystemColumn())
-			{
-				m_pdrgpulNonDroppedCols->Append(GPOS_NEW(m_pmp) ULONG(ul));
-			}
-		}
-	}
-
-	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_phmululNonDroppedCols);
+	CMDUtilsGPDB::InitializeMDColInfo(pmp, pdrgpmdcol, m_phmiulAttno2Pos, m_pdrgpulNonDroppedCols, m_phmululNonDroppedCols);
+	m_ulDroppedCols = m_pdrgpulNonDroppedCols->UlLength();
 
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -102,12 +102,6 @@ CMDRelationGPDB::CMDRelationGPDB
 			m_ulSystemColumns++;
 		}
 
-		(void) m_phmiulAttno2Pos->FInsert
-									(
-									GPOS_NEW(m_pmp) INT(pmdcol->IAttno()),
-									GPOS_NEW(m_pmp) ULONG(ul)
-									);
-
 		if (pmdcol->FDropped())
 		{
 			m_ulDroppedCols++;
@@ -122,6 +116,9 @@ CMDRelationGPDB::CMDRelationGPDB
 			ulPosNonDropped++;
 		}
 	}
+
+	IMDRelation::InitializeAttrNumToArrayPositionMap(pmp, pdrgpmdcol, m_phmiulAttno2Pos);
+
 	m_pstr = CDXLUtils::PstrSerializeMDObj(m_pmp, this, false /*fSerializeHeader*/, false /*fIndent*/);
 }
 

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -112,7 +112,7 @@ CMDRelationGPDB::CMDRelationGPDB
 		{
 			m_ulDroppedCols++;
 		}
-		else	
+		else
 		{
 			if (!fSystemCol)
 			{
@@ -699,7 +699,7 @@ CMDRelationGPDB::Serialize
 						CDXLTokens::PstrToken(EdxltokenColumns));
 	for (ULONG ul = 0; ul < m_pdrgpmdcol->UlLength(); ul++)
 	{
-		CMDColumn *pmdcol = (*m_pdrgpmdcol)[ul];
+		IMDColumn *pmdcol = (*m_pdrgpmdcol)[ul];
 		pmdcol->Serialize(pxmlser);
 
 		GPOS_CHECK_ABORT;

--- a/libnaucrates/src/md/CMDUtilsGPDB.cpp
+++ b/libnaucrates/src/md/CMDUtilsGPDB.cpp
@@ -1,0 +1,50 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Inc.
+//
+//	@filename:
+//		CMDUtilsGPDB.cpp
+//
+//	@doc:
+//		Implementation of utils function that are used by GPDB related metadata
+//
+//---------------------------------------------------------------------------
+
+#include "naucrates/md/CMDUtilsGPDB.h"
+
+using namespace gpdxl;
+using namespace gpmd;
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap
+//
+//	@doc:
+//		Initialize the attribute number to column array position mapping
+//
+//---------------------------------------------------------------------------
+void
+CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap
+	(
+	IMemoryPool *pmp,
+	DrgPmdcol *pdrgpmdcol,
+	HMIUl *phmiulAttno2Pos
+	)
+{
+	GPOS_ASSERT(NULL != pdrgpmdcol);
+	GPOS_ASSERT(NULL != phmiulAttno2Pos);
+
+	const ULONG ulArity = pdrgpmdcol->UlLength();
+	for (ULONG ul = 0; ul < ulArity; ul++)
+	{
+		const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
+
+		(void) phmiulAttno2Pos->FInsert
+								(
+								GPOS_NEW(pmp) INT(pmdcol->IAttno()),
+								GPOS_NEW(pmp) ULONG(ul)
+								);
+	}
+}
+
+// EOF

--- a/libnaucrates/src/md/CMDUtilsGPDB.cpp
+++ b/libnaucrates/src/md/CMDUtilsGPDB.cpp
@@ -6,7 +6,7 @@
 //		CMDUtilsGPDB.cpp
 //
 //	@doc:
-//		Implementation of utils function that are used by GPDB related metadata
+//		Implementation of utility functions that are used by GPDB related metadata
 //
 //---------------------------------------------------------------------------
 

--- a/libnaucrates/src/md/CMDUtilsGPDB.cpp
+++ b/libnaucrates/src/md/CMDUtilsGPDB.cpp
@@ -37,6 +37,7 @@ CMDUtilsGPDB::InitializeMDColInfo
 {
 	GPOS_ASSERT(NULL != pdrgpmdcol);
 	GPOS_ASSERT(NULL != phmiulAttno2Pos);
+	GPOS_ASSERT(NULL != pdrgpulNonDroppedCols);
 
 	const ULONG ulArity = pdrgpmdcol->UlLength();
 	ULONG ulPosNonDropped = 0;

--- a/libnaucrates/src/md/CMDUtilsGPDB.cpp
+++ b/libnaucrates/src/md/CMDUtilsGPDB.cpp
@@ -17,24 +17,27 @@ using namespace gpmd;
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap
+//		CMDUtilsGPDB::InitializeMDColInfo
 //
 //	@doc:
 //		Initialize the attribute number to column array position mapping
 //
 //---------------------------------------------------------------------------
 void
-CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap
+CMDUtilsGPDB::InitializeMDColInfo
 	(
 	IMemoryPool *pmp,
 	DrgPmdcol *pdrgpmdcol,
-	HMIUl *phmiulAttno2Pos
+	HMIUl *phmiulAttno2Pos,
+	HMUlUl *phmululNonDroppedCols
 	)
 {
 	GPOS_ASSERT(NULL != pdrgpmdcol);
 	GPOS_ASSERT(NULL != phmiulAttno2Pos);
 
+	BOOL fMaintainNonDroppedCols = (NULL != phmululNonDroppedCols);
 	const ULONG ulArity = pdrgpmdcol->UlLength();
+	ULONG ulPosNonDropped = 0;
 	for (ULONG ul = 0; ul < ulArity; ul++)
 	{
 		const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
@@ -44,6 +47,13 @@ CMDUtilsGPDB::InitializeAttrNumToArrayPositionMap
 								GPOS_NEW(pmp) INT(pmdcol->IAttno()),
 								GPOS_NEW(pmp) ULONG(ul)
 								);
+
+
+		if (fMaintainNonDroppedCols && !pmdcol->FDropped())
+		{
+			(void) phmululNonDroppedCols->FInsert(GPOS_NEW(pmp) ULONG(ul), GPOS_NEW(pmp) ULONG(ulPosNonDropped));
+			ulPosNonDropped++;
+		}
 	}
 }
 

--- a/libnaucrates/src/md/CMDUtilsGPDB.cpp
+++ b/libnaucrates/src/md/CMDUtilsGPDB.cpp
@@ -20,8 +20,10 @@ using namespace gpmd;
 //		CMDUtilsGPDB::InitializeMDColInfo
 //
 //	@doc:
-//		Initialize the attribute number to column array position mapping
-//
+//		From the array of metadata columns populate the following output variables
+//		phmiulAttno2Pos - attribute number to column array position mapping
+//		pdrgpulNonDroppedCols - array of non-dropped columns
+//		phmululNonDroppedCols - column array position mapping to position array of non-dropped columns
 //---------------------------------------------------------------------------
 void
 CMDUtilsGPDB::InitializeMDColInfo
@@ -29,13 +31,13 @@ CMDUtilsGPDB::InitializeMDColInfo
 	IMemoryPool *pmp,
 	DrgPmdcol *pdrgpmdcol,
 	HMIUl *phmiulAttno2Pos,
+	DrgPul *pdrgpulNonDroppedCols,
 	HMUlUl *phmululNonDroppedCols
 	)
 {
 	GPOS_ASSERT(NULL != pdrgpmdcol);
 	GPOS_ASSERT(NULL != phmiulAttno2Pos);
 
-	BOOL fMaintainNonDroppedCols = (NULL != phmululNonDroppedCols);
 	const ULONG ulArity = pdrgpmdcol->UlLength();
 	ULONG ulPosNonDropped = 0;
 	for (ULONG ul = 0; ul < ulArity; ul++)
@@ -49,9 +51,13 @@ CMDUtilsGPDB::InitializeMDColInfo
 								);
 
 
-		if (fMaintainNonDroppedCols && !pmdcol->FDropped())
+		if (!pmdcol->FDropped())
 		{
-			(void) phmululNonDroppedCols->FInsert(GPOS_NEW(pmp) ULONG(ul), GPOS_NEW(pmp) ULONG(ulPosNonDropped));
+			pdrgpulNonDroppedCols->Append(GPOS_NEW(pmp) ULONG(ul));
+			if (NULL != phmululNonDroppedCols)
+			{
+				(void) phmululNonDroppedCols->FInsert(GPOS_NEW(pmp) ULONG(ul), GPOS_NEW(pmp) ULONG(ulPosNonDropped));
+			}
 			ulPosNonDropped++;
 		}
 	}

--- a/libnaucrates/src/md/IMDRelation.cpp
+++ b/libnaucrates/src/md/IMDRelation.cpp
@@ -119,36 +119,4 @@ IMDRelation::PstrColumns
 	return pstr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		IMDRelation::InitializeAttrNumToArrayPositionMap
-//
-//	@doc:
-//		Initialize the attribute number to column array position mapping
-//
-//---------------------------------------------------------------------------
-void
-IMDRelation::InitializeAttrNumToArrayPositionMap
-	(
-	IMemoryPool *pmp,
-	DrgPmdcol *pdrgpmdcol,
-	HMIUl *phmiulAttno2Pos
-	)
-{
-	GPOS_ASSERT(NULL != pdrgpmdcol);
-	GPOS_ASSERT(NULL != phmiulAttno2Pos);
-
-	const ULONG ulArity = pdrgpmdcol->UlLength();
-	for (ULONG ul = 0; ul < ulArity; ul++)
-	{
-		const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
-
-		(void) phmiulAttno2Pos->FInsert
-								(
-								GPOS_NEW(pmp) INT(pmdcol->IAttno()),
-								GPOS_NEW(pmp) ULONG(ul)
-								);
-	}
-}
-
 // EOF

--- a/libnaucrates/src/md/IMDRelation.cpp
+++ b/libnaucrates/src/md/IMDRelation.cpp
@@ -119,4 +119,36 @@ IMDRelation::PstrColumns
 	return pstr;
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		IMDRelation::InitializeAttrNumToArrayPositionMap
+//
+//	@doc:
+//		Initialize the attribute number to column array position mapping
+//
+//---------------------------------------------------------------------------
+void
+IMDRelation::InitializeAttrNumToArrayPositionMap
+	(
+	IMemoryPool *pmp,
+	DrgPmdcol *pdrgpmdcol,
+	HMIUl *phmiulAttno2Pos
+	)
+{
+	GPOS_ASSERT(NULL != pdrgpmdcol);
+	GPOS_ASSERT(NULL != phmiulAttno2Pos);
+
+	const ULONG ulArity = pdrgpmdcol->UlLength();
+	for (ULONG ul = 0; ul < ulArity; ul++)
+	{
+		const IMDColumn *pmdcol = (*pdrgpmdcol)[ul];
+
+		(void) phmiulAttno2Pos->FInsert
+								(
+								GPOS_NEW(pmp) INT(pmdcol->IAttno()),
+								GPOS_NEW(pmp) ULONG(ul)
+								);
+	}
+}
+
 // EOF

--- a/server/src/unittest/gpopt/mdcache/CMDAccessorTest.cpp
+++ b/server/src/unittest/gpopt/mdcache/CMDAccessorTest.cpp
@@ -508,13 +508,16 @@ CMDAccessorTest::EresUnittest_CheckConstraint()
 	// create the array of column reference for the table columns
 	// for the DXL to Expr translation
 	DrgPcr *pdrgpcr = GPOS_NEW(pmp) DrgPcr(pmp);
-	const ULONG ulCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulCols = pmdrel->UlColumns();
 	for (ULONG ul = 0; ul < ulCols; ul++)
 	{
 		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
-		CColRef *pcr = pcf->PcrCreate(pmdtype);
-		pdrgpcr->Append(pcr);
+		if (!pmdcol->FSystemColumn())
+		{
+			const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
+			CColRef *pcr = pcf->PcrCreate(pmdtype);
+			pdrgpcr->Append(pcr);
+		}
 	}
 
 	// get one of its check constraint
@@ -584,13 +587,17 @@ CMDAccessorTest::EresUnittest_IndexPartConstraint()
 	// create the array of column reference for the table columns
 	// for the DXL to Expr translation
 	DrgPcr *pdrgpcr = GPOS_NEW(pmp) DrgPcr(pmp);
-	const ULONG ulCols = pmdrel->UlColumns() - pmdrel->UlSystemColumns();
+	const ULONG ulCols = pmdrel->UlColumns();
 	for (ULONG ul = 0; ul < ulCols; ul++)
 	{
 		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
-		CColRef *pcr = pcf->PcrCreate(pmdtype);
-		pdrgpcr->Append(pcr);
+
+		if (!pmdcol->FSystemColumn())
+		{
+			const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
+			CColRef *pcr = pcf->PcrCreate(pmdtype);
+			pdrgpcr->Append(pcr);
+		}
 	}
 
 	// get one of its indexes

--- a/server/src/unittest/gpopt/mdcache/CMDAccessorTest.cpp
+++ b/server/src/unittest/gpopt/mdcache/CMDAccessorTest.cpp
@@ -512,12 +512,9 @@ CMDAccessorTest::EresUnittest_CheckConstraint()
 	for (ULONG ul = 0; ul < ulCols; ul++)
 	{
 		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
-		if (!pmdcol->FSystemColumn())
-		{
-			const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
-			CColRef *pcr = pcf->PcrCreate(pmdtype);
-			pdrgpcr->Append(pcr);
-		}
+		const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
+		CColRef *pcr = pcf->PcrCreate(pmdtype);
+		pdrgpcr->Append(pcr);
 	}
 
 	// get one of its check constraint
@@ -592,12 +589,9 @@ CMDAccessorTest::EresUnittest_IndexPartConstraint()
 	{
 		const IMDColumn *pmdcol = pmdrel->Pmdcol(ul);
 
-		if (!pmdcol->FSystemColumn())
-		{
-			const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
-			CColRef *pcr = pcf->PcrCreate(pmdtype);
-			pdrgpcr->Append(pcr);
-		}
+		const IMDType *pmdtype = mda.Pmdtype(pmdcol->PmdidType());
+		CColRef *pcr = pcf->PcrCreate(pmdtype);
+		pdrgpcr->Append(pcr);
 	}
 
 	// get one of its indexes


### PR DESCRIPTION
Tracker Story: [#118416535]

Objectives:

A) Pull up the common logic in the following classes into a util function
* CMDRelationGPDB
* CMDRelationCtasGPDB
* CMDRelationExternalGPDB

B) There was several GPDB specific implicit assumption made such as system columns are always in the end

C) Unclean API resulting in the same logic of identifying which is a non-dropped column being re-written in many places (as shown in #117875199, missing column statistics, etc.)

@d @xinzweb @oarap @hsyuan please take a look.