### PR TITLE
[#125960675] Array Constraints Preprocesssing (Array Pt 3)

### DIFF
--- a/data/dxl/minidump/DPE-IN.mdp
+++ b/data/dxl/minidump/DPE-IN.mdp
@@ -19,7 +19,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015, 103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.36394823.1.1" Name="p" Rows="0.000000" EmptyRelation="true"/>
@@ -868,25 +868,13 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
 	          </dxl:ProjElem>
 	        </dxl:ProjList>
 	        <dxl:Filter>
-	          <dxl:And>
-	            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-	              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Array>
-	            </dxl:ArrayComp>
-	            <dxl:Or>
-	              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	              </dxl:Comparison>
-	              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Comparison>
-	            </dxl:Or>
-	          </dxl:And>
+	           <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	             <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+	             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	             </dxl:Array>
+	           </dxl:ArrayComp>
 	        </dxl:Filter>
 	        <dxl:TableDescriptor Mdid="0.24719017.1.1" TableName="x">
 	          <dxl:Columns>
@@ -1017,16 +1005,13 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
 	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
 	            </dxl:PropagationExpression>
 	            <dxl:PrintableFilter>
-	              <dxl:Or>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:Or>
+	              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	                 <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	                 </dxl:Array>
+	               </dxl:ArrayComp>
 	            </dxl:PrintableFilter>
 	          </dxl:PartitionSelector>
 	          <dxl:DynamicTableScan PartIndexId="1">
@@ -1042,16 +1027,13 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
 	              </dxl:ProjElem>
 	            </dxl:ProjList>
 	            <dxl:Filter>
-	              <dxl:Or>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:Or>
+	              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	                 <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	                 </dxl:Array>
+	               </dxl:ArrayComp>
 	            </dxl:Filter>
 	            <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
 	              <dxl:Columns>

--- a/data/dxl/minidump/IN-ArrayCmp.mdp
+++ b/data/dxl/minidump/IN-ArrayCmp.mdp
@@ -2,7 +2,7 @@
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="103001"/>
+    <dxl:TraceFlags Value="103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true"> 
        <dxl:EqualityOp Mdid="0.91.1.0"/>                                                                                                                      
@@ -311,30 +311,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:And>
-            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
-            <dxl:Or>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:Or>
-          </dxl:And>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.711616.1.1" TableName="x">
           <dxl:Columns>
@@ -363,20 +347,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.719808.1.1" TableName="y">
           <dxl:Columns>

--- a/data/dxl/minidump/NOT-IN-ArrayCmp.mdp
+++ b/data/dxl/minidump/NOT-IN-ArrayCmp.mdp
@@ -2,7 +2,7 @@
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="103001"/>
+    <dxl:TraceFlags Value="103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
 	     <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true"> 
 	       <dxl:EqualityOp Mdid="0.91.1.0"/>                                                                                                                      
@@ -335,46 +335,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:And>
-            <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
-            <dxl:Or>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:And>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                </dxl:Comparison>
-              </dxl:And>
-              <dxl:And>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-                </dxl:Comparison>
-              </dxl:And>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:Or>
-          </dxl:And>
+          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.711616.1.1" TableName="x">
           <dxl:Columns>
@@ -403,36 +371,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-              </dxl:Comparison>
-            </dxl:And>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:And>
-            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.719808.1.1" TableName="y">
           <dxl:Columns>

--- a/libgpopt/include/gpopt/base/CConstraint.h
+++ b/libgpopt/include/gpopt/base/CConstraint.h
@@ -33,9 +33,6 @@ namespace gpopt
 	typedef CHashMap<CColRef, DrgPcnstr, gpos::UlHash<CColRef>, gpos::FEqual<CColRef>,
 					CleanupNULL<CColRef>, CleanupRelease<DrgPcnstr> > HMColConstr;
 
-	// range array
-	typedef CDynamicPtrArray<CRange, CleanupRelease> DrgPrng;
-
 	// mapping CConstraint -> BOOL to cache previous containment queries,
 	// we use pointer equality here for fast map lookup -- since we do shallow comparison, we do not take ownership
 	// of pointer values
@@ -274,9 +271,15 @@ namespace gpopt
 
 	}; // class CConstraint
 
+	// shorthand for printing, pointer.
+	inline
+	IOstream &operator << (IOstream &os, const CConstraint *cnstr)
+	{
+		return cnstr->OsPrint(os);
+	}
 	// shorthand for printing
 	inline
-	IOstream &operator << (IOstream &os, CConstraint &cnstr)
+	IOstream &operator << (IOstream &os, const CConstraint &cnstr)
 	{
 		return cnstr.OsPrint(os);
 	}

--- a/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -18,9 +18,14 @@
 #include "gpopt/base/CConstraint.h"
 #include "gpopt/base/CRange.h"
 #include "gpopt/operators/CScalarConst.h"
