### PR TITLE
Publish Github release for GPOS [#115977749]

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -12,6 +12,7 @@ groups:
   - orca_secondary
   - build_gpdb_centos6
   - gpdb_icg
+  - gpos_publish_tag
 - name: xerces
   jobs:
   - gp_xerces
@@ -35,6 +36,20 @@ groups:
 # RESOURCES #
 #############
 resources:
+- name: bin_gpdb_with_orca_centos6
+  type: s3
+  source:
+    access_key_id: {{aws-access-key-id}}
+    bucket: gporca-concourse-bucket
+    region_name: us-west-2
+    secret_access_key: {{aws-secret-access-key}}
+    versioned_file: bin_gpdb_with_orca_centos6.tar.gz
+- name: gpos_github_release
+  type: github-release
+  source:
+    user: greenplum-db
+    repository: gpos
+    access_token: {{gposbot_access_token}}
 - name: gpos_src
   type: git
   source:
@@ -252,6 +267,28 @@ resources:
 # JOBS #
 ########
 jobs:
+- name: gpos_publish_tag
+  max_in_flight: 1
+  plan:
+  - get: gpos_src
+    passed:
+    - gpos_centos5_release
+  - get: bin_gpos_centos5_release
+    passed:
+    - gpos_centos5_release
+    trigger: true
+  - get: bin_gpos_centos5_debug
+    trigger: true
+  - task: gpos_publish_tag
+    file: gpos_src/concourse/publish_tag.yml
+  - put: gpos_github_release
+    params:
+      name: gpos_github_release_stage/tag.txt
+      tag: gpos_github_release_stage/tag.txt
+      commitish: gpos_github_release_stage/commit.txt
+      globs:
+        - gpos_github_release_stage/bin_gpos_centos5_release.tar.gz
+        - gpos_github_release_stage/bin_gpos_centos5_debug.tar.gz
 - name: gp_xerces
   max_in_flight: 2
   plan:


### PR DESCRIPTION
This change enables to ORCA pipeline to publish GPOS binaries and releases to GPOS repo. This change needs to go in together with greenplum-db/gpos#23

@d, @oarap and @hsyuan 