### PR TITLE
Extract CDatumSortedSet

### DIFF
--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -890,6 +890,8 @@ add_library(gpopt
             src/operators/CPhysicalParallelUnionAll.cpp
             include/gpopt/base/CDistributionSpecStrictHashed.h
             src/base/CDistributionSpecStrictHashed.cpp
+            include/gpopt/base/CDatumSortedSet.h
+            src/base/CDatumSortedSet.cpp
             )
 
 target_link_libraries(gpopt

--- a/libgpopt/include/gpopt/base/CDatumSortedSet.h
+++ b/libgpopt/include/gpopt/base/CDatumSortedSet.h
@@ -1,0 +1,33 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#ifndef GPOPT_CDatumSortedSet_H
+#define GPOPT_CDatumSortedSet_H
+
+#include "naucrates/base/IDatum.h"
+#include "gpos/memory/IMemoryPool.h"
+#include "gpopt/operators/CExpression.h"
+#include "gpopt/base/IComparator.h"
+
+namespace gpopt
+{
+	// A sorted and uniq'd array of pointers to datums
+	// It facilitates the construction of CConstraintInterval
+	class CDatumSortedSet : public DrgPdatum
+	{
+		private:
+			BOOL m_fIncludesNull;
+
+		public:
+			CDatumSortedSet
+			(
+			IMemoryPool *pmp,
+			CExpression *pexprArray,
+			const IComparator *pcomp
+			);
+
+			BOOL FIncludesNull() const;
+	};
+}
+
+#endif

--- a/libgpopt/src/base/CDatumSortedSet.cpp
+++ b/libgpopt/src/base/CDatumSortedSet.cpp
@@ -1,0 +1,63 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#include "gpopt/operators/COperator.h"
+#include "gpopt/base/CDatumSortedSet.h"
+#include "gpopt/operators/CScalarConst.h"
+#include "gpopt/base/CUtils.h"
+#include "gpos/common/CAutoRef.h"
+
+using namespace gpopt;
+
+CDatumSortedSet::CDatumSortedSet
+	(
+	IMemoryPool *pmp,
+	CExpression *pexprArray,
+	const IComparator *pcomp
+	)
+	:
+	DrgPdatum(pmp),
+	m_fIncludesNull(false)
+{
+	GPOS_ASSERT(0 < pexprArray->UlArity());
+	GPOS_ASSERT(COperator::EopScalarArray == pexprArray->Pop()->Eopid());
+
+	const ULONG ulArrayExprArity = pexprArray->UlArity();
+
+	gpos::CAutoRef<DrgPdatum> aprngdatum(GPOS_NEW(pmp) DrgPdatum(pmp));
+	for (ULONG ul = 0; ul < ulArrayExprArity; ul++)
+	{
+		CScalarConst *popScConst = CScalarConst::PopConvert((*pexprArray)[ul]->Pop());
+		IDatum *pdatum = popScConst->Pdatum();
+		if (pdatum->FNull())
+		{
+			m_fIncludesNull = true;
+		}
+		else
+		{
+			pdatum->AddRef();
+			aprngdatum->Append(pdatum);
+		}
+	}
+	aprngdatum->Sort(&CUtils::IDatumCmp);
+
+	// de-duplicate
+	const ULONG ulRangeArrayArity = aprngdatum->UlLength();
+	IDatum *pdatumPrev = (*aprngdatum)[0];
+	pdatumPrev->AddRef();
+	Append(pdatumPrev);
+	for (ULONG ul = 1; ul < ulRangeArrayArity; ul++)
+	{
+		if (!pcomp->FEqual((*aprngdatum)[ul], pdatumPrev))
+		{
+			pdatumPrev = (*aprngdatum)[ul];
+			pdatumPrev->AddRef();
+			Append(pdatumPrev);
+		}
+	}
+}
+
+BOOL CDatumSortedSet::FIncludesNull() const
+{
+	return m_fIncludesNull;
+}


### PR DESCRIPTION
We extracted into a class the logic of constructing an array of datums to feed into the construction of ranges for an interval constraint.

This removes repeated deduplication logic in the creation of `CRange`s.