### PR TITLE
[#125960675] Preprocessing stage for Array Conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 656)
+set(GPORCA_VERSION_MINOR 657)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.656
+LIB_VERSION = 1.657
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -177,6 +177,14 @@ namespace gpopt
 				const CColRefSet *pcrsReqd
 				);
 
+			// generate a scalar bool op expression or return the only child expression in array
+			static CExpression *
+			PexprScalarBoolOpConvert2In(IMemoryPool *pmp, CScalarBoolOp::EBoolOperator eboolop, DrgPexpr *pdrgpexpr);
+
+			// determines if the expression is likely convertible to an array expression
+			static BOOL
+			FConvert2InIsConvertable(CExpression *pexpr, CScalarBoolOp::EBoolOperator eboolop);
+
 			// private ctor
 			CExpressionPreprocessor();
 
@@ -200,6 +208,10 @@ namespace gpopt
 			// derive constraints on given expression
 			static
 			CExpression *PexprAddPredicatesFromConstraints(IMemoryPool *pmp, CExpression *pexpr);
+
+			// convert series of AND or OR comparisons into array IN expressions
+			static
+			CExpression *PexprConvert2In(IMemoryPool *pmp, CExpression *pexpr);
 
 	}; // class CExpressionPreprocessor
 }

--- a/server/include/unittest/gpopt/CTestUtils.h
+++ b/server/include/unittest/gpopt/CTestUtils.h
@@ -545,6 +545,10 @@ namespace gpopt
 			static
 			CExpression *PexprScalarNestedPreds(IMemoryPool *pmp, CExpression *pexpr, CScalarBoolOp::EBoolOperator eboolop);
 
+			// find the first child expression with the given operator id
+			static
+			CExpression *PexprFindFirstExpressionWithOpId(CExpression *pexpr, COperator::EOperatorId eopid);
+
 			// equality predicate shortcut
 			static
 			void EqualityPredicate(IMemoryPool *pmp, CColRefSet *pcrsLeft, CColRefSet *pcrsRight, DrgPexpr *pdrgpexpr);

--- a/server/include/unittest/gpopt/operators/CExpressionPreprocessorTest.h
+++ b/server/include/unittest/gpopt/operators/CExpressionPreprocessorTest.h
@@ -167,6 +167,10 @@ namespace gpopt
 			static
 			GPOS_RESULT EresTestLOJ(BOOL fAddWindowFunction);
 
+			// helper to create an expression with a predicate containing an array and other comparisons
+			static
+			CExpression *PexprCreateConvertableArray(IMemoryPool *pmp, BOOL fCreateInStatement);
+
 		public:
 
 			// unittests
@@ -184,6 +188,9 @@ namespace gpopt
 			static GPOS_RESULT EresUnittest_PreProcessOrPrefilters();
 			static GPOS_RESULT EresUnittest_PreProcessOrPrefiltersPartialPush();
 			static GPOS_RESULT EresUnittest_CollapseInnerJoin();
+			static GPOS_RESULT EresUnittest_PreProcessConvert2InPredicate();
+			static GPOS_RESULT EresUnittest_PreProcessConvert2InPredicateDeepExpressionTree();
+			static GPOS_RESULT EresUnittest_PreProcessConvertArrayWithEquals();
 
 	}; // class CExpressionPreprocessorTest
 }

--- a/server/src/unittest/CTestUtils.cpp
+++ b/server/src/unittest/CTestUtils.cpp
@@ -2880,6 +2880,41 @@ CTestUtils::PexprScalarNestedPreds
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CTestUtils::PexprFindFirstExpressionWithOpId
+//
+//	@doc:
+//		DFS of expression tree to find and return a pointer to the expression
+//		containing the given operator type. NULL if not found
+//
+//---------------------------------------------------------------------------
+CExpression *
+CTestUtils::PexprFindFirstExpressionWithOpId
+	(
+	CExpression *pexpr,
+	COperator::EOperatorId eopid
+	)
+{
+	GPOS_ASSERT(NULL != pexpr);
+	if (eopid == pexpr->Pop()->Eopid())
+	{
+		return pexpr;
+	}
+
+	ULONG ulArity = pexpr->UlArity();
+	for (ULONG ul = 0; ul < ulArity; ul++)
+	{
+		CExpression *pexprFound = PexprFindFirstExpressionWithOpId((*pexpr)[ul], eopid);
+		if (NULL != pexprFound)
+		{
+			return pexprFound;
+		}
+	}
+
+	return NULL;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CTestUtils::EqualityPredicate
 //
 //	@doc:


### PR DESCRIPTION
### Preprocessing stage for Array Conversion

Adds an expression preprocessing stage to convert applicable expressions into array IN or NOT IN expressions. This creates more succinct expression trees and reduces redundancy in final expression output.

Therefore an expression like `x = 1 OR x = 2` should be converted into the equivalent `x IN (1,2)`.

This feature works by doing a recursive walk of the expression tree which looks for multiple AND or OR children which are either array expressions or ScalarComparison children. It then converts them into Constraints. Constraints hold logic to detect redundancy and also to convert OR/AND statements into array statements (Array Pt 1).

We chose to put this method after step 8 of expression preprocessing because step 9 will propagate constraints, and therefore it makes sense to propagate array constraints instead of OR constraints because they are more succinct and also preprocessing will attempt to re-derive constraints from propagated constraints which can lead to redundant expressions being created if array constraints are not passed.

This feature is controlled by the `EnableArrayDerive` traceflag.

@lpetrov-pivotal and I learned a lot about reference counting while implementing the Preprocessing method. We summarized our findings in [this document](https://docs.google.com/a/pivotal.io/document/d/1nndCf-ZreeLYtdXeVdOy6BHx_xgyVbVrv9GSdMkxoRg/edit?usp=sharing).