+#include "gpopt/operators/CScalarArrayCmp.h"
 
 namespace gpopt
 {
+
+	// range array
+	typedef CDynamicPtrArray<CRange, CleanupRelease> DrgPrng;
+
 	using namespace gpos;
 	using namespace gpmd;
 
@@ -30,6 +35,9 @@ namespace gpopt
 	//
 	//	@doc:
 	//		Representation of an interval constraint
+	//
+	//		If x has a CConstraintInterval C on it, this means that x is in the
+	//		ranges contained in C.
 	//
 	//---------------------------------------------------------------------------
 	class CConstraintInterval : public CConstraint
@@ -84,6 +92,8 @@ namespace gpopt
 			virtual
 			CExpression *PexprConstructScalar(IMemoryPool *pmp) const;
 
+			CExpression *PexprConstructArrayScalar(IMemoryPool *pmp) const;
+
 			// create interval from scalar comparison expression
 			static
 			CConstraintInterval *PciIntervalFromScalarCmp
@@ -128,6 +138,15 @@ namespace gpopt
 									CExpression *pexpr,
 									CColRef *pcr
 									);
+
+			static
+			DrgPrng *PciRangeFromColConstCmp(IMemoryPool *pmp,
+											 IMDType::ECmpType ecmpt,
+											 const CScalarConst *popScConst);
+
+			// create an array IN or NOT IN expression
+			CExpression *
+			PexprConstructArrayScalar(IMemoryPool *pmp, bool isIn) const;
 		public:
 
 			// ctor
@@ -216,6 +235,12 @@ namespace gpopt
 			virtual
 			CConstraint *PcnstrRemapForColumn(IMemoryPool *pmp, CColRef *pcr) const;
 
+			// converts to an array in expression
+			bool convertsToNotIn() const;
+
+			// converts to an array not in expression
+			bool convertsToIn() const;
+
 			// print
 			virtual
 			IOstream &OsPrint(IOstream &os) const;
@@ -257,7 +282,31 @@ namespace gpopt
 				CColRef *pcr = NULL
 				);
 
+			//  ConstraintInterval from the given expression
+			static
+			CConstraintInterval *PcnstrIntervalFromScalarArrayCmp
+				(
+				IMemoryPool *pmp,
+				CExpression *pexpr,
+				CColRef *pcr
+				);
+
 	}; // class CConstraintInterval
+
+	// shorthand for printing, reference
+	inline
+	IOstream &operator << (IOstream &os, const CConstraintInterval &interval)
+	{
+		return interval.OsPrint(os);
+	}
+
+	// shorthand for printing, pointer
+	inline
+	IOstream &operator << (IOstream &os, const CConstraintInterval *interval)
+	{
+		return interval->OsPrint(os);
+	}
+
 }
 
 #endif // !GPOPT_CConstraintInterval_H

--- a/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -223,6 +223,9 @@ namespace gpopt
 			virtual
 			CExpression *PexprScalar(IMemoryPool *pmp);
 
+			// scalar expression  which will be a disjunction
+			CExpression *PexprConstructDisjunctionScalar(IMemoryPool *pmp) const;
+
 			// return constraint on a given column
 			virtual
 			CConstraint *Pcnstr(IMemoryPool *pmp, const CColRef *pcr);

--- a/libgpopt/include/gpopt/base/CRange.h
+++ b/libgpopt/include/gpopt/base/CRange.h
@@ -170,6 +170,9 @@ namespace gpopt
 			// does this range overlap only the right end of the given range
 			BOOL FOverlapsRight(CRange *prange);
 
+			// does the right element equal the left element of the given range
+			BOOL FRightEqualsLeft(CRange *prange);
+
 			// does this range start before the given range starts
 			BOOL FStartsBefore(CRange *prange);
 

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -748,6 +748,9 @@ namespace gpopt
 			static
 			BOOL FComparisonPossible(DrgPcr *pdrgpcr, IMDType::ECmpType ecmpt);
 
+			static
+			ULONG FCountOperator(CExpression *pexpr, INT Eopid);
+
 			// return the max prefix of hashable columns for the given columns
 			static
 			DrgPcr *PdrgpcrHashablePrefix(IMemoryPool *pmp, DrgPcr *pdrgpcr);
@@ -986,6 +989,10 @@ namespace gpopt
 			template <class T>
 			static
 			BOOL FMatchBitmapScan(T *pop1, COperator *pop2);
+
+			// compares two Idatums, useful for sorting functions
+			static
+			INT IDatumCmp(const void *pv1, const void *pv2);
 	}; // class CUtils
 
 } // namespace gpopt

--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -173,6 +173,10 @@ namespace gpopt
 				const CColRefSet *pcrsReqd
 				);
 
+			// determines if the expression is likely convertible to an array expression
+			static BOOL
+			PexprConvert2InIsConvertable(CExpression *pexpr, ULONG parentOpType);
+
 			// private ctor
 			CExpressionPreprocessor();
 
@@ -196,6 +200,10 @@ namespace gpopt
 			// derive constraints on given expression
 			static
 			CExpression *PexprAddPredicatesFromConstraints(IMemoryPool *pmp, CExpression *pexpr);
+
+			// convert series of AND or OR comparisons into array IN expressions
+			static
+			CExpression *PexprConvert2In(IMemoryPool *pmp, CExpression *pexpr);
 
 	}; // class CExpressionPreprocessor
 }

--- a/libgpopt/include/gpopt/operators/CScalarArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarArray.h
@@ -120,6 +120,8 @@ namespace gpopt
 			virtual 
 			IMDId *PmdidType() const;
 
