### PR TITLE
Allow static compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 # doubt, do the safe thing and increment this number.
 set(GPORCA_ABI_VERSION 3)
 
+# Default to shared libraries.
+option(BUILD_SHARED_LIBS "build shared libraries" ON)
+
 # Configure CCache if available
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)

--- a/libgpdbcost/CMakeLists.txt
+++ b/libgpdbcost/CMakeLists.txt
@@ -3,7 +3,7 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libgpopt/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libnaucrates/include)
-add_library(gpdbcost SHARED
+add_library(gpdbcost
             include/gpdbcost/CCostModelGPDB.h
             src/CCostModelGPDB.cpp
             include/gpdbcost/CCostModelGPDBLegacy.h

--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libnaucrates/include)
 configure_file(version.h.in
         ${PROJECT_BINARY_DIR}/libgpopt/include/libgpopt/version.h)
 
-add_library(gpopt SHARED
+add_library(gpopt
             include/gpopt/base/CDistributionSpec.h
             include/gpopt/base/CDistributionSpecAny.h
             include/gpopt/base/CDistributionSpecUniversal.h

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -3,7 +3,7 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libgpopt/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libgpdbcost/include)
-add_library(naucrates SHARED
+add_library(naucrates
             include/naucrates/base/IDatum.h
             include/naucrates/base/IDatumBool.h
             include/naucrates/base/IDatumGeneric.h


### PR DESCRIPTION
We still default to shared libraries, but you can use the
"cmake -DBUILD_SHARED_LIBS=off" option to build static libraries instead.