### PR TITLE
Array constraint derivation fix nulls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 650)
+set(GPORCA_VERSION_MINOR 651)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.650
+LIB_VERSION = 1.651
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/IN-ArrayCmp.mdp
+++ b/data/dxl/minidump/IN-ArrayCmp.mdp
@@ -2,7 +2,7 @@
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="103001"/>
+    <dxl:TraceFlags Value="103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true"> 
        <dxl:EqualityOp Mdid="0.91.1.0"/>                                                                                                                      
@@ -311,30 +311,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:And>
-            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
-            <dxl:Or>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:Or>
-          </dxl:And>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.711616.1.1" TableName="x">
           <dxl:Columns>
@@ -363,20 +347,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.719808.1.1" TableName="y">
           <dxl:Columns>

--- a/data/dxl/minidump/NOT-IN-ArrayCmp.mdp
+++ b/data/dxl/minidump/NOT-IN-ArrayCmp.mdp
@@ -2,7 +2,7 @@
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="103001"/>
+    <dxl:TraceFlags Value="103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
 	     <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true"> 
 	       <dxl:EqualityOp Mdid="0.91.1.0"/>                                                                                                                      
@@ -335,46 +335,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:And>
-            <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
-            <dxl:Or>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:And>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                </dxl:Comparison>
-              </dxl:And>
-              <dxl:And>
-                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-                </dxl:Comparison>
-              </dxl:And>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:Or>
-          </dxl:And>
+          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.711616.1.1" TableName="x">
           <dxl:Columns>
@@ -403,36 +371,14 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-              </dxl:Comparison>
-            </dxl:And>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:And>
-            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.719808.1.1" TableName="y">
           <dxl:Columns>

--- a/libgpopt/include/gpopt/base/CConstraint.h
+++ b/libgpopt/include/gpopt/base/CConstraint.h
@@ -33,9 +33,6 @@ namespace gpopt
 	typedef CHashMap<CColRef, DrgPcnstr, gpos::UlHash<CColRef>, gpos::FEqual<CColRef>,
 					CleanupNULL<CColRef>, CleanupRelease<DrgPcnstr> > HMColConstr;
 
-	// range array
-	typedef CDynamicPtrArray<CRange, CleanupRelease> DrgPrng;
-
 	// mapping CConstraint -> BOOL to cache previous containment queries,
 	// we use pointer equality here for fast map lookup -- since we do shallow comparison, we do not take ownership
 	// of pointer values
@@ -274,9 +271,15 @@ namespace gpopt
 
 	}; // class CConstraint
 
+	// shorthand for printing, pointer.
+	inline
+	IOstream &operator << (IOstream &os, const CConstraint *cnstr)
+	{
+		return cnstr->OsPrint(os);
+	}
 	// shorthand for printing
 	inline
-	IOstream &operator << (IOstream &os, CConstraint &cnstr)
+	IOstream &operator << (IOstream &os, const CConstraint &cnstr)
 	{
 		return cnstr.OsPrint(os);
 	}

--- a/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -92,6 +92,7 @@ namespace gpopt
 			virtual
 			CExpression *PexprConstructScalar(IMemoryPool *pmp) const;
 
+			virtual
 			CExpression *PexprConstructArrayScalar(IMemoryPool *pmp) const;
 
 			// create interval from scalar comparison expression
@@ -139,6 +140,7 @@ namespace gpopt
 									CColRef *pcr
 									);
 
+			// creates a range like [x,x] where x is a constant
 			static
 			DrgPrng *PciRangeFromColConstCmp(IMemoryPool *pmp,
 											 IMDType::ECmpType ecmpt,
@@ -236,10 +238,10 @@ namespace gpopt
 			CConstraint *PcnstrRemapForColumn(IMemoryPool *pmp, CColRef *pcr) const;
 
 			// converts to an array in expression
-			bool convertsToNotIn() const;
+			bool FConvertsToNotIn() const;
 
 			// converts to an array not in expression
-			bool convertsToIn() const;
+			bool FConvertsToIn() const;
 
 			// print
 			virtual
@@ -282,7 +284,7 @@ namespace gpopt
 				CColRef *pcr = NULL
 				);
 