+			// print
+			IOstream &OsPrint(IOstream &os) const;
 
 	}; // class CScalarArray
 

--- a/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -505,6 +505,17 @@ namespace gpopt
 				BOOL *pfDML
 				);
 
+			CDXLNode *PdxlArrayExprOnPartKey
+				(
+				CExpression *pexprPred,
+				CColRef *pcrPartKey,
+				IMDId *pmdidTypePartKey,
+				ULONG ulPartLevel,
+				BOOL *pfLTComparison,	// input/output
+				BOOL *pfGTComparison,	// input/output
+				BOOL *pfEQComparison	// input/output
+				);
+
 			// translate a DML operator
 			CDXLNode *PdxlnDML(CExpression *pexpr, DrgPcr *pdrgpcr, DrgPds *pdrgpdsBaseTables, ULONG *pulNonGatherMotions, BOOL *pfDML);
 

--- a/libgpopt/src/base/CConstraint.cpp
+++ b/libgpopt/src/base/CConstraint.cpp
@@ -139,7 +139,6 @@ CConstraint::PcnstrFromScalarArrayCmp
 	return NULL;
 }
 
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CConstraint::PcnstrFromScalarExpr
@@ -185,13 +184,13 @@ CConstraint::PcnstrFromScalarExpr
 
 		CConstraint *pcnstr = NULL;
 		*ppdrgpcrs = GPOS_NEW(pmp) DrgPcrs(pmp);
-		if (CUtils::FScalarArrayCmp(pexpr))
+
+		// try creating a single constraint from the expression
+		pcnstr = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexpr, pcr);
+		if (NULL == pcnstr && CUtils::FScalarArrayCmp(pexpr))
 		{
+			// try creating a disjunction of several interval constraints in the array case
 			pcnstr = PcnstrFromScalarArrayCmp(pmp, pexpr, pcr);
-		}
-		else
-		{
-			pcnstr = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexpr, pcr);
 		}
 
 		if (NULL != pcnstr)

--- a/libgpopt/src/base/CConstraintInterval.cpp
+++ b/libgpopt/src/base/CConstraintInterval.cpp
@@ -632,6 +632,25 @@ CConstraintInterval::PexprConstructScalar
 	}
 
 	// otherwise, we generate a disjunction of ranges
+	return PexprConstructDisjunctionScalar(pmp);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CConstraintInterval::PexprConstructDisjunctionScalar
+//
+//	@doc:
+//		Construct scalar expression composed of disjunctions as opposed to an
+//		array IN or NOT IN expression
+//
+//---------------------------------------------------------------------------
+CExpression *
+CConstraintInterval::PexprConstructDisjunctionScalar
+	(
+		IMemoryPool *pmp
+	)
+	const
+{
 	DrgPexpr *pdrgpexpr = GPOS_NEW(pmp) DrgPexpr(pmp);
 
 	const ULONG ulLen = m_pdrgprng->UlLength();

--- a/libgpopt/src/base/CRange.cpp
+++ b/libgpopt/src/base/CRange.cpp
@@ -241,6 +241,38 @@ CRange::FOverlapsRight
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CRange::FRightEqualsLeft
+//
+//	@doc:
+//		Checks if the right element equal the left element of the given range.
+//      This is useful when checking if 2 ranges touch at the ends
+//
+//---------------------------------------------------------------------------
+BOOL
+CRange::FRightEqualsLeft
+	(
+	CRange *prange
+	)
+{
+	GPOS_ASSERT(NULL != prange);
+
+	IDatum *pdatumLeft = prange->PdatumLeft();
+
+	if (NULL == pdatumLeft && NULL == m_pdatumRight)
+	{
+		return true;
+	}
+
+	if (NULL == pdatumLeft || NULL == m_pdatumRight)
+	{
+		return false;
+	}
+
+	return m_pcomp->FEqual(m_pdatumRight, pdatumLeft);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CRange::FStartsWithOrBefore
 //
 //	@doc:

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -4094,6 +4094,35 @@ CUtils::FComparisonPossible
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CUtils::FCountOperator
+//
+//	@doc:
+//		counts the number of times a certain operator appears
+//
+//---------------------------------------------------------------------------
+ULONG
+CUtils::FCountOperator
+	(
+		CExpression *pexpr,
+		INT Eopid
+	)
+{
+	INT iopCnt = 0;
+	if (pexpr->Pop()->Eopid() == Eopid)
+	{
+		iopCnt += 1;
+	}
+
+
+	for (ULONG ulChild = 0; ulChild < pexpr->UlArity(); ulChild++)
+	{
+		iopCnt += FCountOperator((*pexpr)[ulChild], Eopid);
+	}
+	return iopCnt;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CUtils::PdrgpcrHashablePrefix
 //
 //	@doc:
@@ -5741,6 +5770,37 @@ CUtils::PexprCollapseProjects
 						pexprProject,
 						GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CScalarProjectList(pmp), pdrgpexprPrEl)
 						);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CUtils::IDatumCmp
+//
+//	@doc:
+//		Compares two datums. Takes pointer pointer to a datums.
+//
+//---------------------------------------------------------------------------
+INT CUtils::IDatumCmp
+		(
+		const void *pv1,
+		const void *pv2
+		)
+{
+	const IDatum *dat1 = *(IDatum**)(pv1);
+	const IDatum *dat2 = *(IDatum**)(pv2);
+
+	const IComparator *pcomp = COptCtxt::PoctxtFromTLS()->Pcomp();
+
+	if (pcomp->FEqual(dat1, dat2))
+	{
+		return 0;
+	}
+	else if (pcomp->FLessThan(dat1, dat2))
+	{
+		return -1;
+	}
+
+	return 1;
 }
 
 // EOF

--- a/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1859,18 +1859,34 @@ CPredicateUtils::PexprExtractPredicatesOnPartKeys
 		return NULL;
 	}
 
