### PR TITLE
Revert "Don't genereate plan using ScalarArrayCmp qual for B-Tree index" [#128092771]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 658)
+set(GPORCA_VERSION_MINOR 659)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.658
+LIB_VERSION = 1.659
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/BTreeIndex-Against-InList.mdp
+++ b/data/dxl/minidump/BTreeIndex-Against-InList.mdp
@@ -297,50 +297,52 @@ SELECT * FROM test WHERE a in (1, 47);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="448.213950" Rows="2.000000" Width="4"/>
-        </dxl:Properties>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:TableScan>
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="448.213920" Rows="2.000000" Width="4"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter>
-            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47"/>
-              </dxl:Array>
-            </dxl:ArrayComp>
-          </dxl:Filter>
-          <dxl:TableDescriptor Mdid="0.41665.1.1" TableName="test">
-            <dxl:Columns>
-              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-              <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-              <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-              <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-              <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-              <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-            </dxl:Columns>
-          </dxl:TableDescriptor>
-        </dxl:TableScan>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+    <dxl:Plan Id="0" SpaceSize="2">
+	  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+	    <dxl:Properties>
+	      <dxl:Cost StartupCost="0" TotalCost="4.000228" Rows="2.000000" Width="4"/>
+	    </dxl:Properties>
+	    <dxl:ProjList>
+	      <dxl:ProjElem ColId="0" Alias="a">
+	        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	      </dxl:ProjElem>
+	    </dxl:ProjList>
+	    <dxl:Filter/>
+	    <dxl:SortingColumnList/>
+	    <dxl:IndexScan IndexScanDirection="Forward">
+	      <dxl:Properties>
+	        <dxl:Cost StartupCost="0" TotalCost="4.000193" Rows="2.000000" Width="4"/>
+	      </dxl:Properties>
+	      <dxl:ProjList>
+	        <dxl:ProjElem ColId="0" Alias="a">
+	          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	        </dxl:ProjElem>
+	      </dxl:ProjList>
+	      <dxl:Filter/>
+	      <dxl:IndexCondList>
+	        <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+	          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+	          <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+	            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47"/>
+	          </dxl:Array>
+	        </dxl:ArrayComp>
+	      </dxl:IndexCondList>
+	      <dxl:IndexDescriptor Mdid="0.41692.1.0" IndexName="test_index"/>
+	      <dxl:TableDescriptor Mdid="0.41665.1.1" TableName="test">
+	        <dxl:Columns>
+	          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+	          <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+	          <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+	          <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+	          <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+	          <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+	          <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+	          <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+	        </dxl:Columns>
+	      </dxl:TableDescriptor>
+	    </dxl:IndexScan>
+	  </dxl:GatherMotion>
+	</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/libgpopt/src/operators/CPredicateUtils.cpp
@@ -3108,8 +3108,7 @@ CPredicateUtils::FCompatibleIndexPredicate
 		CScalarCmp *popScCmp = CScalarCmp::PopConvert(pexprPred->Pop());
 		pmdobjScCmp = pmda->Pmdscop(popScCmp->PmdidOp());
 	}
-	else if (COperator::EopScalarArrayCmp == pexprPred->Pop()->Eopid() &&
-			IMDIndex::EmdindBitmap == pmdindex->Emdindt())
+	else if (COperator::EopScalarArrayCmp == pexprPred->Pop()->Eopid())
 	{
 		CScalarArrayCmp *popScArrCmp = CScalarArrayCmp::PopConvert(pexprPred->Pop());
 		pmdobjScCmp = pmda->Pmdscop(popScArrCmp->PmdidOp());


### PR DESCRIPTION
This reverts commit ec95176 . ORCA will proceed to generate a plan
without assuming the capability (or in this case, in inability) of the
index scan to handle qual of type ScalarArrayOpExpr . A change in
translator will guard against such a plan if the database is unable to
execute an Index Scan with a `ScalarArrayOpExpr` qual.