### PR TITLE
[#123259241] fix array paritition tests

### DIFF
--- a/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -19,7 +19,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.36394823.1.1" Name="p" Rows="0.000000" EmptyRelation="true"/>
@@ -801,7 +801,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-	 <dxl:Plan Id="0" SpaceSize="14">
+	<dxl:Plan Id="0" SpaceSize="14">
 	  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
 	    <dxl:Properties>
 	      <dxl:Cost StartupCost="0" TotalCost="863.372722" Rows="1.000000" Width="12"/>
@@ -852,35 +852,13 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
 	          </dxl:ProjElem>
 	        </dxl:ProjList>
 	        <dxl:Filter>
-	          <dxl:And>
-	            <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-	              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Array>
-	            </dxl:ArrayComp>
-	            <dxl:Or>
-	              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	              </dxl:Comparison>
-	              <dxl:And>
-	                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:And>
-	              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Comparison>
-	            </dxl:Or>
-	          </dxl:And>
+	          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+	            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+	            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	            </dxl:Array>
+	          </dxl:ArrayComp>
 	        </dxl:Filter>
 	        <dxl:TableDescriptor Mdid="0.24719017.1.1" TableName="x">
 	          <dxl:Columns>
@@ -975,26 +953,13 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
 	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
 	            </dxl:PropagationExpression>
 	            <dxl:PrintableFilter>
-	              <dxl:Or>
-	                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	              <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+	                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
 	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:And>
-	                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                  </dxl:Comparison>
-	                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                  </dxl:Comparison>
-	                </dxl:And>
-	                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
 	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:Or>
+	                </dxl:Array>
+	              </dxl:ArrayComp>
 	            </dxl:PrintableFilter>
 	          </dxl:PartitionSelector>
 	          <dxl:DynamicTableScan PartIndexId="1">
@@ -1010,26 +975,13 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
 	              </dxl:ProjElem>
 	            </dxl:ProjList>
 	            <dxl:Filter>
-	              <dxl:Or>
-	                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	              <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+	                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
 	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                </dxl:Comparison>
-	                <dxl:And>
-	                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                  </dxl:Comparison>
-	                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                  </dxl:Comparison>
-	                </dxl:And>
-	                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
 	                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	                </dxl:Comparison>
-	              </dxl:Or>
+	                </dxl:Array>
+	              </dxl:ArrayComp>
 	            </dxl:Filter>
 	            <dxl:TableDescriptor Mdid="0.36394823.1.1" TableName="p">
 	              <dxl:Columns>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102117,102119,102121,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102117,102119,102121,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:GPDBScalarOp Mdid="0.518.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true">
@@ -801,16 +801,12 @@
           <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
         </dxl:PropagationExpression>
         <dxl:PrintableFilter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-              <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+            <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-              <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:PrintableFilter>
       </dxl:PartitionSelector>
       <dxl:DynamicTableScan PartIndexId="1">

--- a/data/dxl/minidump/Part-Selection-IN.mdp
+++ b/data/dxl/minidump/Part-Selection-IN.mdp
@@ -18,7 +18,7 @@ Select * from P where P.a IN (1,2);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.36394823.1.1" Name="p" Rows="0.000000" EmptyRelation="true"/>
@@ -565,16 +565,13 @@ Select * from P where P.a IN (1,2);
 	          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
 	        </dxl:PropagationExpression>
 	        <dxl:PrintableFilter>
-	          <dxl:Or>
-	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
 	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	            </dxl:Comparison>
-	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
 	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	            </dxl:Comparison>
-	          </dxl:Or>
+	              </dxl:Array>
+	          </dxl:ArrayComp>
 	        </dxl:PrintableFilter>
 	      </dxl:PartitionSelector>
 	      <dxl:DynamicTableScan PartIndexId="1">

--- a/data/dxl/minidump/Part-Selection-NOT-IN.mdp
+++ b/data/dxl/minidump/Part-Selection-NOT-IN.mdp
@@ -18,7 +18,7 @@ Select * from P where P.a NOT IN (1,2);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102120,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.36394823.1.1" Name="p" Rows="0.000000" EmptyRelation="true"/>
@@ -500,26 +500,13 @@ Select * from P where P.a NOT IN (1,2);
 	          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
 	        </dxl:PropagationExpression>
 	        <dxl:PrintableFilter>
-	          <dxl:Or>
-	            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	            </dxl:Comparison>
-	            <dxl:And>
-	              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	              </dxl:Comparison>
-	              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	              </dxl:Comparison>
-	            </dxl:And>
-	            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-	              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	            </dxl:Comparison>
-	          </dxl:Or>
+	          <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+	             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+	             </dxl:Array>
+	           </dxl:ArrayComp>
 	        </dxl:PrintableFilter>
 	      </dxl:PartitionSelector>
 	      <dxl:DynamicTableScan PartIndexId="1">

--- a/data/dxl/minidump/PartTbl-ArrayIn.mdp
+++ b/data/dxl/minidump/PartTbl-ArrayIn.mdp
@@ -11,7 +11,7 @@ WHERE b in (1,2);
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102024,103001"/>
+      <dxl:TraceFlags Value="102024,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
@@ -389,16 +389,13 @@ WHERE b in (1,2);
           <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
         </dxl:PropagationExpression>
         <dxl:PrintableFilter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-          </dxl:Or>
+           <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+             </dxl:Array>
+           </dxl:ArrayComp>
         </dxl:PrintableFilter>
       </dxl:PartitionSelector>
       <dxl:DynamicTableScan PartIndexId="1">

--- a/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
+++ b/data/dxl/minidump/PartTbl-ComplexPredicate1.mdp
@@ -12,7 +12,7 @@ explain select * from foo where b = 25 or b = 35;
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="102024,102025,102115,102116,102119,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="102024,102025,102115,102116,102119,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
@@ -381,16 +381,13 @@ explain select * from foo where b = 25 or b = 35;
           <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
         </dxl:PropagationExpression>
         <dxl:PrintableFilter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="25"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="35"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:PrintableFilter>
       </dxl:PartitionSelector>
       <dxl:DynamicTableScan PartIndexId="1">
@@ -409,16 +406,13 @@ explain select * from foo where b = 25 or b = 35;
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="25"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="35"/>
-            </dxl:Comparison>
-          </dxl:Or>
+            </dxl:Array>
+          </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.3406382.1.1" TableName="foo">
           <dxl:Columns>

--- a/data/dxl/minidump/PartTbl-ComplexPredicate4.mdp
+++ b/data/dxl/minidump/PartTbl-ComplexPredicate4.mdp
@@ -12,7 +12,7 @@ explain select * from foo where ((b = 25 or b=35) and a > 10) or (b<15 and a>5);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="102024,102025,102115,102116,102119,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="102024,102025,102115,102116,102119,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
@@ -439,16 +439,13 @@ explain select * from foo where ((b = 25 or b=35) and a > 10) or (b<15 and a>5);
         <dxl:Filter>
           <dxl:Or>
             <dxl:And>
-              <dxl:Or>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="25"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="35"/>
-                </dxl:Comparison>
-              </dxl:Or>
+                </dxl:Array>
+              </dxl:ArrayComp>
               <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>

--- a/data/dxl/minidump/PartTbl-Disjunction.mdp
+++ b/data/dxl/minidump/PartTbl-Disjunction.mdp
@@ -11,7 +11,7 @@ WHERE b = 1 or b = 2;
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102024,103001"/>
+      <dxl:TraceFlags Value="102024,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
@@ -392,16 +392,13 @@ WHERE b = 1 or b = 2;
           <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
         </dxl:PropagationExpression>
         <dxl:PrintableFilter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-          </dxl:Or>
+           <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+             </dxl:Array>
+           </dxl:ArrayComp>
         </dxl:PrintableFilter>
       </dxl:PartitionSelector>
       <dxl:DynamicTableScan PartIndexId="1">
@@ -423,16 +420,13 @@ WHERE b = 1 or b = 2;
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-          </dxl:Or>
+           <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+             </dxl:Array>
+           </dxl:ArrayComp>
         </dxl:Filter>
         <dxl:TableDescriptor Mdid="0.671910.1.1" TableName="p">
           <dxl:Columns>

--- a/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -5,7 +5,7 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102,101013,103001"/>
+      <dxl:TraceFlags Value="102,101013,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -552,16 +552,12 @@
           <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
         </dxl:PropagationExpression>
         <dxl:PrintableFilter>
-          <dxl:Or>
-            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-            </dxl:Comparison>
-          </dxl:Or>
+           <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+             <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+               <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+             </dxl:Array>
+           </dxl:ArrayComp>
         </dxl:PrintableFilter>
       </dxl:PartitionSelector>
       <dxl:DynamicTableScan PartIndexId="1">

--- a/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -24,7 +24,7 @@ select  i_item_id
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="96"/>
-      <dxl:TraceFlags Value="101013,102120,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
@@ -20504,9 +20504,9 @@ select  i_item_id
                 <dxl:Ident ColId="14" ColName="i_manufact_id" TypeMdid="0.23.1.0"/>
                 <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="677"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="694"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="808"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940"/>
                 </dxl:Array>
               </dxl:ArrayComp>
               <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
@@ -21122,9 +21122,9 @@ select  i_item_id
                                   <dxl:Ident ColId="13" ColName="i_manufact_id" TypeMdid="0.23.1.0"/>
                                   <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                                     <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="677"/>
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940"/>
                                     <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="694"/>
                                     <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="808"/>
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940"/>
                                   </dxl:Array>
                                 </dxl:ArrayComp>
                               </dxl:And>


### PR DESCRIPTION
This adds the traceflag for `ArrayConstraints` and fixes the resulting plans. Changes to plans are mainly in `PrintableFilter` element (OR->Array), but also in some `Filter` elements (OR->Array).

Also the constant's ordering in `ScalarArray` element (now sorted).