-	// if we have any Array Comparisons, we expand them into conjunctions/disjunctions
-	// of comparison predicates and then reconstruct scalar expression
-	DrgPexpr *pdrgpexprConjuncts = PdrgpexprConjuncts(pmp, pexprScalar);
-	DrgPexpr *pdrgpexprExpandedConjuncts = PdrgpexprExpandConjuncts(pmp, pdrgpexprConjuncts);
-	pdrgpexprConjuncts->Release();
-	CExpression *pexprExpandedScalar = PexprConjunction(pmp, pdrgpexprExpandedConjuncts);
-	pdrgpexprConjuncts = PdrgpexprConjuncts(pmp, pexprExpandedScalar);
-
+	DrgPexpr *pdrgpexprConjuncts = NULL;
 	DrgPcrs *pdrgpcrsChild = NULL;
-	CConstraint *pcnstr = CConstraint::PcnstrFromScalarExpr(pmp, pexprExpandedScalar, &pdrgpcrsChild);
-	CRefCount::SafeRelease(pdrgpcrsChild);
-	pexprExpandedScalar->Release();
+	CConstraint *pcnstr = NULL;
+	if(GPOS_FTRACE(EopttraceEnableArrayDerive))
+	{
+		// previously, we expanded array expressions. However, there is now code to handle array
+		// constraints in the DXL translator and therefore, it is unnecessary work to expanded arrays
+		// into disjunctions so we skip that step.
+		pdrgpexprConjuncts = PdrgpexprConjuncts(pmp, pexprScalar);
+
+		pcnstr = CConstraint::PcnstrFromScalarExpr(pmp, pexprScalar, &pdrgpcrsChild);
+		CRefCount::SafeRelease(pdrgpcrsChild);
+	}
+	else
+	{
+		// if we have any Array Comparisons, we expand them into conjunctions/disjunctions
+		// of comparison predicates and then reconstruct scalar expression
+		pdrgpexprConjuncts = PdrgpexprConjuncts(pmp, pexprScalar);
+		DrgPexpr *pdrgpexprExpandedConjuncts = PdrgpexprExpandConjuncts(pmp, pdrgpexprConjuncts);
+		pdrgpexprConjuncts->Release();
+		CExpression *pexprExpandedScalar = PexprConjunction(pmp, pdrgpexprExpandedConjuncts);
+		pdrgpexprConjuncts = PdrgpexprConjuncts(pmp, pexprExpandedScalar);
+
+		pcnstr = CConstraint::PcnstrFromScalarExpr(pmp, pexprExpandedScalar, &pdrgpcrsChild);
+		CRefCount::SafeRelease(pdrgpcrsChild);
+		pexprExpandedScalar->Release();
+	}
+
 
 	// check if expanded scalar leads to a contradiction in computed constraint
 	BOOL fContradiction = (NULL != pcnstr && pcnstr->FContradiction());

--- a/libgpopt/src/operators/CScalarArray.cpp
+++ b/libgpopt/src/operators/CScalarArray.cpp
@@ -165,6 +165,21 @@ CScalarArray::PmdidType() const
 	return m_pmdidArray;
 }
 
+IOstream &
+CScalarArray::OsPrint(IOstream &os) const
+{
+	os << "CScalarArray: {eleMDId: ";
+	m_pmdidElem->OsPrint(os);
+	os << ", arrayMDId: ";
+	m_pmdidArray->OsPrint(os);
+	if (m_fMultiDimensional)
+	{
+		os << ", multidimensional";
+	}
+	os << "}";
+	return os;
+}
+
 
 // EOF
 

--- a/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -160,6 +160,8 @@ namespace gpos
 		// prune unused computed columns
 		EopttraceDisablePruneUnusedComputedColumns = 103024,
 
+		// create constraint intervals from array expressions in preprocessing
+		EopttraceEnableArrayDerive = 103026,
 		///////////////////////////////////////////////////////
 		///////////////////// statistics flags ////////////////
 		//////////////////////////////////////////////////////

--- a/server/include/unittest/gpopt/CTestUtils.h
+++ b/server/include/unittest/gpopt/CTestUtils.h
@@ -20,6 +20,7 @@
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CExpression.h"
+#include "gpopt/operators/CScalarArrayCmp.h"
 #include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CScalarBoolOp.h"
@@ -351,6 +352,9 @@ namespace gpopt
 			// generate a select expression with an array compare
 			static
 			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp);
+
+			static
+			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType eScalarArrayCmpType, IMDType::ECmpType eCmpType);
 			
 			// generate an n-ary join expression
 			static

