### PR TITLE
[#128188689] Adds ArrayConstraints flag and fixes to several tests

### DIFF
--- a/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
+++ b/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
@@ -18,7 +18,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101001,102024,102025,102121,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101001,102024,102025,102121,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -967,10 +967,6 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
 	      </dxl:ProjList>
 	      <dxl:Filter>
 	        <dxl:Or>
-	          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	            <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
-	            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-	          </dxl:Comparison>
 	          <dxl:And>
 	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
 	              <dxl:Ident ColId="1" ColName="c2" TypeMdid="0.25.1.0"/>
@@ -981,30 +977,25 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
 	              <dxl:ConstValue TypeMdid="0.701.1.0" IsNull="false" IsByValue="true" Value="AAAAAAAAWUA=" DoubleValue="100.000000"/>
 	            </dxl:Comparison>
 	          </dxl:And>
-	        </dxl:Or>
-	      </dxl:Filter>
-	      <dxl:RecheckCond>
-	        <dxl:Or>
 	          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
 	            <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
 	            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
 	          </dxl:Comparison>
+	        </dxl:Or>
+	      </dxl:Filter>
+	      <dxl:RecheckCond>
+	        <dxl:Or>
 	          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
 	            <dxl:Ident ColId="1" ColName="c2" TypeMdid="0.25.1.0"/>
 	            <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
 	          </dxl:Comparison>
+	          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+	            <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+	            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+	          </dxl:Comparison>
 	        </dxl:Or>
 	      </dxl:RecheckCond>
 	      <dxl:BitmapOr TypeMdid="0.2283.1.0">
-	        <dxl:BitmapIndexProbe>
-	          <dxl:IndexCondList>
-	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	              <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
-	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-	            </dxl:Comparison>
-	          </dxl:IndexCondList>
-	          <dxl:IndexDescriptor Mdid="0.1632594.1.0" IndexName="t_c1"/>
-	        </dxl:BitmapIndexProbe>
 	        <dxl:BitmapIndexProbe>
 	          <dxl:IndexCondList>
 	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
@@ -1013,6 +1004,15 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
 	            </dxl:Comparison>
 	          </dxl:IndexCondList>
 	          <dxl:IndexDescriptor Mdid="0.1632615.1.0" IndexName="t_c2"/>
+	        </dxl:BitmapIndexProbe>
+	        <dxl:BitmapIndexProbe>
+	          <dxl:IndexCondList>
+	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+	              <dxl:Ident ColId="0" ColName="c1" TypeMdid="0.23.1.0"/>
+	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+	            </dxl:Comparison>
+	          </dxl:IndexCondList>
+	          <dxl:IndexDescriptor Mdid="0.1632594.1.0" IndexName="t_c1"/>
 	        </dxl:BitmapIndexProbe>
 	      </dxl:BitmapOr>
 	      <dxl:TableDescriptor Mdid="0.1632545.1.1" TableName="t">

--- a/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
 <!--
-TPCDS SQL: 
-select item.i_item_id, item.i_item_desc, item.i_current_price 
-from item, store_sales 
-where ss_item_sk=i_item_sk and  i_current_price &gt= 62::numeric AND i_current_price &lt= 92::numeric AND (i_manufact_id = ANY (ARRAY[129, 270, 821, 423]))  
+TPCDS SQL:
+select item.i_item_id, item.i_item_desc, item.i_current_price
+from item, store_sales
+where ss_item_sk=i_item_sk and  i_current_price &gt= 62::numeric AND i_current_price &lt= 92::numeric AND (i_manufact_id = ANY (ARRAY[129, 270, 821, 423]))
 group  by item.i_item_id, item.i_item_desc, item.i_current_price;
 -->
   <dxl:Thread Id="0">
@@ -12,7 +12,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102024,102025,102115,102116,102117,102119,102121,103001"/>
+      <dxl:TraceFlags Value="102024,102025,102115,102116,102117,102119,102121,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.25472.1.1" Name="store_sales" Rows="737331968.000000" EmptyRelation="false"/>
@@ -11096,8 +11096,8 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
                       <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                         <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="129"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="270"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="821"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="423"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="821"/>
                       </dxl:Array>
                     </dxl:ArrayComp>
                   </dxl:And>

--- a/data/dxl/minidump/DirectDispatch-MultiCol-Disjunction.mdp
+++ b/data/dxl/minidump/DirectDispatch-MultiCol-Disjunction.mdp
@@ -10,7 +10,7 @@ explain select * from r where (a=1 or a=3) and b=3;
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102119,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102119,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -256,16 +256,13 @@ explain select * from r where (a=1 or a=3) and b=3;
           </dxl:ProjList>
           <dxl:Filter>
             <dxl:And>
-              <dxl:Or>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-                </dxl:Comparison>
-              </dxl:Or>
+                </dxl:Array>
+              </dxl:ArrayComp>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>

--- a/data/dxl/minidump/DirectDispatch-SingleCol-Disjunction-IsNull.mdp
+++ b/data/dxl/minidump/DirectDispatch-SingleCol-Disjunction-IsNull.mdp
@@ -10,7 +10,7 @@ explain select * from r where a=1 or a is null;
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102119,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102119,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:ColumnStatistics Mdid="1.1813600.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
@@ -223,13 +223,13 @@ explain select * from r where a=1 or a is null;
           </dxl:ProjList>
           <dxl:Filter>
             <dxl:Or>
+              <dxl:IsNull>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:IsNull>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
               </dxl:Comparison>
-              <dxl:IsNull>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:IsNull>
             </dxl:Or>
           </dxl:Filter>
           <dxl:TableDescriptor Mdid="0.1813600.1.1" TableName="r">
@@ -247,14 +247,14 @@ explain select * from r where a=1 or a is null;
           </dxl:TableDescriptor>
         </dxl:TableScan>
       </dxl:GatherMotion>
-  <dxl:DirectDispatchInfo>
-    <dxl:KeyValue>
-      <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-    </dxl:KeyValue>
-    <dxl:KeyValue>
-      <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
-    </dxl:KeyValue>
-  </dxl:DirectDispatchInfo>
+      <dxl:DirectDispatchInfo>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+        </dxl:KeyValue>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/data/dxl/minidump/DirectDispatch-SingleCol-Disjunction.mdp
+++ b/data/dxl/minidump/DirectDispatch-SingleCol-Disjunction.mdp
@@ -10,7 +10,7 @@ explain select * from r where a=1 or a=3;
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102119,102128,103001,103014,103015"/>
+      <dxl:TraceFlags Value="101013,102024,102025,102115,102116,102119,102128,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:ColumnStatistics Mdid="1.1813600.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
@@ -223,16 +223,13 @@ explain select * from r where a=1 or a=3;
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter>
-            <dxl:Or>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:Or>
+              </dxl:Array>
+            </dxl:ArrayComp>
           </dxl:Filter>
           <dxl:TableDescriptor Mdid="0.1813600.1.1" TableName="r">
             <dxl:Columns>

--- a/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-select item.i_item_id, item.i_item_desc, item.i_current_price 
-from item, store_sales 
-where ss_item_sk=i_item_sk and  i_current_price &gt;= 62::numeric AND i_current_price &lt;= 92::numeric AND (i_manufact_id = ANY (ARRAY[129, 270, 821, 423]))  
+select item.i_item_id, item.i_item_desc, item.i_current_price
+from item, store_sales
+where ss_item_sk=i_item_sk and  i_current_price &gt;= 62::numeric AND i_current_price &lt;= 92::numeric AND (i_manufact_id = ANY (ARRAY[129, 270, 821, 423]))
 group  by item.i_item_id, item.i_item_desc, item.i_current_price;
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
@@ -12,7 +12,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2"/>
-      <dxl:TraceFlags Value="102024,102025,102115,102116,102117,102119,102121,102127,103001,103014,103015"/>
+      <dxl:TraceFlags Value="102024,102025,102115,102116,102117,102119,102121,102127,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:ColumnStatistics Mdid="1.672855.1.1.27" Name="tableoid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
@@ -11188,8 +11188,8 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
                       <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
                         <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="129"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="270"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="821"/>
                         <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="423"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="821"/>
                       </dxl:Array>
                     </dxl:ArrayComp>
                   </dxl:And>

--- a/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
+++ b/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
@@ -5,7 +5,7 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102016,103001"/>
+      <dxl:TraceFlags Value="102016,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
@@ -551,10 +551,12 @@
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter>
-                              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                              <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
                                 <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-                              </dxl:Comparison>
+                                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                                </dxl:Array>
+                              </dxl:ArrayComp>
                             </dxl:Filter>
                             <dxl:TableDescriptor Mdid="0.415883.1.1" TableName="b">
                               <dxl:Columns>

--- a/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -5,7 +5,7 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102007,103001"/>
+      <dxl:TraceFlags Value="102007,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
@@ -46,10 +46,10 @@
         <dxl:Commutator Mdid="0.96.1.0"/>
         <dxl:InverseOp Mdid="0.518.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true"> 
-       <dxl:ResultType Mdid="0.20.1.0"/>                                                  
-       <dxl:IntermediateResultType Mdid="0.20.1.0"/>                                      
-      </dxl:GPDBAgg>                                                                        
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+       <dxl:ResultType Mdid="0.20.1.0"/>
+       <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
@@ -532,10 +532,12 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+              <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
                 <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-              </dxl:Comparison>
+                <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                </dxl:Array>
+              </dxl:ArrayComp>
             </dxl:Filter>
             <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
               <dxl:Columns>

--- a/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -5,7 +5,7 @@
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
-      <dxl:TraceFlags Value="102007,103001"/>
+      <dxl:TraceFlags Value="102007,103001,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
@@ -427,7 +427,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="281662">
+<dxl:Plan Id="0" SpaceSize="281382">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="16.184570" Rows="1.000000" Width="8"/>
@@ -607,10 +607,12 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                    <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
                       <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-                    </dxl:Comparison>
+                      <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                      </dxl:Array>
+                    </dxl:ArrayComp>
                   </dxl:Filter>
                   <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
                     <dxl:Columns>


### PR DESCRIPTION
As part of our effort to find bugs in the Array constraints feature, we turned on Array Constraints by default and ran the ctest suite. The tests which failed, we examined the changed DXL and reasons for failure and determined that the changes to the plans were logically equivalent to the original plan, simply modified to use arrays in some cases. Turning the ArrayConstraints flag on for these tests will also exercise the ArrayConstraints change, which is desirable.

We intentionally did not enable the flag for CArrayExpansionTest. It requires the flag to be off to test its intended code path.