### PR TITLE
118865569 fix wrong error message when produced a wrong plan with Gather with more than one segments.

### DIFF
--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3818,7 +3818,7 @@ CTranslatorExprToDXL::CheckValidity
 	{
 		if((pdxlopMotion->PdrgpiInputSegIds()->UlLength() == 1) && COptCtxt::PoctxtFromTLS()->Pcm()->UlHosts() > 1)
 		{
-			GPOS_RAISE(gpopt::ExmaGPOPT, gpopt::ExmiInvalidPlanAlternative, GPOS_WSZ_LIT("GatherMotion has 1 input but there are more segments in the system"));
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiExpr2DXLUnsupportedFeature, GPOS_WSZ_LIT("GatherMotion has 1 input but there are more segments in the system"));
 		}
 	}
 }


### PR DESCRIPTION
@vraghavan78 @d @oarap 

There are two commits.

First one, fixed the wrong error major/minor number used for this DXL validation error.

Second commit, fixed the unittest framework so that we can verify the negative test cases with expected exceptions. So that, we can capture such missed cases where we failed the DXL translation due to different exception.