### PR TITLE
Orca generates wrong results for value scan with self comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 639)
+set(GPORCA_VERSION_MINOR 640)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.639
+LIB_VERSION = 1.640
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -147,7 +147,7 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="1386">
+    <dxl:Plan Id="0" SpaceSize="1386">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="18.062500" Rows="1.000000" Width="1"/>
@@ -203,18 +203,23 @@
                           <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                          <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="2" Alias="?column?">
-                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="1" Alias="">
                             <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="?column?">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>

--- a/data/dxl/minidump/ValueScanWithDuplicateAndSelfComparison.mdp
+++ b/data/dxl/minidump/ValueScanWithDuplicateAndSelfComparison.mdp
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<!--
+select * from (values (2),(null),(1)) v(k) where k = k;
+-->
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103003,103014,103015,103022,104004,104005,101001, 105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="k" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+        <dxl:UnionAll InputColumns="1;2;3" CastAcrossInputs="false">
+          <dxl:Columns>
+            <dxl:Column ColId="1" Attno="1" ColName="column1" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="2" Attno="1" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="3" Attno="1" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:UnionAll>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:Append IsTarget="false" IsZapped="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="0.000123" Rows="3.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="k">
+            <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000037" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="column1">
+              <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="column1">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+          </dxl:Result>
+        </dxl:Result>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000037" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="column1">
+              <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="column1">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+          </dxl:Result>
+        </dxl:Result>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000037" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="2" Alias="column1">
+              <dxl:Ident ColId="2" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="column1" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="2" ColName="column1" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="2" Alias="column1">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+          </dxl:Result>
+        </dxl:Result>
+      </dxl:Append>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -388,9 +388,6 @@ namespace gpopt
 			 
 			// register MD provider for serving MD relation entry for CTAS
 			void RegisterMDRelationCtas(CDXLLogicalCTAS *pdxlopCTAS);
-			
-			// create an array of column descriptors from an array of dxl column references
-			DrgPcoldesc *Pdrgpdxlcd(const DrgPdxlcd *pdrgpdxlcd);
 
 			// create an array of column references from an array of dxl column references
 			DrgPcr *Pdrgpcr(const DrgPdxlcd *pdrgpdxlcd);

--- a/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2381,33 +2381,33 @@ CTranslatorDXLToExpr::PexprLogicalConstTableGet
 	CDXLLogicalConstTable *pdxlopConstTable = CDXLLogicalConstTable::PdxlopConvert(pdxlnConstTable->Pdxlop());
 
 	const DrgPdxlcd *pdrgpdxlcd = pdxlopConstTable->Pdrgpdxlcd();
+
 	// translate the column descriptors
 	DrgPcoldesc *pdrgpcoldesc = GPOS_NEW(m_pmp) DrgPcoldesc(m_pmp);
 	const ULONG ulColumns = pdrgpdxlcd->UlLength();
 
-	for (ULONG ul = 0; ul < ulColumns; ul++)
+	for (ULONG ulColIdx = 0; ulColIdx < ulColumns; ulColIdx++)
 	{
-		CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ul];
+		CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ulColIdx];
 		const IMDType *pmdtype = m_pmda->Pmdtype(pdxlcd->PmdidType());
 		CName name(m_pmp, pdxlcd->Pmdname()->Pstr());
 
 		const ULONG ulWidth = pdxlcd->UlWidth();
-
 		CColumnDescriptor *pcoldesc = GPOS_NEW(m_pmp) CColumnDescriptor
 														(
 														m_pmp,
 														pmdtype,
 														name,
-														ul + 1, // iAttno
+														ulColIdx + 1, // iAttno
 														true, // FNullable
 														ulWidth
 														);
-		pdrgpcoldescOutput->Append(pcoldesc);
+		pdrgpcoldesc->Append(pcoldesc);
 	}
 
+	// translate values
 	DrgPdrgPdatum *pdrgpdrgpdatum = GPOS_NEW(m_pmp) DrgPdrgPdatum(m_pmp);
 	
