### PR TITLE
[#128239337] Fix constraint bug in preprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 661)
+set(GPORCA_VERSION_MINOR 662)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.661
+LIB_VERSION = 1.662
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/data/dxl/minidump/UnnestSQJoins.mdp
@@ -2,7 +2,7 @@
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>
-    <dxl:TraceFlags Value="101000,101001,103001"/>
+    <dxl:TraceFlags Value="101000,101001,103001,103026"/>
     <dxl:Metadata SystemIds="0.GPDB">
      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true"> 
        <dxl:EqualityOp Mdid="0.410.1.0"/>                                                                                                                     


### PR DESCRIPTION
We ran into cases where the preprocessor step 'PexprConvert2In' would
try to create a constraint but fail and get a null value returned to it,
which would cause ORCA to crash. This was because the constraints
framework can only create constraints on certain types. By adding an
additional check for constrainable types we guarantee that a constraint
will be returned.

Also added an ASSERT to check for this condition.