-			//  ConstraintInterval from the given expression
+			// generate a ConstraintInterval from the given expression
 			static
 			CConstraintInterval *PcnstrIntervalFromScalarArrayCmp
 				(

--- a/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -18,9 +18,14 @@
 #include "gpopt/base/CConstraint.h"
 #include "gpopt/base/CRange.h"
 #include "gpopt/operators/CScalarConst.h"
+#include "gpopt/operators/CScalarArrayCmp.h"
 
 namespace gpopt
 {
+
+	// range array
+	typedef CDynamicPtrArray<CRange, CleanupRelease> DrgPrng;
+
 	using namespace gpos;
 	using namespace gpmd;
 
@@ -30,6 +35,9 @@ namespace gpopt
 	//
 	//	@doc:
 	//		Representation of an interval constraint
+	//
+	//		If x has a CConstraintInterval C on it, this means that x is in the
+	//		ranges contained in C.
 	//
 	//---------------------------------------------------------------------------
 	class CConstraintInterval : public CConstraint
@@ -84,6 +92,8 @@ namespace gpopt
 			virtual
 			CExpression *PexprConstructScalar(IMemoryPool *pmp) const;
 
+			CExpression *PexprConstructArrayScalar(IMemoryPool *pmp) const;
+
 			// create interval from scalar comparison expression
 			static
 			CConstraintInterval *PciIntervalFromScalarCmp
@@ -128,6 +138,15 @@ namespace gpopt
 									CExpression *pexpr,
 									CColRef *pcr
 									);
+
+			static
+			DrgPrng *PciRangeFromColConstCmp(IMemoryPool *pmp,
+											 IMDType::ECmpType ecmpt,
+											 const CScalarConst *popScConst);
+
+			// create an array IN or NOT IN expression
+			CExpression *
+			PexprConstructArrayScalar(IMemoryPool *pmp, bool isIn) const;
 		public:
 
 			// ctor
@@ -216,6 +235,12 @@ namespace gpopt
 			virtual
 			CConstraint *PcnstrRemapForColumn(IMemoryPool *pmp, CColRef *pcr) const;
 
+			// converts to an array in expression
+			bool convertsToNotIn() const;
+
+			// converts to an array not in expression
+			bool convertsToIn() const;
+
 			// print
 			virtual
 			IOstream &OsPrint(IOstream &os) const;
@@ -257,7 +282,31 @@ namespace gpopt
 				CColRef *pcr = NULL
 				);
 
+			//  ConstraintInterval from the given expression
+			static
+			CConstraintInterval *PcnstrIntervalFromScalarArrayCmp
+				(
+				IMemoryPool *pmp,
+				CExpression *pexpr,
+				CColRef *pcr
+				);
+
 	}; // class CConstraintInterval
+
+	// shorthand for printing, reference
+	inline
+	IOstream &operator << (IOstream &os, const CConstraintInterval &interval)
+	{
+		return interval.OsPrint(os);
+	}
+
+	// shorthand for printing, pointer
+	inline
+	IOstream &operator << (IOstream &os, const CConstraintInterval *interval)
+	{
+		return interval->OsPrint(os);
+	}
+
 }
 
 #endif // !GPOPT_CConstraintInterval_H

--- a/libgpopt/include/gpopt/base/CRange.h
+++ b/libgpopt/include/gpopt/base/CRange.h
@@ -170,6 +170,9 @@ namespace gpopt
 			// does this range overlap only the right end of the given range
 			BOOL FOverlapsRight(CRange *prange);
 
+			// does the right element equal the left element of the given range
+			BOOL FRightEqualsLeft(CRange *prange);
+
 			// does this range start before the given range starts
 			BOOL FStartsBefore(CRange *prange);
 

--- a/libgpopt/include/gpopt/base/CRange.h
+++ b/libgpopt/include/gpopt/base/CRange.h
@@ -170,8 +170,8 @@ namespace gpopt
 			// does this range overlap only the right end of the given range
 			BOOL FOverlapsRight(CRange *prange);
 
-			// does the right element equal the left element of the given range
-			BOOL FRightEqualsLeft(CRange *prange);
+			// does this range's upper bound equal the given range's lower bound
+			BOOL FUpperBoundEqualsLowerBound(CRange *prange);
 
 			// does this range start before the given range starts
 			BOOL FStartsBefore(CRange *prange);

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -748,6 +748,9 @@ namespace gpopt
 			static
 			BOOL FComparisonPossible(DrgPcr *pdrgpcr, IMDType::ECmpType ecmpt);
 
+			static
+			ULONG FCountOperator(CExpression *pexpr, INT Eopid);
+
 			// return the max prefix of hashable columns for the given columns
 			static
 			DrgPcr *PdrgpcrHashablePrefix(IMemoryPool *pmp, DrgPcr *pdrgpcr);
@@ -986,6 +989,10 @@ namespace gpopt
 			template <class T>
 			static
 			BOOL FMatchBitmapScan(T *pop1, COperator *pop2);
+
+			// compares two Idatums, useful for sorting functions
+			static
+			INT IDatumCmp(const void *pv1, const void *pv2);
 	}; // class CUtils
 
 } // namespace gpopt

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -18,6 +18,7 @@
 #include "gpopt/base/CWindowFrame.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CExpression.h"
+#include "gpopt/operators/CScalarArrayCmp.h"
 #include "gpopt/operators/CScalarCmp.h"
 #include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CScalarBoolOp.h"
@@ -152,6 +153,10 @@ namespace gpopt
 			// generate an equality comparison expression for an expression and a column reference
 			static
 			CExpression *PexprScalarEqCmp(IMemoryPool *pmp, CExpression *pexprLeft, const CColRef *pcrRight);
+
+			// generate an array comparison expression for a column reference and an expression
+			static
+			CExpression *PexprScalarArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType earrcmptype, IMDType::ECmpType ecmptype, DrgPexpr *pexprScalarChildren, const CColRef *pcr);
 
 			// generate an Is Distinct From expression
 			static

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -749,7 +749,7 @@ namespace gpopt
 			BOOL FComparisonPossible(DrgPcr *pdrgpcr, IMDType::ECmpType ecmpt);
 
 			static
-			ULONG FCountOperator(CExpression *pexpr, INT Eopid);
+			ULONG UlCountOperator(const CExpression *pexpr, COperator::EOperatorId eopid);
 
 			// return the max prefix of hashable columns for the given columns
 			static

