### PR TITLE
[#123259241] Array Constraints Partition Filters (Array Pt 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 652)
+set(GPORCA_VERSION_MINOR 653)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.652
+LIB_VERSION = 1.653
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/DPE-IN.mdp
+++ b/data/dxl/minidump/DPE-IN.mdp
@@ -19,7 +19,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015, 103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.36394823.1.1" Name="p" Rows="0.000000" EmptyRelation="true"/>
@@ -868,25 +868,13 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
 	          </dxl:ProjElem>
 	        </dxl:ProjList>
 	        <dxl:Filter>
-	          <dxl:And>
-	            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-	              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Array>
-	            </dxl:ArrayComp>
-	            <dxl:Or>
-	              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	              </dxl:Comparison>
-	              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Comparison>
-	            </dxl:Or>
-	          </dxl:And>
+	           <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	             <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+	             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	             </dxl:Array>
+	           </dxl:ArrayComp>
 	        </dxl:Filter>
 	        <dxl:TableDescriptor Mdid="0.24719017.1.1" TableName="x">
 	          <dxl:Columns>
@@ -1017,16 +1005,13 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
 	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
 	            </dxl:PropagationExpression>
 	            <dxl:PrintableFilter>
-	              <dxl:Or>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:Or>
+	              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	                 <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	                 </dxl:Array>
+	               </dxl:ArrayComp>
 	            </dxl:PrintableFilter>
 	          </dxl:PartitionSelector>
 	          <dxl:DynamicTableScan PartIndexId="1">
@@ -1042,16 +1027,13 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
 	              </dxl:ProjElem>
 	            </dxl:ProjList>
 	            <dxl:Filter>
-	              <dxl:Or>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:Or>
+	              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	                 <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	                 </dxl:Array>
+	               </dxl:ArrayComp>
 	            </dxl:Filter>
 	            <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
 	              <dxl:Columns>

--- a/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -225,6 +225,9 @@ namespace gpopt
 			virtual
 			CExpression *PexprScalar(IMemoryPool *pmp);
 
+			// scalar expression  which will be a disjunction
+			CExpression *PexprConstructDisjunctionScalar(IMemoryPool *pmp) const;
+
 			// return constraint on a given column
 			virtual
 			CConstraint *Pcnstr(IMemoryPool *pmp, const CColRef *pcr);

--- a/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -505,6 +505,17 @@ namespace gpopt
 				BOOL *pfDML
 				);
 
+			CDXLNode *PdxlArrayExprOnPartKey
+				(
+				CExpression *pexprPred,
+				CColRef *pcrPartKey,
+				IMDId *pmdidTypePartKey,
+				ULONG ulPartLevel,
+				BOOL *pfLTComparison,	// input/output
+				BOOL *pfGTComparison,	// input/output
+				BOOL *pfEQComparison	// input/output
+				);
+
 			// translate a DML operator
 			CDXLNode *PdxlnDML(CExpression *pexpr, DrgPcr *pdrgpcr, DrgPds *pdrgpdsBaseTables, ULONG *pulNonGatherMotions, BOOL *pfDML);
 

--- a/libgpopt/src/base/CConstraintInterval.cpp
+++ b/libgpopt/src/base/CConstraintInterval.cpp
@@ -623,6 +623,33 @@ CConstraintInterval::PexprConstructScalar
 	}
 
 	// otherwise, we generate a disjunction of ranges
+	return PexprConstructDisjunctionScalar(pmp);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CConstraintInterval::PexprConstructDisjunctionScalar
+//
+//	@doc:
+//		Returns a disjunction of several equality or inequality expressions
+//		describing this interval. Or, returns a singular expression if the
+//		interval can be represented as such.
+//		For example an interval containing ranges like
+//			[1,1],(7,inf)
+//		converts to an expression like
+//			x = 1 OR x > 7
+//		but an interval containing the range
+//			(-inf, inf)
+//		converts to a scalar true
+//
+//---------------------------------------------------------------------------
+CExpression *
+CConstraintInterval::PexprConstructDisjunctionScalar
+	(
+		IMemoryPool *pmp
+	)
+	const
+{
 	DrgPexpr *pdrgpexpr = GPOS_NEW(pmp) DrgPexpr(pmp);
 
 	const ULONG ulLen = m_pdrgprng->UlLength();


### PR DESCRIPTION
### Fixes partition filters with array constraints
**This PR commits on top of [Pt 1](https://github.com/greenplum-db/gporca/pull/74)** The last commit is the new commit.

Partition filters are expressions which limit the partitions which GPDB scans when doing a table scan.

Allowing array constraints to be derived on expressions exposed a situation where array constraints propagated to partition filters. Arrays weren't previously handled by the Expression to DXL translator, they were processed into disjunctions just prior to translation. The fix we implemented is twofold:

1.  Allow array expressions to be expanded out into OR expressions during DXL translation. This avoids any error conditions when array expressions appear in partition filters because the DXL translator can successfully translate it. 
2.  Do not expand array expressions in a PredicateUtils helper function which was ran as part of an expression tree pre-DXL translation cleaning.

The trace flag `EopttraceEnableArrayDerive ` enables the PredicateUtils change. A test has been modified to show the effect of enabling the traceflag. When the traceflag is eventually removed, there will be several more tests that need updating. This will come in a later PR.