-	// translate values
 	const ULONG ulValues = pdxlopConstTable->UlTupleCount();
 	for (ULONG ul = 0; ul < ulValues; ul++)
 	{

--- a/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -1052,47 +1052,6 @@ CTranslatorDXLToExpr::Pdrgpcr
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToExpr::Pdrgpdxlcd
-//
-//	@doc:
-// 		Construct an array of new column descriptors from the array of
-//		DXL column descriptors
-//
-//---------------------------------------------------------------------------
-DrgPcoldesc *
-CTranslatorDXLToExpr::Pdrgpdxlcd
-	(
-	const DrgPdxlcd *pdrgpdxlcd
-	)
-{
-	DrgPcoldesc *pdrgpcoldescOutput = GPOS_NEW(m_pmp) DrgPcoldesc(m_pmp);
-	const ULONG ulColumns = pdrgpdxlcd->UlLength();
-
-	for (ULONG ul = 0; ul < ulColumns; ul++)
-	{
-		CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ul];
-		const IMDType *pmdtype = m_pmda->Pmdtype(pdxlcd->PmdidType());
-		CName name(m_pmp, pdxlcd->Pmdname()->Pstr());
-
-		const ULONG ulWidth = pdxlcd->UlWidth();
-
-		CColumnDescriptor *pcoldesc = GPOS_NEW(m_pmp) CColumnDescriptor
-													(
-													m_pmp,
-													pmdtype,
-													name,
-													ul + 1, // iAttno
-													false, // FNullable
-													ulWidth
-													);
-		pdrgpcoldescOutput->Append(pcoldesc);
-	}
-
-	return pdrgpcoldescOutput;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
 //		CTranslatorDXLToExpr::ConstructDXLColId2ColRefMapping
 //
 //	@doc:
@@ -2421,8 +2380,30 @@ CTranslatorDXLToExpr::PexprLogicalConstTableGet
 {
 	CDXLLogicalConstTable *pdxlopConstTable = CDXLLogicalConstTable::PdxlopConvert(pdxlnConstTable->Pdxlop());
 
+	const DrgPdxlcd *pdrgpdxlcd = pdxlopConstTable->Pdrgpdxlcd();
 	// translate the column descriptors
-	DrgPcoldesc *pdrgpcoldesc = Pdrgpdxlcd(pdxlopConstTable->Pdrgpdxlcd());
+	DrgPcoldesc *pdrgpcoldesc = GPOS_NEW(m_pmp) DrgPcoldesc(m_pmp);
+	const ULONG ulColumns = pdrgpdxlcd->UlLength();
+
+	for (ULONG ul = 0; ul < ulColumns; ul++)
+	{
+		CDXLColDescr *pdxlcd = (*pdrgpdxlcd)[ul];
+		const IMDType *pmdtype = m_pmda->Pmdtype(pdxlcd->PmdidType());
+		CName name(m_pmp, pdxlcd->Pmdname()->Pstr());
+
+		const ULONG ulWidth = pdxlcd->UlWidth();
+
+		CColumnDescriptor *pcoldesc = GPOS_NEW(m_pmp) CColumnDescriptor
+														(
+														m_pmp,
+														pmdtype,
+														name,
+														ul + 1, // iAttno
+														true, // FNullable
+														ulWidth
+														);
+		pdrgpcoldescOutput->Append(pcoldesc);
+	}
 
 	DrgPdrgPdatum *pdrgpdrgpdatum = GPOS_NEW(m_pmp) DrgPdrgPdatum(m_pmp);
 	

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1476,10 +1476,6 @@ CTranslatorExprToDXL::PdxlnResult
 					pdxlprop
 					);
 		}