--- a/libgpopt/include/gpopt/operators/CScalarArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarArray.h
@@ -120,6 +120,8 @@ namespace gpopt
 			virtual 
 			IMDId *PmdidType() const;
 
+			// print
+			IOstream &OsPrint(IOstream &os) const;
 
 	}; // class CScalarArray
 

--- a/libgpopt/src/base/CConstraint.cpp
+++ b/libgpopt/src/base/CConstraint.cpp
@@ -139,7 +139,6 @@ CConstraint::PcnstrFromScalarArrayCmp
 	return NULL;
 }
 
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CConstraint::PcnstrFromScalarExpr
@@ -185,13 +184,13 @@ CConstraint::PcnstrFromScalarExpr
 
 		CConstraint *pcnstr = NULL;
 		*ppdrgpcrs = GPOS_NEW(pmp) DrgPcrs(pmp);
-		if (CUtils::FScalarArrayCmp(pexpr))
+
+		// try creating a single constraint from the expression
+		pcnstr = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexpr, pcr);
+		if (NULL == pcnstr && CUtils::FScalarArrayCmp(pexpr))
 		{
+			// try creating a disjunction of several interval constraints in the array case
 			pcnstr = PcnstrFromScalarArrayCmp(pmp, pexpr, pcr);
-		}
-		else
-		{
-			pcnstr = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexpr, pcr);
 		}
 
 		if (NULL != pcnstr)

--- a/libgpopt/src/base/CConstraint.cpp
+++ b/libgpopt/src/base/CConstraint.cpp
@@ -185,8 +185,14 @@ CConstraint::PcnstrFromScalarExpr
 		CConstraint *pcnstr = NULL;
 		*ppdrgpcrs = GPOS_NEW(pmp) DrgPcrs(pmp);
 
-		// try creating a single constraint from the expression
+		// first, try creating a single interval constraint from the expression
 		pcnstr = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexpr, pcr);
+		if (NULL == pcnstr && CUtils::FScalarArrayCmp(pexpr))
+		{
+			// if the interval creation failed, try creating a disjunction or conjunction
+			// of several interval constraints in the array case
+			pcnstr = PcnstrFromScalarArrayCmp(pmp, pexpr, pcr);
+		}
 
 		if (NULL != pcnstr)
 		{

--- a/libgpopt/src/base/CConstraint.cpp
+++ b/libgpopt/src/base/CConstraint.cpp
@@ -187,11 +187,6 @@ CConstraint::PcnstrFromScalarExpr
 
 		// try creating a single constraint from the expression
 		pcnstr = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexpr, pcr);
