### PR TITLE
Changes GPOS_ASSERT to GPOS_RTL_ASSERTS in a Constraint test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 654)
+set(GPORCA_VERSION_MINOR 655)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.654
+LIB_VERSION = 1.655
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/server/src/unittest/gpopt/base/CConstraintTest.cpp
+++ b/server/src/unittest/gpopt/base/CConstraintTest.cpp
@@ -690,7 +690,7 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 
 	// install opt context in TLS
 	CAutoOptCtxt aoc(pmp, &mda, pceeval, CTestUtils::Pcm(pmp));
-	GPOS_ASSERT(NULL != COptCtxt::PoctxtFromTLS()->Pcomp());
+	GPOS_RTL_ASSERT(NULL != COptCtxt::PoctxtFromTLS()->Pcomp());
 
 	CAutoTraceFlag atf(EopttraceEnableArrayDerive, true);
 
@@ -725,10 +725,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstin->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstin);
 
-	GPOS_ASSERT(!pcnstin->FConvertsToNotIn());
-	GPOS_ASSERT(pcnstin->FConvertsToIn());
-	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(3 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_RTL_ASSERT(!pcnstin->FConvertsToNotIn());
+	GPOS_RTL_ASSERT(pcnstin->FConvertsToIn());
+	GPOS_RTL_ASSERT(CUtils::FScalarArrayCmp(pexpr));
+	GPOS_RTL_ASSERT(3 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstin->Release();
 
@@ -742,10 +742,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstin->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstin);
 
-	GPOS_ASSERT(!pcnstin->FConvertsToNotIn());
-	GPOS_ASSERT(pcnstin->FConvertsToIn());
-	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(4 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_RTL_ASSERT(!pcnstin->FConvertsToNotIn());
+	GPOS_RTL_ASSERT(pcnstin->FConvertsToIn());
+	GPOS_RTL_ASSERT(CUtils::FScalarArrayCmp(pexpr));
+	GPOS_RTL_ASSERT(4 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstin->Release();
 
@@ -762,10 +762,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstNotIn->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstNotIn);
 
-	GPOS_ASSERT(pcnstNotIn->FConvertsToNotIn());
-	GPOS_ASSERT(!pcnstNotIn->FConvertsToIn());
-	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(3 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_RTL_ASSERT(pcnstNotIn->FConvertsToNotIn());
+	GPOS_RTL_ASSERT(!pcnstNotIn->FConvertsToIn());
+	GPOS_RTL_ASSERT(CUtils::FScalarArrayCmp(pexpr));
+	GPOS_RTL_ASSERT(3 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstNotIn->Release();
 
@@ -782,10 +782,10 @@ CConstraintTest::EresUnittest_CConstraintIntervalPexpr()
 	pexpr = pcnstNotIn->PexprScalar(pmp); // pexpr is owned by the constraint
 	PrintConstraint(pmp, pcnstNotIn);
 
-	GPOS_ASSERT(pcnstNotIn->FConvertsToNotIn());
-	GPOS_ASSERT(!pcnstNotIn->FConvertsToIn());
-	GPOS_ASSERT(CUtils::FScalarArrayCmp(pexpr));
-	GPOS_ASSERT(4 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
+	GPOS_RTL_ASSERT(pcnstNotIn->FConvertsToNotIn());
+	GPOS_RTL_ASSERT(!pcnstNotIn->FConvertsToIn());
+	GPOS_RTL_ASSERT(CUtils::FScalarArrayCmp(pexpr));
+	GPOS_RTL_ASSERT(4 == CUtils::UlCountOperator(pexpr, COperator::EopScalarConst));
 
 	pcnstNotIn->Release();
 


### PR DESCRIPTION
Recent versions of GCC will error-out with unused variable messages in cases where variables are only used in DEBUG builds. In one problematic test, switching the asserts to build in retail should solve the issue.

@hlinnaka @d This should solve the compiler issue as a bandaid solution.

*Open question*: Shouldn't all asserts in tests compile into retail? I mean, tests are tests and not customer facing. 