-		case COperator::EopPhysicalConstTableGet:
-		{
-			return PdxlnResultFromConstTableGet(pexprRelational, pdrgpcr, pexprScalar);
-		}
 		case COperator::EopPhysicalDynamicTableScan:
 		{
 			pdxlprop->AddRef();

--- a/server/src/unittest/gpopt/minidump/CSetopTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CSetopTest.cpp
@@ -35,6 +35,7 @@ ULONG CSetopTest::m_ulSetopTestCounter = 0;  // start from first test
 // minidump files
 const CHAR *rgszSetOpFileNames[] =
 	{
+	"../data/dxl/minidump/ValueScanWithDuplicateAndSelfComparison.mdp",
 	"../data/dxl/minidump/PushGbBelowNaryUnionAll.mdp",
 	"../data/dxl/minidump/PushGbBelowNaryUnion-1.mdp",
 	"../data/dxl/minidump/PushGbBelowNaryUnion-2.mdp",


### PR DESCRIPTION
Tracker Story: #121621417

```
vraghavan=# select * from (values (2),(null),(1)) v(k) where k = k;
 k
---
 2

 1
(3 rows)
vraghavan=# set optimizer_print_query = on;
LOG:  statement: set optimizer_print_query = on;
SET
vraghavan=# explain select * from (values (2),(null),(1)) v(k) where k = k;
LOG:  statement: explain select * from (values (2),(null),(1)) v(k) where k = k;
LOG:  2016-06-15 13:36:11:897288 PDT,THD000,TRACE,"
Algebrized query:
+--CLogicalSelect
   |--CLogicalUnionAll Output: ("column1" (0)), Input: [("column1" (0)), ("column1" (1)), ("column1" (2))]
   |  |--CLogicalConstTableGet Columns: ["column1" (0)] Values: [(2)]
   |  |--CLogicalConstTableGet Columns: ["column1" (1)] Values: [(null)]
   |  +--CLogicalConstTableGet Columns: ["column1" (2)] Values: [(1)]
   +--CScalarCmp (=)
      |--CScalarIdent "column1" (0)
      +--CScalarIdent "column1" (0)

Algebrized preprocessed query:
+--CLogicalUnionAll Output: ("column1" (0)), Input: [("column1" (0)), ("column1" (1)), ("column1" (2))]
   |--CLogicalConstTableGet Columns: ["column1" (0)] Values: [(2)]
   |--CLogicalConstTableGet Columns: ["column1" (1)] Values: [(null)]
   +--CLogicalConstTableGet Columns: ["column1" (2)] Values: [(1)]
",
2016-06-15 13:36:11:901171 PDT,THD000,TRACE,"
Physical plan:
+--CPhysicalUnionAll   rows:3   width:4  rebinds:1   cost:0.000024   origin: [Grp:3, GrpExpr:1]
   |--CPhysicalConstTableGet   rows:1   width:4  rebinds:1   cost:0.000004   origin: [Grp:0, GrpExpr:1]
   |--CPhysicalConstTableGet   rows:1   width:4  rebinds:1   cost:0.000004   origin: [Grp:1, GrpExpr:1]
   +--CPhysicalConstTableGet   rows:1   width:4  rebinds:1   cost:0.000004   origin: [Grp:2, GrpExpr:1]
",
                   QUERY PLAN
------------------------------------------------
 Append  (cost=0.00..0.00 rows=1 width=4)
   ->  Result  (cost=0.00..0.00 rows=1 width=4)
   ->  Result  (cost=0.00..0.00 rows=1 width=4)
   ->  Result  (cost=0.00..0.00 rows=1 width=4)
 Settings:  optimizer=on
 Optimizer status: PQO version 1.633
(6 rows)
```

As you can see, the predicate **k=k** is missing. Reasoning for this behavior is that the constraint cleanup code thought that the **k** is a non-nullable column. The bug of setting **k** as a nullable column is in **CTranslatorDXLToExpr::PexprLogicalConstTableGet**.

In addition to the above fix I also did the following:
* Refactor the function that is only called by **CTranslatorDXLToExpr::PexprLogicalConstTableGet** into that function.
* Disabled pushing filter into the constant table get -- because with this feature the DXL to PlStmt translator complains. I think this is an orthogonal issue. Will fix that in a separate fix.