-		if (NULL == pcnstr && CUtils::FScalarArrayCmp(pexpr))
-		{
-			// try creating a disjunction of several interval constraints in the array case
-			pcnstr = PcnstrFromScalarArrayCmp(pmp, pexpr, pcr);
-		}
 
 		if (NULL != pcnstr)
 		{

--- a/libgpopt/src/base/CRange.cpp
+++ b/libgpopt/src/base/CRange.cpp
@@ -241,6 +241,38 @@ CRange::FOverlapsRight
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CRange::FRightEqualsLeft
+//
+//	@doc:
+//		Checks if the right element equal the left element of the given range.
+//      This is useful when checking if 2 ranges touch at the ends
+//
+//---------------------------------------------------------------------------
+BOOL
+CRange::FRightEqualsLeft
+	(
+	CRange *prange
+	)
+{
+	GPOS_ASSERT(NULL != prange);
+
+	IDatum *pdatumLeft = prange->PdatumLeft();
+
+	if (NULL == pdatumLeft && NULL == m_pdatumRight)
+	{
+		return true;
+	}
+
+	if (NULL == pdatumLeft || NULL == m_pdatumRight)
+	{
+		return false;
+	}
+
+	return m_pcomp->FEqual(m_pdatumRight, pdatumLeft);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CRange::FStartsWithOrBefore
 //
 //	@doc:

--- a/libgpopt/src/base/CRange.cpp
+++ b/libgpopt/src/base/CRange.cpp
@@ -241,15 +241,18 @@ CRange::FOverlapsRight
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CRange::FRightEqualsLeft
+//		CRange::FUpperBoundEqualsLowerBound
 //
 //	@doc:
-//		Checks if the right element equal the left element of the given range.
-//      This is useful when checking if 2 ranges touch at the ends
+//		Checks if this range's upper bound value is equal to the given range's
+//		lower bound value. Ignores inclusivity/exclusivity Examples:
+//			(-inf, 8)(8, inf)	true
+//			(-inf, 8](8, inf)	true
+//			(-inf, inf)(8, inf)	false
 //
 //---------------------------------------------------------------------------
 BOOL
-CRange::FRightEqualsLeft
+CRange::FUpperBoundEqualsLowerBound
 	(
 	CRange *prange
 	)

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -4094,6 +4094,35 @@ CUtils::FComparisonPossible
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CUtils::FCountOperator
+//
+//	@doc:
+//		counts the number of times a certain operator appears
+//
+//---------------------------------------------------------------------------
+ULONG
+CUtils::FCountOperator
+	(
+		CExpression *pexpr,
+		INT Eopid
+	)
+{
+	INT iopCnt = 0;
+	if (pexpr->Pop()->Eopid() == Eopid)
+	{
+		iopCnt += 1;
+	}
+
+
+	for (ULONG ulChild = 0; ulChild < pexpr->UlArity(); ulChild++)
+	{
+		iopCnt += FCountOperator((*pexpr)[ulChild], Eopid);
+	}
+	return iopCnt;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CUtils::PdrgpcrHashablePrefix
 //
 //	@doc:
@@ -5763,6 +5792,37 @@ CUtils::PexprCollapseProjects
 						pexprProject,
 						GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CScalarProjectList(pmp), pdrgpexprPrEl)
 						);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CUtils::IDatumCmp
+//
+//	@doc:
+//		Compares two datums. Takes pointer pointer to a datums.
+//
+//---------------------------------------------------------------------------
+INT CUtils::IDatumCmp
+		(
+		const void *pv1,
+		const void *pv2
+		)
+{
+	const IDatum *dat1 = *(IDatum**)(pv1);
+	const IDatum *dat2 = *(IDatum**)(pv2);
+
+	const IComparator *pcomp = COptCtxt::PoctxtFromTLS()->Pcomp();
+
+	if (pcomp->FEqual(dat1, dat2))
+	{
+		return 0;
+	}
+	else if (pcomp->FLessThan(dat1, dat2))
+	{
+		return -1;
+	}
+
+	return 1;
 }
 
 // EOF

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -4094,31 +4094,31 @@ CUtils::FComparisonPossible
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CUtils::FCountOperator
+//		CUtils::UlCountOperator
 //
 //	@doc:
 //		counts the number of times a certain operator appears
 //
 //---------------------------------------------------------------------------
 ULONG
-CUtils::FCountOperator
+CUtils::UlCountOperator
 	(
-		CExpression *pexpr,
-		INT Eopid
+		const CExpression *pexpr,
+		COperator::EOperatorId eopid
 	)
 {
-	INT iopCnt = 0;
-	if (pexpr->Pop()->Eopid() == Eopid)
+	ULONG ulOpCnt = 0;
+	if (eopid == pexpr->Pop()->Eopid())
 	{
-		iopCnt += 1;
+		ulOpCnt += 1;
 	}
 
-
-	for (ULONG ulChild = 0; ulChild < pexpr->UlArity(); ulChild++)
+	const ULONG ulArity = pexpr->UlArity();
+	for (ULONG ulChild = 0; ulChild < ulArity; ulChild++)
 	{
-		iopCnt += FCountOperator((*pexpr)[ulChild], Eopid);
+		ulOpCnt += UlCountOperator((*pexpr)[ulChild], eopid);
 	}
-	return iopCnt;
+	return ulOpCnt;
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/operators/CScalarArray.cpp
+++ b/libgpopt/src/operators/CScalarArray.cpp
@@ -165,6 +165,21 @@ CScalarArray::PmdidType() const
 	return m_pmdidArray;
 }
 
+IOstream &
+CScalarArray::OsPrint(IOstream &os) const
+{
+	os << "CScalarArray: {eleMDId: ";
+	m_pmdidElem->OsPrint(os);
+	os << ", arrayMDId: ";
+	m_pmdidArray->OsPrint(os);
+	if (m_fMultiDimensional)
+	{
+		os << ", multidimensional";
+	}
+	os << "}";
+	return os;
+}
+
 
 // EOF
 

--- a/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -163,6 +163,9 @@ namespace gpos
 		// enable parallel append
 		EopttraceEnableParallelAppend = 103025,
 
+		// create constraint intervals from array expressions in preprocessing
+		EopttraceEnableArrayDerive = 103026,
+
 		///////////////////////////////////////////////////////
 		///////////////////// statistics flags ////////////////
 		//////////////////////////////////////////////////////

--- a/server/include/unittest/gpopt/CTestUtils.h
+++ b/server/include/unittest/gpopt/CTestUtils.h
@@ -20,6 +20,7 @@
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CExpression.h"
+#include "gpopt/operators/CScalarArrayCmp.h"
 #include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CLogicalGet.h"
 #include "gpopt/operators/CScalarBoolOp.h"
@@ -351,6 +352,9 @@ namespace gpopt
 			// generate a select expression with an array compare
 			static
 			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp);
+
+			static
+			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType eScalarArrayCmpType, IMDType::ECmpType eCmpType);
 			
 			// generate an n-ary join expression
 			static

--- a/server/include/unittest/gpopt/CTestUtils.h
+++ b/server/include/unittest/gpopt/CTestUtils.h
@@ -356,6 +356,10 @@ namespace gpopt
 			// generate a select expression with an array compare
 			static
 			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType earrcmptype, IMDType::ECmpType ecmptype);
+
+			// generate a select expression with an array compare
+			static
+			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType earrcmptype, IMDType::ECmpType ecmptype, const DrgPi *pdrgpiVals);
 			
 			// generate an n-ary join expression
 			static

--- a/server/include/unittest/gpopt/CTestUtils.h
+++ b/server/include/unittest/gpopt/CTestUtils.h
@@ -353,8 +353,9 @@ namespace gpopt
 			static
 			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp);
 
+			// generate a select expression with an array compare
 			static