--- a/server/include/unittest/gpopt/base/CConstraintTest.h
+++ b/server/include/unittest/gpopt/base/CConstraintTest.h
@@ -165,6 +165,9 @@ namespace gpopt
 			static GPOS_RESULT EresUnittest_CDisjunction();
 			static GPOS_RESULT EresUnittest_CNegation();
 			static GPOS_RESULT EresUnittest_CConstraintFromScalarExpr();
+			static GPOS_RESULT EresUnittest_CConstraintIntervalConvertsTo();
+			static GPOS_RESULT EresUnittest_CConstraintIntervalPexpr();
+			static GPOS_RESULT EresUnittest_CConstraintIntervalFromArrayExpr();
 
 #ifdef GPOS_DEBUG
 			// tests for unconstrainable types

--- a/server/include/unittest/gpopt/operators/CExpressionPreprocessorTest.h
+++ b/server/include/unittest/gpopt/operators/CExpressionPreprocessorTest.h
@@ -184,6 +184,9 @@ namespace gpopt
 			static GPOS_RESULT EresUnittest_PreProcessOrPrefilters();
 			static GPOS_RESULT EresUnittest_PreProcessOrPrefiltersPartialPush();
 			static GPOS_RESULT EresUnittest_CollapseInnerJoin();
+			static GPOS_RESULT EresUnittest_PreProcessConvert2InPredicate();
+			static GPOS_RESULT EresUnittest_PreProcessConvert2InPredicateDeepExpressionTree();
+			static GPOS_RESULT EresUnittest_PreProcessConvertArrayWithEquals();
 
 	}; // class CExpressionPreprocessorTest
 }

