### PR TITLE
Correct minidump for #46

### DIFF
--- a/data/dxl/minidump/OneSegmentGather.mdp
+++ b/data/dxl/minidump/OneSegmentGather.mdp
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
 <!--
---
--- Name: reprotables; Type: TABLE; Owner: -; Tablespace: 
---
+
+
+/* Name: reprotables; Type: TABLE; Owner: -; Tablespace: */
+
 
 DROP TABLE IF EXISTS reprotables;
 
@@ -15,9 +16,9 @@ WITH (appendonly=false) DISTRIBUTED RANDOMLY;
 
 SET allow_system_table_mods="DML";
 
---
--- Table: reprotables, Attribute: join_col
---
+
+/* Table: reprotables, Attribute: join_col */
+
 INSERT INTO pg_statistic VALUES (
 	'reprotables'::regclass,
 	1::smallint,
@@ -42,9 +43,9 @@ INSERT INTO pg_statistic VALUES (
 	NULL::int4[]);
 
 
---
--- Table: reprotables, Attribute: filter_col
---
+
+/* Table: reprotables, Attribute: filter_col */
+
 INSERT INTO pg_statistic VALUES (
 	'reprotables'::regclass,
 	5::smallint,
@@ -68,7 +69,7 @@ INSERT INTO pg_statistic VALUES (
 	NULL::varchar[],
 	NULL::varchar[]);
 
--- Table: reprotables
+/* Table: reprotables */
 UPDATE pg_class
 SET
 	relpages = 30::int,

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -360,11 +360,11 @@ CICGTest::EresUnittest_RunUnsupportedMinidumpTests()
 	const ULONG ulTests = GPOS_ARRAY_SIZE(rgszUnsupportedFileNames);
 	for (ULONG ul = m_ulUnsupportedTestCounter; ul < ulTests; ul++)
 	{
+		CDXLMinidump *pdxlmd = CMinidumperUtils::PdxlmdLoad(pmp, rgszUnsupportedFileNames[ul]);
+
 		GPOS_TRY
 		{
 			ICostModel *pcm = CTestUtils::Pcm(pmp);
-
-			CDXLMinidump *pdxlmd = CMinidumperUtils::PdxlmdLoad(pmp, rgszUnsupportedFileNames[ul]);
 
 			COptimizerConfig *poconf = pdxlmd->Poconf();
 			CDXLNode *pdxlnPlan = CMinidumperUtils::PdxlnExecuteMinidump
@@ -380,7 +380,6 @@ CICGTest::EresUnittest_RunUnsupportedMinidumpTests()
 
 
 			GPOS_CHECK_ABORT;
-			GPOS_DELETE(pdxlmd);
 			pdxlnPlan->Release();
 			pcm->Release();
 
@@ -393,6 +392,8 @@ CICGTest::EresUnittest_RunUnsupportedMinidumpTests()
 			GPOS_RESET_EX;
 		}
 		GPOS_CATCH_END;
+
+		GPOS_DELETE(pdxlmd);
 		m_ulUnsupportedTestCounter++;
 	}
 	


### PR DESCRIPTION
This patch replaces double dashes with C-style comments in the XML
comments. Otherwise our tests would be passing for the wrong reason: we
expect ORCA to fallback in the form of throwing an exception, but we
were giving it a pass for blowing up during XML parsing.

This corrects a subtle bug introduced in 978a927 as part of #46 