### PR TITLE
Fall back to planner when optimizing scalar group with non-scalar subgroups [#123212061]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 641)
+set(GPORCA_VERSION_MINOR 642)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.641
+LIB_VERSION = 1.642
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------


### PR DESCRIPTION
In very rare case, Orca may generate the plan that a group is a scalar
group, but it has non-scalar sub groups. i.e.:
Group 7 ():  --> pgroupRoot->FScalar() == true
   0: CScalarSubquery["?column?" (19)] [ 6 ]
Group 6 (#GExprs: 2): --> pgroupChild->FScalar() == false
   0: CLogicalProject [ 2 5 ]
   1: CPhysicalComputeScalar [ 2 5 ]
In the above case, because group 7 has scalar expression, Orca skipped
generating optimization context for group 7 and its subgroup group 6,
even the group 6 doesn't have scalar expression and it needs optimization.
Orca doesn't support this feature yet, so falls back to planner.