-			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType eScalarArrayCmpType, IMDType::ECmpType eCmpType);
+			CExpression *PexprLogicalSelectArrayCmp(IMemoryPool *pmp, CScalarArrayCmp::EArrCmpType earrcmptype, IMDType::ECmpType ecmptype);
 			
 			// generate an n-ary join expression
 			static

--- a/server/include/unittest/gpopt/base/CConstraintTest.h
+++ b/server/include/unittest/gpopt/base/CConstraintTest.h
@@ -165,6 +165,9 @@ namespace gpopt
 			static GPOS_RESULT EresUnittest_CDisjunction();
 			static GPOS_RESULT EresUnittest_CNegation();
 			static GPOS_RESULT EresUnittest_CConstraintFromScalarExpr();
+			static GPOS_RESULT EresUnittest_CConstraintIntervalConvertsTo();
+			static GPOS_RESULT EresUnittest_CConstraintIntervalPexpr();
+			static GPOS_RESULT EresUnittest_CConstraintIntervalFromArrayExpr();
 
 #ifdef GPOS_DEBUG
 			// tests for unconstrainable types

--- a/server/src/unittest/CTestUtils.cpp
+++ b/server/src/unittest/CTestUtils.cpp
@@ -880,6 +880,32 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	IMemoryPool *pmp
 	)
 {
+	return PexprLogicalSelectArrayCmp(pmp, CScalarArrayCmp::EarrcmpAny, IMDType::EcmptEq);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTestUtils::PexprLogicalSelectArrayCmp
+//
+//	@doc:
+//		Generate a Select expression with an array compare. Takes an enum for
+//		the type of array comparison (ANY or ALL) and an enum for the comparator
+//		type (=, !=, <, etc)
+//
+//---------------------------------------------------------------------------
+CExpression *
+CTestUtils::PexprLogicalSelectArrayCmp
+	(
+	IMemoryPool *pmp,
+	CScalarArrayCmp::EArrCmpType eScalarArrayCmpType,
+	IMDType::ECmpType eCmpType
+	)
+{
+	// must be a valid array comparison enum
+	GPOS_ASSERT(CScalarArrayCmp::EarrcmpSentinel > eScalarArrayCmpType);
+	// must be a valid comparator type
+	GPOS_ASSERT(IMDType::EcmptOther > eCmpType);
+
 	CMDAccessor *pmda = COptCtxt::PoctxtFromTLS()->Pmda();
 
 	// generate a get expression
@@ -902,7 +928,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	// get column type mdid and mdid of the array type corresponding to that type 
 	IMDId *pmdidColType = pcr->Pmdtype()->Pmdid();
 	IMDId *pmdidArrType = pcr->Pmdtype()->PmdidTypeArray();
-	IMDId *pmdidCmpOp = pcr->Pmdtype()->PmdidCmp(IMDType::EcmptEq);
+	IMDId *pmdidCmpOp = pcr->Pmdtype()->PmdidCmp(eCmpType);
 
 	pmdidColType->AddRef();
 	pmdidArrType->AddRef();
@@ -922,7 +948,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 			GPOS_NEW(pmp) CExpression
 						(
 						pmp,
-						GPOS_NEW(pmp) CScalarArrayCmp(pmp, pmdidCmpOp, GPOS_NEW(pmp) CWStringConst(pmp, strOp.Wsz()), CScalarArrayCmp::EarrcmpAny),
+						GPOS_NEW(pmp) CScalarArrayCmp(pmp, pmdidCmpOp, GPOS_NEW(pmp) CWStringConst(pmp, strOp.Wsz()), eScalarArrayCmpType),
 						pexprIdent,
 						pexprArray
 						);

--- a/server/src/unittest/CTestUtils.cpp
+++ b/server/src/unittest/CTestUtils.cpp
@@ -890,7 +890,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 //	@doc:
 //		Generate a Select expression with an array compare. Takes an enum for
 //		the type of array comparison (ANY or ALL) and an enum for the comparator
-//		type (=, !=, <, etc)
+//		type (=, !=, <, etc).
 //
 //---------------------------------------------------------------------------
 CExpression *
@@ -899,6 +899,37 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	IMemoryPool *pmp,
 	CScalarArrayCmp::EArrCmpType earrcmptype,
 	IMDType::ECmpType ecmptype
+	)
+{
+	const ULONG ulArraySize = 5;
+	DrgPi *pdrgpiVals = GPOS_NEW(pmp) DrgPi(pmp);
+	for (ULONG iVal = 0; iVal < ulArraySize; iVal++)
+	{
+		pdrgpiVals->Append(GPOS_NEW(pmp) INT(iVal));
+	}
+	CExpression *pexprSelect = PexprLogicalSelectArrayCmp(pmp, earrcmptype, ecmptype, pdrgpiVals);
+	pdrgpiVals->Release();
+	return pexprSelect;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTestUtils::PexprLogicalSelectArrayCmp
+//
+//	@doc:
+//		Generate a Select expression with an array compare. Takes an enum for
+//		the type of array comparison (ANY or ALL) and an enum for the comparator
+//		type (=, !=, <, etc). The array will be populated with the given integer
+//		values.
+//
+//---------------------------------------------------------------------------
+CExpression *
+CTestUtils::PexprLogicalSelectArrayCmp
+	(
+	IMemoryPool *pmp,
+	CScalarArrayCmp::EArrCmpType earrcmptype,
+	IMDType::ECmpType ecmptype,
+	const DrgPi *pdrgpiVals
 	)
 {
 	GPOS_ASSERT(CScalarArrayCmp::EarrcmpSentinel > earrcmptype);
@@ -917,9 +948,10 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	// construct an array of integers
 	DrgPexpr *pdrgpexprArrayElems = GPOS_NEW(pmp) DrgPexpr(pmp);
 	
-	for (ULONG ul = 0; ul < 5; ul++)
+	const ULONG ulValsLength = pdrgpiVals->UlLength();
+	for (ULONG ul = 0; ul < ulValsLength; ul++)
 	{
-		CExpression *pexprArrayElem = CUtils::PexprScalarConstInt4(pmp, ul);
+		CExpression *pexprArrayElem = CUtils::PexprScalarConstInt4(pmp, *(*pdrgpiVals)[ul]);
 		pdrgpexprArrayElems->Append(pexprArrayElem);
 	}
 

--- a/server/src/unittest/CTestUtils.cpp
+++ b/server/src/unittest/CTestUtils.cpp
@@ -897,14 +897,12 @@ CExpression *
 CTestUtils::PexprLogicalSelectArrayCmp
 	(
 	IMemoryPool *pmp,
-	CScalarArrayCmp::EArrCmpType eScalarArrayCmpType,
-	IMDType::ECmpType eCmpType
+	CScalarArrayCmp::EArrCmpType earrcmptype,
+	IMDType::ECmpType ecmptype
 	)
 {
-	// must be a valid array comparison enum
-	GPOS_ASSERT(CScalarArrayCmp::EarrcmpSentinel > eScalarArrayCmpType);
-	// must be a valid comparator type
-	GPOS_ASSERT(IMDType::EcmptOther > eCmpType);
+	GPOS_ASSERT(CScalarArrayCmp::EarrcmpSentinel > earrcmptype);
+	GPOS_ASSERT(IMDType::EcmptOther > ecmptype);
 
 	CMDAccessor *pmda = COptCtxt::PoctxtFromTLS()->Pmda();
 
@@ -928,7 +926,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 	// get column type mdid and mdid of the array type corresponding to that type 
 	IMDId *pmdidColType = pcr->Pmdtype()->Pmdid();
 	IMDId *pmdidArrType = pcr->Pmdtype()->PmdidTypeArray();
-	IMDId *pmdidCmpOp = pcr->Pmdtype()->PmdidCmp(eCmpType);
+	IMDId *pmdidCmpOp = pcr->Pmdtype()->PmdidCmp(ecmptype);
 
 	pmdidColType->AddRef();
 	pmdidArrType->AddRef();
@@ -948,7 +946,7 @@ CTestUtils::PexprLogicalSelectArrayCmp
 			GPOS_NEW(pmp) CExpression
 						(
 						pmp,
-						GPOS_NEW(pmp) CScalarArrayCmp(pmp, pmdidCmpOp, GPOS_NEW(pmp) CWStringConst(pmp, strOp.Wsz()), eScalarArrayCmpType),
+						GPOS_NEW(pmp) CScalarArrayCmp(pmp, pmdidCmpOp, GPOS_NEW(pmp) CWStringConst(pmp, strOp.Wsz()), earrcmptype),
 						pexprIdent,
 						pexprArray
 						);

--- a/server/src/unittest/gpopt/base/CConstraintTest.cpp
+++ b/server/src/unittest/gpopt/base/CConstraintTest.cpp
@@ -646,14 +646,14 @@ CConstraintTest::EresUnittest_CConstraintIntervalConvertsTo()
 	PrintConstraint(pmp, pcnstin);
 
 	// should convert to in
-	GPOS_ASSERT(pcnstin->convertsToIn());
-	GPOS_ASSERT(!pcnstin->convertsToNotIn());
+	GPOS_ASSERT(pcnstin->FConvertsToIn());
+	GPOS_ASSERT(!pcnstin->FConvertsToNotIn());
 
 	CConstraintInterval *pcnstNotIn = pcnstin->PciComplement(pmp);
 
 	// should convert to a not in statement after taking the complement
-	GPOS_ASSERT(pcnstNotIn->convertsToNotIn());
-	GPOS_ASSERT(!pcnstNotIn->convertsToIn());
+	GPOS_ASSERT(pcnstNotIn->FConvertsToNotIn());
+	GPOS_ASSERT(!pcnstNotIn->FConvertsToIn());
 
 	pcnstin->Release();
 	pcnstNotIn->Release();
@@ -722,10 +722,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstin->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstin);
 
-	GPOS_ASSERT(!pcnstin->convertsToNotIn());
-	GPOS_ASSERT(pcnstin->convertsToIn());
+	GPOS_ASSERT(!pcnstin->FConvertsToNotIn());
+	GPOS_ASSERT(pcnstin->FConvertsToIn());
 	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(3 == CUtils::FCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_ASSERT(3 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstin->Release();
 
@@ -739,10 +739,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstin->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstin);
 
-	GPOS_ASSERT(!pcnstin->convertsToNotIn());
-	GPOS_ASSERT(pcnstin->convertsToIn());
+	GPOS_ASSERT(!pcnstin->FConvertsToNotIn());
+	GPOS_ASSERT(pcnstin->FConvertsToIn());
 	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(4 == CUtils::FCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_ASSERT(4 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstin->Release();
 
@@ -759,10 +759,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstNotIn->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstNotIn);
 
-	GPOS_ASSERT(pcnstNotIn->convertsToNotIn());
-	GPOS_ASSERT(!pcnstNotIn->convertsToIn());
+	GPOS_ASSERT(pcnstNotIn->FConvertsToNotIn());
+	GPOS_ASSERT(!pcnstNotIn->FConvertsToIn());
 	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(3 == CUtils::FCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_ASSERT(3 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstNotIn->Release();
 
@@ -779,10 +779,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstNotIn->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstNotIn);
 
-	GPOS_ASSERT(pcnstNotIn->convertsToNotIn());
-	GPOS_ASSERT(!pcnstNotIn->convertsToIn());
+	GPOS_ASSERT(pcnstNotIn->FConvertsToNotIn());
+	GPOS_ASSERT(!pcnstNotIn->FConvertsToIn());
 	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(4 == CUtils::FCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_ASSERT(4 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstNotIn->Release();
 
@@ -829,11 +829,11 @@ CConstraintTest::EresUnittest_CConstraintIntervalFromArrayExpr()
 	CExpression *pexprArrayComp = (*pexpr->PdrgPexpr())[1];
 	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexprArrayComp));
 
-	CConstraintInterval *pIn = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexprArrayComp, pcr);
-	GPOS_ASSERT(CConstraint::EctInterval == pIn->Ect());
-	GPOS_ASSERT(pIn->Pdrgprng()->UlLength() == CUtils::FCountOperator(pexprArrayComp, COperator::EopScalarConst));
+	CConstraintInterval *pcnstIn = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexprArrayComp, pcr);
+	GPOS_ASSERT(CConstraint::EctInterval == pcnstIn->Ect());
+	GPOS_ASSERT(pcnstIn->Pdrgprng()->UlLength() == CUtils::UlCountOperator(pexprArrayComp, COperator::EopScalarConst));
 
-	pIn->Release();
+	pcnstIn->Release();
 	pexpr->Release();
 
 	// test a NOT IN expression
@@ -841,13 +841,13 @@ CConstraintTest::EresUnittest_CConstraintIntervalFromArrayExpr()
 	CExpression *pexprNotIn = CTestUtils::PexprLogicalSelectArrayCmp(pmp, CScalarArrayCmp::EarrcmpAll, IMDType::EcmptNEq);
 	CExpression *pexprArrayNotInComp = (*pexprNotIn->PdrgPexpr())[1];
 	CColRef *pcrNot = CDrvdPropRelational::Pdprel(pexprNotIn->PdpDerive())->PcrsOutput()->PcrAny();
-	CConstraintInterval *pNotIn = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexprArrayNotInComp, pcrNot);
-	GPOS_ASSERT(CConstraint::EctInterval == pNotIn->Ect());
+	CConstraintInterval *pcnstNotIn = CConstraintInterval::PciIntervalFromScalarExpr(pmp, pexprArrayNotInComp, pcrNot);
+	GPOS_ASSERT(CConstraint::EctInterval == pcnstNotIn->Ect());
 	// a NOT IN range array should have one more element than the expression array consts
-	GPOS_ASSERT(pNotIn->Pdrgprng()->UlLength() == 1 + CUtils::FCountOperator(pexprArrayNotInComp, COperator::EopScalarConst));
+	GPOS_ASSERT(pcnstNotIn->Pdrgprng()->UlLength() == 1 + CUtils::UlCountOperator(pexprArrayNotInComp, COperator::EopScalarConst));
 
 	pexprNotIn->Release();
-	pNotIn->Release();
+	pcnstNotIn->Release();
 
 	return GPOS_OK;
 }

--- a/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
+++ b/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
@@ -14,6 +14,7 @@
 
 #include "gpos/io/COstreamString.h"
 #include "gpos/string/CWStringDynamic.h"
+#include "gpos/task/CAutoTraceFlag.h"
 
 #include "gpopt/base/CUtils.h"
 #include "gpopt/eval/CConstExprEvaluatorDefault.h"
@@ -1634,6 +1635,7 @@ CExpressionPreprocessorTest::EresUnittest_PreProcessOrPrefilters()
 {
 	CAutoMemoryPool amp;
 	IMemoryPool *pmp = amp.Pmp();
+	CAutoTraceFlag atf(EopttraceEnableArrayDerive, true /*fVal*/);
 
 	// reset metadata cache
 	CMDCache::Reset();
@@ -1758,22 +1760,26 @@ CExpressionPreprocessorTest::EresUnittest_PreProcessOrPrefilters()
 			"   |     |  +--CScalarCmp (=)\n"
 			"   |     |     |--CScalarIdent \"column_0002\" (5)\n"
 			"   |     |     +--CScalarConst (0)\n"
-			"   |     +--CScalarBoolOp (EboolopOr)\n"
-			"   |        |--CScalarCmp (=)\n"
-			"   |        |  |--CScalarIdent \"column_0000\" (3)\n"
-			"   |        |  +--CScalarConst (1)\n"
-			"   |        +--CScalarCmp (=)\n"
-			"   |           |--CScalarIdent \"column_0000\" (3)\n"
+			"   |     +--CScalarArrayCmp Any (=)\n"
+			"   |        |--CScalarIdent \"column_0000\" (3)\n"
+			"   |        +--CScalarArray: {eleMDId: (23,1.0), arrayMDId: (1007,1.0)}\n"
+			"   |           |--CScalarConst (1)\n"
 			"   |           +--CScalarConst (2)\n"
 			"   |--CLogicalSelect\n"
 			"   |  |--CLogicalGet \"BaseTableAlias\" (\"BaseTable\"), Columns: [\"column_0000\" (0), \"column_0001\" (1), \"column_0002\" (2)] Key sets: {[0]}\n"
-			"   |  +--CScalarBoolOp (EboolopOr)\n"
-			"   |     |--CScalarCmp (=)\n"
-			"   |     |  |--CScalarIdent \"column_0000\" (0)\n"
-			"   |     |  +--CScalarConst (1)\n"
-			"   |     +--CScalarCmp (=)\n"
+			"   |  +--CScalarBoolOp (EboolopAnd)\n"
+			"   |     |--CScalarBoolOp (EboolopOr)\n"
+			"   |     |  |--CScalarCmp (=)\n"
+			"   |     |  |  |--CScalarIdent \"column_0000\" (0)\n"
+			"   |     |  |  +--CScalarConst (2)\n"
+			"   |     |  +--CScalarCmp (=)\n"
+			"   |     |     |--CScalarIdent \"column_0000\" (0)\n"
+			"   |     |     +--CScalarConst (1)\n"
+			"   |     +--CScalarArrayCmp Any (=)\n"
 			"   |        |--CScalarIdent \"column_0000\" (0)\n"
-			"   |        +--CScalarConst (2)\n"
+			"   |        +--CScalarArray: {eleMDId: (23,1.0), arrayMDId: (1007,1.0)}\n"
+			"   |           |--CScalarConst (1)\n"
+			"   |           +--CScalarConst (2)\n"
 			"   +--CScalarBoolOp (EboolopAnd)\n"
 			"      |--CScalarBoolOp (EboolopOr)\n"
 			"      |  |--CScalarBoolOp (EboolopAnd)\n"


### PR DESCRIPTION
## Summary:
Fixes a bug in CConstraintInterval involving NULLs
When a CConstraintInterval was constructed using an array containing  CDatumGenericGPDB types we exposed a bug where the comparison logic with NULLS was different between datums which could be evaluated within ORCA.

The fix is straightforward: check for NULL datums in an array when constructing a CConstraintInterval. Set a flag in the CConstraintInterval class and do not add the NULL datum to the data structures inside of the Interval.

Also adds a unit test.

## Process:
@d and I spent a day trying to find out why we would generate an invalid plan when running part of gp_optimizer from ICG.
```SQL
set optimizer=on;
set optimizer_print_plan=on;
set optimizer_print_optimization_stats=on;
set optimizer_enable_array_derivation=on;
set optimizer_enumerate_plans=on;
set optimizer_enable_partial_index=on;
set optimizer_enable_space_pruning=off;
set client_min_messages='log';

create table t_text 
   (timest date, user_id numeric(16,0) not null, tag1 char(5), tag2 char(5))
   distributed by (user_id)
   partition by list(tag1) 
      (  partition partgood values('good'::text),
         partition partbad values('bad'::text),
         partition partugly values('ugly'::text)
      );
create index user_id_idx on t_text_1_prt_partgood(user_id);
explain select * from t_text where user_id=9;

set optimizer_minidump=always;
set optimizer_plan_id=2;

-- kills segments
select * from t_text where user_id=9;
```
The above repro will create an invalid plan in a release build and cause ORCA to fail an assert in debug build. 

**The actual issue required**:
* An array expression with NULLs and including non-integer types
* Constraint derivation to be called on the array

A smaller repro which gets at the issue is:
```SQL
set optimizer=on;
set optimizer_use_external_constant_expression_evaluation_for_ints = on;
set optimizer_enable_array_derivation=on;
create table if not exists foo (id int);
create table if not exists bar (like foo);
explain select * from foo,bar where bar.id = foo.id and foo.id IN (2, 1, NULL);
```
**Resulting plan**:
```
                   QUERY PLAN
------------------------------------------------
 Result  (cost=0.00..0.00 rows=0 width=8)
   ->  Result  (cost=0.00..0.00 rows=0 width=8)
         One-Time Filter: false
 Settings:  optimizer=on
 Optimizer status: PQO version 1.648
(5 rows)
```
Which is incorrect. After our fix, we get:
```
                                           QUERY PLAN
------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
   ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
         Hash Cond: foo.id = bar.id
         ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=4)
               Filter: (id = ANY ('{2,1,NULL}'::integer[])) AND (id = ANY ('{1,2}'::integer[]))
         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
               ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=4)
                     Filter: id = ANY ('{1,2}'::integer[])
 Settings:  optimizer=on
 Optimizer status: PQO version 1.648
```
Which has corrected the issue.
_________
@vraghavan78 this should be added after pt 1 goes in