--- a/server/src/unittest/CTestUtils.cpp
+++ b/server/src/unittest/CTestUtils.cpp
@@ -880,6 +880,32 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	IMemoryPool *pmp
 	)
 {
+	return PexprLogicalSelectArrayCmp(pmp, CScalarArrayCmp::EarrcmpAny, IMDType::EcmptEq);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTestUtils::PexprLogicalSelectArrayCmp
+//
+//	@doc:
+//		Generate a Select expression with an array compare. Takes an enum for
+//		the type of array comparison (ANY or ALL) and an enum for the comparator
+//		type (=, !=, <, etc)
+//
+//---------------------------------------------------------------------------
+CExpression *
+CTestUtils::PexprLogicalSelectArrayCmp
+	(
+	IMemoryPool *pmp,
+	CScalarArrayCmp::EArrCmpType eScalarArrayCmpType,
+	IMDType::ECmpType eCmpType
+	)
+{
+	// must be a valid array comparison enum
+	GPOS_ASSERT(CScalarArrayCmp::EarrcmpSentinel > eScalarArrayCmpType);
+	// must be a valid comparator type
+	GPOS_ASSERT(IMDType::EcmptOther > eCmpType);
+
 	CMDAccessor *pmda = COptCtxt::PoctxtFromTLS()->Pmda();
 
 	// generate a get expression
@@ -902,7 +928,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	// get column type mdid and mdid of the array type corresponding to that type 
 	IMDId *pmdidColType = pcr->Pmdtype()->Pmdid();
 	IMDId *pmdidArrType = pcr->Pmdtype()->PmdidTypeArray();
-	IMDId *pmdidCmpOp = pcr->Pmdtype()->PmdidCmp(IMDType::EcmptEq);
+	IMDId *pmdidCmpOp = pcr->Pmdtype()->PmdidCmp(eCmpType);
 
 	pmdidColType->AddRef();
 	pmdidArrType->AddRef();
@@ -922,7 +948,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 			GPOS_NEW(pmp) CExpression
 						(
 						pmp,
-						GPOS_NEW(pmp) CScalarArrayCmp(pmp, pmdidCmpOp, GPOS_NEW(pmp) CWStringConst(pmp, strOp.Wsz()), CScalarArrayCmp::EarrcmpAny),
+						GPOS_NEW(pmp) CScalarArrayCmp(pmp, pmdidCmpOp, GPOS_NEW(pmp) CWStringConst(pmp, strOp.Wsz()), eScalarArrayCmpType),
 						pexprIdent,
 						pexprArray
 						);

--- a/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
+++ b/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
@@ -14,6 +14,7 @@
 
 #include "gpos/io/COstreamString.h"
 #include "gpos/string/CWStringDynamic.h"
+#include "gpos/task/CAutoTraceFlag.h"
 
 #include "gpopt/base/CUtils.h"
 #include "gpopt/eval/CConstExprEvaluatorDefault.h"
@@ -1634,6 +1635,7 @@ CExpressionPreprocessorTest::EresUnittest_PreProcessOrPrefilters()
 {
 	CAutoMemoryPool amp;
 	IMemoryPool *pmp = amp.Pmp();
+	CAutoTraceFlag atf(EopttraceEnableArrayDerive, true /*fVal*/);
 
 	// reset metadata cache
 	CMDCache::Reset();
@@ -1758,22 +1760,26 @@ CExpressionPreprocessorTest::EresUnittest_PreProcessOrPrefilters()
 			"   |     |  +--CScalarCmp (=)\n"
 			"   |     |     |--CScalarIdent \"column_0002\" (5)\n"
 			"   |     |     +--CScalarConst (0)\n"
-			"   |     +--CScalarBoolOp (EboolopOr)\n"
-			"   |        |--CScalarCmp (=)\n"
-			"   |        |  |--CScalarIdent \"column_0000\" (3)\n"
-			"   |        |  +--CScalarConst (1)\n"
-			"   |        +--CScalarCmp (=)\n"
-			"   |           |--CScalarIdent \"column_0000\" (3)\n"
+			"   |     +--CScalarArrayCmp Any (=)\n"
+			"   |        |--CScalarIdent \"column_0000\" (3)\n"
+			"   |        +--CScalarArray: {eleMDId: (23,1.0), arrayMDId: (1007,1.0)}\n"
+			"   |           |--CScalarConst (1)\n"
 			"   |           +--CScalarConst (2)\n"
 			"   |--CLogicalSelect\n"
 			"   |  |--CLogicalGet \"BaseTableAlias\" (\"BaseTable\"), Columns: [\"column_0000\" (0), \"column_0001\" (1), \"column_0002\" (2)] Key sets: {[0]}\n"
-			"   |  +--CScalarBoolOp (EboolopOr)\n"
-			"   |     |--CScalarCmp (=)\n"
-			"   |     |  |--CScalarIdent \"column_0000\" (0)\n"
-			"   |     |  +--CScalarConst (1)\n"
-			"   |     +--CScalarCmp (=)\n"
+			"   |  +--CScalarBoolOp (EboolopAnd)\n"
+			"   |     |--CScalarBoolOp (EboolopOr)\n"
+			"   |     |  |--CScalarCmp (=)\n"
+			"   |     |  |  |--CScalarIdent \"column_0000\" (0)\n"
+			"   |     |  |  +--CScalarConst (2)\n"
+			"   |     |  +--CScalarCmp (=)\n"
+			"   |     |     |--CScalarIdent \"column_0000\" (0)\n"
+			"   |     |     +--CScalarConst (1)\n"
+			"   |     +--CScalarArrayCmp Any (=)\n"
 			"   |        |--CScalarIdent \"column_0000\" (0)\n"
-			"   |        +--CScalarConst (2)\n"
+			"   |        +--CScalarArray: {eleMDId: (23,1.0), arrayMDId: (1007,1.0)}\n"
+			"   |           |--CScalarConst (1)\n"
+			"   |           +--CScalarConst (2)\n"
 			"   +--CScalarBoolOp (EboolopAnd)\n"
 			"      |--CScalarBoolOp (EboolopOr)\n"
 			"      |  |--CScalarBoolOp (EboolopAnd)\n"

--- a/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
+++ b/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
@@ -63,7 +63,10 @@ CExpressionPreprocessorTest::EresUnittest()
 		GPOS_UNITTEST_FUNC(EresUnittest_PreProcessOuterJoinMinidumps),
 		GPOS_UNITTEST_FUNC(EresUnittest_PreProcessOrPrefilters),
 		GPOS_UNITTEST_FUNC(EresUnittest_PreProcessOrPrefiltersPartialPush),
-		GPOS_UNITTEST_FUNC(EresUnittest_CollapseInnerJoin)
+		GPOS_UNITTEST_FUNC(EresUnittest_CollapseInnerJoin),
+		GPOS_UNITTEST_FUNC(EresUnittest_PreProcessConvert2InPredicate),
+		GPOS_UNITTEST_FUNC(EresUnittest_PreProcessConvertArrayWithEquals),
+		GPOS_UNITTEST_FUNC(EresUnittest_PreProcessConvert2InPredicateDeepExpressionTree)
 		};
 
 	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
@@ -2170,6 +2173,223 @@ CExpressionPreprocessorTest::EresUnittest_CollapseInnerJoin()
 	{
 		rgpexpr[ul]->Release();
 	}
+
+	return GPOS_OK;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CExpressionPreprocessorTest
+//				::EresUnittest_PreProcessConvert2InPredicate
+//
+//	@doc:
+//		Tests that a expression with nested OR statements will convert them into
+//		an array IN statement. The statement we are testing looks is equivalent to
+//		+LogicalGet
+//			+-ScalarBoolOp (Or)
+//				+-ScalarBoolCmp
+//					+-ScalarId
+//					+-ScalarConst
+//				+-ScalarBoolCmp
+//					+-ScalarId
+//					+-ScalarConst
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CExpressionPreprocessorTest::EresUnittest_PreProcessConvert2InPredicate()
+{
+	CAutoTraceFlag atf(EopttraceEnableArrayDerive, true /*fVal*/);
+
+	CAutoMemoryPool amp;
+	IMemoryPool *pmp = amp.Pmp();
+
+	// reset metadata cache
+	CMDCache::Reset();
+
+	// setup a file-based provider
+	CMDProviderMemory *pmdp = CTestUtils::m_pmdpf;
+	pmdp->AddRef();
+	CMDAccessor mda(pmp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
+
+	CAutoOptCtxt aoc(pmp, &mda, NULL /*pceeval*/, CTestUtils::Pcm(pmp));
+
+	CExpression *pexprGet = CTestUtils::PexprLogicalGet(pmp);
+	COperator *popGet = pexprGet->Pop();
+	popGet->AddRef();
+
+	// Create a disjunct, add as a child
+	CColRef *pcrLeft = CDrvdPropRelational::Pdprel(pexprGet->PdpDerive())->PcrsOutput()->PcrAny();
+	CScalarBoolOp *pcsclrOp = GPOS_NEW(pmp) CScalarBoolOp(pmp, CScalarBoolOp::EboolopOr);
+	CExpression *pexprDisjunct =
+			GPOS_NEW(pmp) CExpression(
+									pmp,
+									pcsclrOp,
+									CUtils::PexprScalarEqCmp(pmp, pcrLeft, CUtils::PexprScalarConstInt4(pmp, 1 /*iVal*/)),
+									CUtils::PexprScalarEqCmp(pmp, pcrLeft, CUtils::PexprScalarConstInt4(pmp, 2 /*iVal*/)),
+									CUtils::PexprScalarEqCmp(pmp, pcrLeft, pcrLeft)
+									);
+
+	CExpression *pexprGetWithChildren = GPOS_NEW(pmp) CExpression(pmp, popGet, pexprDisjunct);
+	pexprGet->Release();
+
+	GPOS_ASSERT(3 == CUtils::FCountOperator(pexprGetWithChildren, COperator::EopScalarCmp));
+
+	CExpression *pexprConvert = CExpressionPreprocessor::PexprConvert2In(pmp, pexprGetWithChildren);
+
+	GPOS_ASSERT(1 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarArrayCmp));
+	GPOS_ASSERT(1 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarCmp));
+	// the OR node should not be removed because there should be an array expression and
+	// a scalar identity comparison
+	GPOS_ASSERT(1 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarBoolOp));
+
+	pexprGetWithChildren->Release();
+	pexprConvert->Release();
+
+	return GPOS_OK;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CExpressionPreprocessorTest
+//				::EresUnittest_PreProcessConvertArrayWithEquals
+//
+//	@doc:
+//		Test that an array expression like A IN (1,2,3,4,5) OR A = 6 OR A = 7
+//		converts to A IN (1,2,3,4,5,6,7).
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CExpressionPreprocessorTest::EresUnittest_PreProcessConvertArrayWithEquals()
+{
+	CAutoTraceFlag atf(EopttraceEnableArrayDerive, true /*fVal*/);
+
+	CAutoMemoryPool amp;
+	IMemoryPool *pmp = amp.Pmp();
+
+	// reset metadata cache
+	CMDCache::Reset();
+
+	// setup a file-based provider
+	CMDProviderMemory *pmdp = CTestUtils::m_pmdpf;
+	pmdp->AddRef();
+	CMDAccessor mda(pmp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
+
+	CAutoOptCtxt aoc(pmp, &mda, NULL /*pceeval*/, CTestUtils::Pcm(pmp));
+
+	CExpression *pexpr = CTestUtils::PexprLogicalSelectArrayCmp(pmp);
+	// get a ref to the comparison column
+	CColRef *pcrLeft = CDrvdPropRelational::Pdprel(pexpr->PdpDerive())->PcrsOutput()->PcrAny();
+
+	// remove the array child and then make an OR node with two equality comparisons
+	CExpression *pexprArrayComp = (*pexpr->PdrgPexpr())[1];
+	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexprArrayComp));
+
+	DrgPexpr *prngexprDisjChildren = GPOS_NEW(pmp) DrgPexpr(pmp);
+	prngexprDisjChildren->Append(pexprArrayComp);
+	prngexprDisjChildren->Append(CUtils::PexprScalarEqCmp(pmp, pcrLeft, CUtils::PexprScalarConstInt4(pmp, 6 /*iVal*/)));
+	prngexprDisjChildren->Append(CUtils::PexprScalarEqCmp(pmp, pcrLeft, CUtils::PexprScalarConstInt4(pmp, 7 /*iVal*/)));
+
+	CScalarBoolOp *pcsclrOp = GPOS_NEW(pmp) CScalarBoolOp(pmp, CScalarBoolOp::EboolopOr);
+	CExpression *pexprDisjunct = GPOS_NEW(pmp) CExpression(pmp, pcsclrOp, prngexprDisjChildren);
+	pexprArrayComp->AddRef(); // needed for Replace()
+	pexpr->PdrgPexpr()->Replace(1, pexprDisjunct);
+
+	GPOS_ASSERT(2 == CUtils::FCountOperator(pexpr, COperator::EopScalarCmp));
+
+	CExpression *pexprConvert = CExpressionPreprocessor::PexprConvert2In(pmp, pexprDisjunct);
+
+	GPOS_ASSERT(0 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarCmp));
+	GPOS_ASSERT(7 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarConst));
+	GPOS_ASSERT(1 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarArrayCmp));
+
+	pexpr->Release();
+	pexprConvert->Release();
+
+	return GPOS_OK;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CExpressionPreprocessorTest
+//				::EresUnittest_PreProcessConvert2InPredicateDeepExpressionTree
+//
+//	@doc:
+//		Test of preprocessing with a whole expression tree. The expression tree
+//		looks like this predicate (x = 1 OR x = 2 OR (x = y AND (y = 3 OR y = 4)))
+//		which should be converted to (x in (1,2) OR (x = y AND y IN (3,4)))
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CExpressionPreprocessorTest::EresUnittest_PreProcessConvert2InPredicateDeepExpressionTree()
+{
+	CAutoTraceFlag atf(EopttraceEnableArrayDerive, true /*fVal*/);
+
+	CAutoMemoryPool amp;
+	IMemoryPool *pmp = amp.Pmp();
+
+	// reset metadata cache
+	CMDCache::Reset();
+
+	// setup a file-based provider
+	CMDProviderMemory *pmdp = CTestUtils::m_pmdpf;
+	pmdp->AddRef();
+	CMDAccessor mda(pmp, CMDCache::Pcache(), CTestUtils::m_sysidDefault, pmdp);
+
+	CAutoOptCtxt aoc(pmp, &mda, NULL /*pceeval*/, CTestUtils::Pcm(pmp));
+
+	CExpression *pexprGet = CTestUtils::PexprLogicalGet(pmp);
+	COperator *popGet = pexprGet->Pop();
+	popGet->AddRef();
+
+	// get a column ref from the outermost Get expression
+	DrgPcr *pdrgpcr = CDrvdPropRelational::Pdprel(pexprGet->PdpDerive())->PcrsOutput()->Pdrgpcr(pmp);
+	GPOS_ASSERT(1 < pdrgpcr->UlLength());
+	CColRef *pcrLeft = (*pdrgpcr)[0];
+	CColRef *pcrRight = (*pdrgpcr)[1];
+
+	// inner most OR
+	CScalarBoolOp *pcsclrOpOrInner = GPOS_NEW(pmp) CScalarBoolOp(pmp, CScalarBoolOp::EboolopOr);
+	CExpression *pexprDisjunctInner =
+			GPOS_NEW(pmp) CExpression(
+									pmp,
+									pcsclrOpOrInner,
+									CUtils::PexprScalarEqCmp(pmp, pcrRight, CUtils::PexprScalarConstInt4(pmp, 3 /*iVal*/)),
+									CUtils::PexprScalarEqCmp(pmp, pcrRight, CUtils::PexprScalarConstInt4(pmp, 4 /*iVal*/))
+									);
+	// middle and expression
+	CScalarBoolOp *pcsclrOpAnd = GPOS_NEW(pmp) CScalarBoolOp(pmp, CScalarBoolOp::EboolopAnd);
+	CExpression *pexprConjunct =
+			GPOS_NEW(pmp) CExpression(
+									pmp,
+									pcsclrOpAnd,
+									pexprDisjunctInner,
+									CUtils::PexprScalarEqCmp(pmp, pcrLeft, pcrRight)
+									);
+	// outer most OR
+	CScalarBoolOp *pcsclrOp = GPOS_NEW(pmp) CScalarBoolOp(pmp, CScalarBoolOp::EboolopOr);
+	CExpression *pexprDisjunct =
+			GPOS_NEW(pmp) CExpression(
+									pmp,
+									pcsclrOp,
+									CUtils::PexprScalarEqCmp(pmp, pcrLeft, CUtils::PexprScalarConstInt4(pmp, 1)),
+									CUtils::PexprScalarEqCmp(pmp, pcrLeft, CUtils::PexprScalarConstInt4(pmp, 2)),
+									pexprConjunct
+									);
+
+	CExpression *pexprGetWithChildren = GPOS_NEW(pmp) CExpression(pmp, popGet, pexprDisjunct);
+	pexprGet->Release();
+
+	GPOS_ASSERT(5 == CUtils::FCountOperator(pexprGetWithChildren, COperator::EopScalarCmp));
+
+	CExpression *pexprConvert = CExpressionPreprocessor::PexprConvert2In(pmp, pexprGetWithChildren);
+
+	GPOS_ASSERT(2 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarArrayCmp));
+	GPOS_ASSERT(1 == CUtils::FCountOperator(pexprConvert, COperator::EopScalarCmp));
+
+	pexprGetWithChildren->Release();
+	pexprConvert->Release();
+	pdrgpcr->Release();
 
 	return GPOS_OK;
 }


### PR DESCRIPTION
### Preprocessing stage for Array Conversion

Adds an expression preprocessing stage to convert applicable expressions into array IN or NOT IN expressions. This creates more succinct expression trees and reduces redundancy in final expression output.

Therefore an expression like `x = 1 OR x = 2` should be converted into the equivalent `x IN (1,2)`.

This feature works by doing a recursive walk of the expression tree which looks for multiple AND or OR children which are either array expressions or ScalarComparison children. It then converts them into Constraints. Constraints hold logic to detect redundancy and also to convert OR/AND statements into array statements (Array Pt 1).

We chose to put this method after step 8 of expression preprocessing because step 9 will propagate constraints, and therefore it makes sense to propagate array constraints instead of OR constraints because they are more succinct and also preprocessing will attempt to re-derive constraints from propagated constraints which can lead to redundant expressions being created if array constraints are not passed.

This feature is controlled by the `EnableArrayDerive` traceflag.

@lpetrov-pivotal and I learned a lot about reference counting while implementing the Preprocessing method. We summarized our findings in [this document](https://docs.google.com/a/pivotal.io/document/d/1nndCf-ZreeLYtdXeVdOy6BHx_xgyVbVrv9GSdMkxoRg/edit?usp=sharing).