### PR TITLE
Do not COALESCE the result of COUNT with GROUP BY in a scalar subquery

### DIFF
--- a/data/dxl/minidump/AddPredsInSubqueries.mdp
+++ b/data/dxl/minidump/AddPredsInSubqueries.mdp
@@ -333,7 +333,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-   <dxl:Plan Id="0" SpaceSize="426">
+   <dxl:Plan Id="0" SpaceSize="414">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="5.273438" Rows="1.000000" Width="16"/>

--- a/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -147,7 +147,7 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1386">
+    <dxl:Plan Id="0" SpaceSize="1254">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="18.062500" Rows="1.000000" Width="1"/>

--- a/data/dxl/minidump/CollapseNot.mdp
+++ b/data/dxl/minidump/CollapseNot.mdp
@@ -286,358 +286,358 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
       </dxl:LogicalProject>
     </dxl:Query>
    <dxl:Plan Id="0" SpaceSize="24">
-	  <dxl:Result>
-	    <dxl:Properties>
-	      <dxl:Cost StartupCost="0" TotalCost="1293.001123" Rows="1.000000" Width="4"/>
-	    </dxl:Properties>
-	    <dxl:ProjList>
-	      <dxl:ProjElem ColId="16" Alias="?column?">
-	        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	      </dxl:ProjElem>
-	    </dxl:ProjList>
-	    <dxl:Filter/>
-	    <dxl:OneTimeFilter/>
-	    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-	      <dxl:Properties>
-	        <dxl:Cost StartupCost="0" TotalCost="1293.001119" Rows="1.000000" Width="1"/>
-	      </dxl:Properties>
-	      <dxl:ProjList/>
-	      <dxl:Filter/>
-	      <dxl:SortingColumnList/>
-	      <dxl:Result>
-	        <dxl:Properties>
-	          <dxl:Cost StartupCost="0" TotalCost="1293.001115" Rows="1.000000" Width="1"/>
-	        </dxl:Properties>
-	        <dxl:ProjList/>
-	        <dxl:Filter>
-	          <dxl:Not>
-	            <dxl:If TypeMdid="0.16.1.0">
-	              <dxl:Not>
-	                <dxl:IsNull>
-	                  <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                </dxl:IsNull>
-	              </dxl:Not>
-	              <dxl:If TypeMdid="0.16.1.0">
-	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-	                  <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-	                  <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.20.1.0"/>
-	                </dxl:Comparison>
-	                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
-	                <dxl:If TypeMdid="0.16.1.0">
-	                  <dxl:Not>
-	                    <dxl:IsNull>
-	                      <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
-	                    </dxl:IsNull>
-	                  </dxl:Not>
-	                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="false"/>
-	                </dxl:If>
-	              </dxl:If>
-	              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
-	            </dxl:If>
-	          </dxl:Not>
-	        </dxl:Filter>
-	        <dxl:OneTimeFilter/>
-	        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-	          <dxl:Properties>
-	            <dxl:Cost StartupCost="0" TotalCost="1293.001082" Rows="1.000000" Width="24"/>
-	          </dxl:Properties>
-	          <dxl:GroupingColumns>
-	            <dxl:GroupingColumn ColId="0"/>
-	            <dxl:GroupingColumn ColId="1"/>
-	            <dxl:GroupingColumn ColId="7"/>
-	          </dxl:GroupingColumns>
-	          <dxl:ProjList>
-	            <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-	              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
-	                <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-	              </dxl:AggFunc>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-	              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final">
-	                <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
-	              </dxl:AggFunc>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="0" Alias="cidr">
-	              <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="1" Alias="ctid">
-	              <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	              <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	            </dxl:ProjElem>
-	          </dxl:ProjList>
-	          <dxl:Filter/>
-	          <dxl:Sort SortDiscardDuplicates="false">
-	            <dxl:Properties>
-	              <dxl:Cost StartupCost="0" TotalCost="1293.001044" Rows="1.000000" Width="34"/>
-	            </dxl:Properties>
-	            <dxl:ProjList>
-	              <dxl:ProjElem ColId="0" Alias="cidr">
-	                <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	              </dxl:ProjElem>
-	              <dxl:ProjElem ColId="1" Alias="ctid">
-	                <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	              </dxl:ProjElem>
-	              <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	              </dxl:ProjElem>
-	              <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-	                <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-	              </dxl:ProjElem>
-	              <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-	                <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
-	              </dxl:ProjElem>
-	            </dxl:ProjList>
-	            <dxl:Filter/>
-	            <dxl:SortingColumnList>
-	              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-	              <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-	            </dxl:SortingColumnList>
-	            <dxl:LimitCount/>
-	            <dxl:LimitOffset/>
-	            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-	              <dxl:Properties>
-	                <dxl:Cost StartupCost="0" TotalCost="1293.001044" Rows="1.000000" Width="34"/>
-	              </dxl:Properties>
-	              <dxl:ProjList>
-	                <dxl:ProjElem ColId="0" Alias="cidr">
-	                  <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                </dxl:ProjElem>
-	                <dxl:ProjElem ColId="1" Alias="ctid">
-	                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                </dxl:ProjElem>
-	                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                </dxl:ProjElem>
-	                <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-	                  <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-	                </dxl:ProjElem>
-	                <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-	                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
-	                </dxl:ProjElem>
-	              </dxl:ProjList>
-	              <dxl:Filter/>
-	              <dxl:SortingColumnList/>
-	              <dxl:HashExprList>
-	                <dxl:HashExpr TypeMdid="0.23.1.0">
-	                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                </dxl:HashExpr>
-	              </dxl:HashExprList>
-	              <dxl:Result>
-	                <dxl:Properties>
-	                  <dxl:Cost StartupCost="0" TotalCost="1293.000937" Rows="1.000000" Width="34"/>
-	                </dxl:Properties>
-	                <dxl:ProjList>
-	                  <dxl:ProjElem ColId="0" Alias="cidr">
-	                    <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                  </dxl:ProjElem>
-	                  <dxl:ProjElem ColId="1" Alias="ctid">
-	                    <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                  </dxl:ProjElem>
-	                  <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                    <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                  </dxl:ProjElem>
-	                  <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-	                    <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
-	                  </dxl:ProjElem>
-	                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-	                    <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
-	                  </dxl:ProjElem>
-	                </dxl:ProjList>
-	                <dxl:Filter/>
-	                <dxl:OneTimeFilter/>
-	                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-	                  <dxl:Properties>
-	                    <dxl:Cost StartupCost="0" TotalCost="1293.000937" Rows="1.000000" Width="34"/>
-	                  </dxl:Properties>
-	                  <dxl:GroupingColumns>
-	                    <dxl:GroupingColumn ColId="0"/>
-	                    <dxl:GroupingColumn ColId="1"/>
-	                    <dxl:GroupingColumn ColId="7"/>
-	                  </dxl:GroupingColumns>
-	                  <dxl:ProjList>
-	                    <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-	                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
-	                    </dxl:ProjElem>
-	                    <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-	                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial">
-	                        <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
-	                      </dxl:AggFunc>
-	                    </dxl:ProjElem>
-	                    <dxl:ProjElem ColId="0" Alias="cidr">
-	                      <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                    </dxl:ProjElem>
-	                    <dxl:ProjElem ColId="1" Alias="ctid">
-	                      <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                    </dxl:ProjElem>
-	                    <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                      <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                    </dxl:ProjElem>
-	                  </dxl:ProjList>
-	                  <dxl:Filter/>
-	                  <dxl:Sort SortDiscardDuplicates="false">
-	                    <dxl:Properties>
-	                      <dxl:Cost StartupCost="0" TotalCost="1293.000896" Rows="1.000000" Width="22"/>
-	                    </dxl:Properties>
-	                    <dxl:ProjList>
-	                      <dxl:ProjElem ColId="0" Alias="cidr">
-	                        <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                      </dxl:ProjElem>
-	                      <dxl:ProjElem ColId="1" Alias="ctid">
-	                        <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                      </dxl:ProjElem>
-	                      <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                        <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                      </dxl:ProjElem>
-	                      <dxl:ProjElem ColId="17" Alias="ColRef_0017">
-	                        <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
-	                      </dxl:ProjElem>
-	                    </dxl:ProjList>
-	                    <dxl:Filter/>
-	                    <dxl:SortingColumnList>
-	                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-	                      <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-	                    </dxl:SortingColumnList>
-	                    <dxl:LimitCount/>
-	                    <dxl:LimitOffset/>
-	                    <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
-	                      <dxl:Properties>
-	                        <dxl:Cost StartupCost="0" TotalCost="1293.000896" Rows="1.000000" Width="22"/>
-	                      </dxl:Properties>
-	                      <dxl:ProjList>
-	                        <dxl:ProjElem ColId="0" Alias="cidr">
-	                          <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                        </dxl:ProjElem>
-	                        <dxl:ProjElem ColId="1" Alias="ctid">
-	                          <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                        </dxl:ProjElem>
-	                        <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                          <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                        </dxl:ProjElem>
-	                        <dxl:ProjElem ColId="17" Alias="ColRef_0017">
-	                          <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
-	                        </dxl:ProjElem>
-	                      </dxl:ProjList>
-	                      <dxl:Filter/>
-	                      <dxl:JoinFilter>
-	                        <dxl:Or>
-	                          <dxl:Comparison ComparisonOperator="&lt;&lt;=" OperatorMdid="0.932.1.0">
-	                            <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                            <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                          </dxl:Comparison>
-	                          <dxl:IsNull>
-	                            <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                          </dxl:IsNull>
-	                        </dxl:Or>
-	                      </dxl:JoinFilter>
-	                      <dxl:TableScan>
-	                        <dxl:Properties>
-	                          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
-	                        </dxl:Properties>
-	                        <dxl:ProjList>
-	                          <dxl:ProjElem ColId="0" Alias="cidr">
-	                            <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                          </dxl:ProjElem>
-	                          <dxl:ProjElem ColId="1" Alias="ctid">
-	                            <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                          </dxl:ProjElem>
-	                          <dxl:ProjElem ColId="7" Alias="gp_segment_id">
-	                            <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                          </dxl:ProjElem>
-	                        </dxl:ProjList>
-	                        <dxl:Filter/>
-	                        <dxl:TableDescriptor Mdid="0.660032.1.1" TableName="inverse">
-	                          <dxl:Columns>
-	                            <dxl:Column ColId="0" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                            <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                            <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-	                            <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-	                            <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-	                            <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-	                            <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-	                            <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                          </dxl:Columns>
-	                        </dxl:TableDescriptor>
-	                      </dxl:TableScan>
-	                      <dxl:Result>
-	                        <dxl:Properties>
-	                          <dxl:Cost StartupCost="0" TotalCost="431.000485" Rows="3.000000" Width="12"/>
-	                        </dxl:Properties>
-	                        <dxl:ProjList>
-	                          <dxl:ProjElem ColId="17" Alias="ColRef_0017">
-	                            <dxl:If TypeMdid="0.23.1.0">
-	                              <dxl:IsNull>
-	                                <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                              </dxl:IsNull>
-	                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
-	                            </dxl:If>
-	                          </dxl:ProjElem>
-	                          <dxl:ProjElem ColId="8" Alias="cidr">
-	                            <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                          </dxl:ProjElem>
-	                        </dxl:ProjList>
-	                        <dxl:Filter/>
-	                        <dxl:OneTimeFilter/>
-	                        <dxl:Materialize Eager="true">
-	                          <dxl:Properties>
-	                            <dxl:Cost StartupCost="0" TotalCost="431.000473" Rows="3.000000" Width="8"/>
-	                          </dxl:Properties>
-	                          <dxl:ProjList>
-	                            <dxl:ProjElem ColId="8" Alias="cidr">
-	                              <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                            </dxl:ProjElem>
-	                          </dxl:ProjList>
-	                          <dxl:Filter/>
-	                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-	                            <dxl:Properties>
-	                              <dxl:Cost StartupCost="0" TotalCost="431.000465" Rows="3.000000" Width="8"/>
-	                            </dxl:Properties>
-	                            <dxl:ProjList>
-	                              <dxl:ProjElem ColId="8" Alias="cidr">
-	                                <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                              </dxl:ProjElem>
-	                            </dxl:ProjList>
-	                            <dxl:Filter/>
-	                            <dxl:SortingColumnList/>
-	                            <dxl:TableScan>
-	                              <dxl:Properties>
-	                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
-	                              </dxl:Properties>
-	                              <dxl:ProjList>
-	                                <dxl:ProjElem ColId="8" Alias="cidr">
-	                                  <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                                </dxl:ProjElem>
-	                              </dxl:ProjList>
-	                              <dxl:Filter/>
-	                              <dxl:TableDescriptor Mdid="0.660032.1.1" TableName="inverse">
-	                                <dxl:Columns>
-	                                  <dxl:Column ColId="8" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
-	                                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                                  <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-	                                  <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-	                                  <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-	                                  <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-	                                  <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-	                                  <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                                </dxl:Columns>
-	                              </dxl:TableDescriptor>
-	                            </dxl:TableScan>
-	                          </dxl:BroadcastMotion>
-	                        </dxl:Materialize>
-	                      </dxl:Result>
-	                    </dxl:NestedLoopJoin>
-	                  </dxl:Sort>
-	                </dxl:Aggregate>
-	              </dxl:Result>
-	            </dxl:RedistributeMotion>
-	          </dxl:Sort>
-	        </dxl:Aggregate>
-	      </dxl:Result>
-	    </dxl:GatherMotion>
-	  </dxl:Result>
-	</dxl:Plan>
+     <dxl:Result>
+       <dxl:Properties>
+         <dxl:Cost StartupCost="0" TotalCost="1293.001123" Rows="1.000000" Width="4"/>
+       </dxl:Properties>
+       <dxl:ProjList>
+         <dxl:ProjElem ColId="16" Alias="?column?">
+           <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+         </dxl:ProjElem>
+       </dxl:ProjList>
+       <dxl:Filter/>
+       <dxl:OneTimeFilter/>
+       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+         <dxl:Properties>
+           <dxl:Cost StartupCost="0" TotalCost="1293.001119" Rows="1.000000" Width="1"/>
+         </dxl:Properties>
+         <dxl:ProjList/>
+         <dxl:Filter/>
+         <dxl:SortingColumnList/>
+         <dxl:Result>
+           <dxl:Properties>
+             <dxl:Cost StartupCost="0" TotalCost="1293.001115" Rows="1.000000" Width="1"/>
+           </dxl:Properties>
+           <dxl:ProjList/>
+           <dxl:Filter>
+             <dxl:Not>
+               <dxl:If TypeMdid="0.16.1.0">
+                 <dxl:Not>
+                   <dxl:IsNull>
+                     <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                   </dxl:IsNull>
+                 </dxl:Not>
+                 <dxl:If TypeMdid="0.16.1.0">
+                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                     <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
+                     <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.20.1.0"/>
+                   </dxl:Comparison>
+                   <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                   <dxl:If TypeMdid="0.16.1.0">
+                     <dxl:Not>
+                       <dxl:IsNull>
+                         <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.20.1.0"/>
+                       </dxl:IsNull>
+                     </dxl:Not>
+                     <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                     <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="false"/>
+                   </dxl:If>
+                 </dxl:If>
+                 <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+               </dxl:If>
+             </dxl:Not>
+           </dxl:Filter>
+           <dxl:OneTimeFilter/>
+           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+             <dxl:Properties>
+               <dxl:Cost StartupCost="0" TotalCost="1293.001082" Rows="1.000000" Width="24"/>
+             </dxl:Properties>
+             <dxl:GroupingColumns>
+               <dxl:GroupingColumn ColId="0"/>
+               <dxl:GroupingColumn ColId="1"/>
+               <dxl:GroupingColumn ColId="7"/>
+             </dxl:GroupingColumns>
+             <dxl:ProjList>
+               <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+                 <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                   <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
+                 </dxl:AggFunc>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final">
+                   <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                 </dxl:AggFunc>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="0" Alias="cidr">
+                 <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="1" Alias="ctid">
+                 <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+               </dxl:ProjElem>
+               <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                 <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+               </dxl:ProjElem>
+             </dxl:ProjList>
+             <dxl:Filter/>
+             <dxl:Sort SortDiscardDuplicates="false">
+               <dxl:Properties>
+                 <dxl:Cost StartupCost="0" TotalCost="1293.001044" Rows="1.000000" Width="34"/>
+               </dxl:Properties>
+               <dxl:ProjList>
+                 <dxl:ProjElem ColId="0" Alias="cidr">
+                   <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="1" Alias="ctid">
+                   <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                   <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                   <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
+                 </dxl:ProjElem>
+                 <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                   <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                 </dxl:ProjElem>
+               </dxl:ProjList>
+               <dxl:Filter/>
+               <dxl:SortingColumnList>
+                 <dxl:SortingColumn ColId="1" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                 <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+               </dxl:SortingColumnList>
+               <dxl:LimitCount/>
+               <dxl:LimitOffset/>
+               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                 <dxl:Properties>
+                   <dxl:Cost StartupCost="0" TotalCost="1293.001044" Rows="1.000000" Width="34"/>
+                 </dxl:Properties>
+                 <dxl:ProjList>
+                   <dxl:ProjElem ColId="0" Alias="cidr">
+                     <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                   </dxl:ProjElem>
+                   <dxl:ProjElem ColId="1" Alias="ctid">
+                     <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                   </dxl:ProjElem>
+                   <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                     <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                   </dxl:ProjElem>
+                   <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                     <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
+                   </dxl:ProjElem>
+                   <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                     <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                   </dxl:ProjElem>
+                 </dxl:ProjList>
+                 <dxl:Filter/>
+                 <dxl:SortingColumnList/>
+                 <dxl:HashExprList>
+                   <dxl:HashExpr TypeMdid="0.23.1.0">
+                     <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                   </dxl:HashExpr>
+                 </dxl:HashExprList>
+                 <dxl:Result>
+                   <dxl:Properties>
+                     <dxl:Cost StartupCost="0" TotalCost="1293.000937" Rows="1.000000" Width="34"/>
+                   </dxl:Properties>
+                   <dxl:ProjList>
+                     <dxl:ProjElem ColId="0" Alias="cidr">
+                       <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                     </dxl:ProjElem>
+                     <dxl:ProjElem ColId="1" Alias="ctid">
+                       <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                     </dxl:ProjElem>
+                     <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                       <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                     </dxl:ProjElem>
+                     <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                       <dxl:Ident ColId="27" ColName="ColRef_0027" TypeMdid="0.20.1.0"/>
+                     </dxl:ProjElem>
+                     <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                       <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
+                     </dxl:ProjElem>
+                   </dxl:ProjList>
+                   <dxl:Filter/>
+                   <dxl:OneTimeFilter/>
+                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                     <dxl:Properties>
+                       <dxl:Cost StartupCost="0" TotalCost="1293.000937" Rows="1.000000" Width="34"/>
+                     </dxl:Properties>
+                     <dxl:GroupingColumns>
+                       <dxl:GroupingColumn ColId="0"/>
+                       <dxl:GroupingColumn ColId="1"/>
+                       <dxl:GroupingColumn ColId="7"/>
+                     </dxl:GroupingColumns>
+                     <dxl:ProjList>
+                       <dxl:ProjElem ColId="27" Alias="ColRef_0027">
+                         <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
+                       </dxl:ProjElem>
+                       <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                         <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial">
+                           <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
+                         </dxl:AggFunc>
+                       </dxl:ProjElem>
+                       <dxl:ProjElem ColId="0" Alias="cidr">
+                         <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                       </dxl:ProjElem>
+                       <dxl:ProjElem ColId="1" Alias="ctid">
+                         <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                       </dxl:ProjElem>
+                       <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                         <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                       </dxl:ProjElem>
+                     </dxl:ProjList>
+                     <dxl:Filter/>
+                     <dxl:Sort SortDiscardDuplicates="false">
+                       <dxl:Properties>
+                         <dxl:Cost StartupCost="0" TotalCost="1293.000896" Rows="1.000000" Width="22"/>
+                       </dxl:Properties>
+                       <dxl:ProjList>
+                         <dxl:ProjElem ColId="0" Alias="cidr">
+                           <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                         </dxl:ProjElem>
+                         <dxl:ProjElem ColId="1" Alias="ctid">
+                           <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                         </dxl:ProjElem>
+                         <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                           <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                         </dxl:ProjElem>
+                         <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+                           <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
+                         </dxl:ProjElem>
+                       </dxl:ProjList>
+                       <dxl:Filter/>
+                       <dxl:SortingColumnList>
+                         <dxl:SortingColumn ColId="1" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                         <dxl:SortingColumn ColId="7" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                       </dxl:SortingColumnList>
+                       <dxl:LimitCount/>
+                       <dxl:LimitOffset/>
+                       <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+                         <dxl:Properties>
+                           <dxl:Cost StartupCost="0" TotalCost="1293.000896" Rows="1.000000" Width="22"/>
+                         </dxl:Properties>
+                         <dxl:ProjList>
+                           <dxl:ProjElem ColId="0" Alias="cidr">
+                             <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                           </dxl:ProjElem>
+                           <dxl:ProjElem ColId="1" Alias="ctid">
+                             <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                           </dxl:ProjElem>
+                           <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                             <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                           </dxl:ProjElem>
+                           <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+                             <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.23.1.0"/>
+                           </dxl:ProjElem>
+                         </dxl:ProjList>
+                         <dxl:Filter/>
+                         <dxl:JoinFilter>
+                           <dxl:Or>
+                             <dxl:Comparison ComparisonOperator="&lt;&lt;=" OperatorMdid="0.932.1.0">
+                               <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                               <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                             </dxl:Comparison>
+                             <dxl:IsNull>
+                               <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                             </dxl:IsNull>
+                           </dxl:Or>
+                         </dxl:JoinFilter>
+                         <dxl:TableScan>
+                           <dxl:Properties>
+                             <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
+                           </dxl:Properties>
+                           <dxl:ProjList>
+                             <dxl:ProjElem ColId="0" Alias="cidr">
+                               <dxl:Ident ColId="0" ColName="cidr" TypeMdid="0.869.1.0"/>
+                             </dxl:ProjElem>
+                             <dxl:ProjElem ColId="1" Alias="ctid">
+                               <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                             </dxl:ProjElem>
+                             <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                               <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                             </dxl:ProjElem>
+                           </dxl:ProjList>
+                           <dxl:Filter/>
+                           <dxl:TableDescriptor Mdid="0.660032.1.1" TableName="inverse">
+                             <dxl:Columns>
+                               <dxl:Column ColId="0" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
+                               <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                               <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                               <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                               <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                               <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                               <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                               <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                             </dxl:Columns>
+                           </dxl:TableDescriptor>
+                         </dxl:TableScan>
+                         <dxl:Result>
+                           <dxl:Properties>
+                             <dxl:Cost StartupCost="0" TotalCost="431.000485" Rows="3.000000" Width="12"/>
+                           </dxl:Properties>
+                           <dxl:ProjList>
+                             <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+                               <dxl:If TypeMdid="0.23.1.0">
+                                 <dxl:IsNull>
+                                   <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                                 </dxl:IsNull>
+                                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                                 <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                               </dxl:If>
+                             </dxl:ProjElem>
+                             <dxl:ProjElem ColId="8" Alias="cidr">
+                               <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                             </dxl:ProjElem>
+                           </dxl:ProjList>
+                           <dxl:Filter/>
+                           <dxl:OneTimeFilter/>
+                           <dxl:Materialize Eager="true">
+                             <dxl:Properties>
+                               <dxl:Cost StartupCost="0" TotalCost="431.000473" Rows="3.000000" Width="8"/>
+                             </dxl:Properties>
+                             <dxl:ProjList>
+                               <dxl:ProjElem ColId="8" Alias="cidr">
+                                 <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                               </dxl:ProjElem>
+                             </dxl:ProjList>
+                             <dxl:Filter/>
+                             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                               <dxl:Properties>
+                                 <dxl:Cost StartupCost="0" TotalCost="431.000465" Rows="3.000000" Width="8"/>
+                               </dxl:Properties>
+                               <dxl:ProjList>
+                                 <dxl:ProjElem ColId="8" Alias="cidr">
+                                   <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                                 </dxl:ProjElem>
+                               </dxl:ProjList>
+                               <dxl:Filter/>
+                               <dxl:SortingColumnList/>
+                               <dxl:TableScan>
+                                 <dxl:Properties>
+                                   <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                                 </dxl:Properties>
+                                 <dxl:ProjList>
+                                   <dxl:ProjElem ColId="8" Alias="cidr">
+                                     <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
+                                   </dxl:ProjElem>
+                                 </dxl:ProjList>
+                                 <dxl:Filter/>
+                                 <dxl:TableDescriptor Mdid="0.660032.1.1" TableName="inverse">
+                                   <dxl:Columns>
+                                     <dxl:Column ColId="8" Attno="1" ColName="cidr" TypeMdid="0.869.1.0"/>
+                                     <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                     <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                     <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                     <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                     <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                     <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                     <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                   </dxl:Columns>
+                                 </dxl:TableDescriptor>
+                               </dxl:TableScan>
+                             </dxl:BroadcastMotion>
+                           </dxl:Materialize>
+                         </dxl:Result>
+                       </dxl:NestedLoopJoin>
+                     </dxl:Sort>
+                   </dxl:Aggregate>
+                 </dxl:Result>
+               </dxl:RedistributeMotion>
+             </dxl:Sort>
+           </dxl:Aggregate>
+         </dxl:Result>
+       </dxl:GatherMotion>
+     </dxl:Result>
+   </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/data/dxl/minidump/DPE-SemiJoin.mdp
+++ b/data/dxl/minidump/DPE-SemiJoin.mdp
@@ -1194,7 +1194,7 @@ Select * from X where X.a < ANY (select a from P);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="31">
+	<dxl:Plan Id="0" SpaceSize="30">
 	  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
 	    <dxl:Properties>
 	      <dxl:Cost StartupCost="0" TotalCost="3660.836565" Rows="11000.000000" Width="4"/>
@@ -1259,7 +1259,7 @@ Select * from X where X.a < ANY (select a from P);
 	                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
 	                  </dxl:Properties>
 	                  <dxl:ProjList>
-	                    <dxl:ProjElem ColId="18" Alias="ColRef_0018">
+	                    <dxl:ProjElem ColId="17" Alias="ColRef_0017">
 	                      <dxl:PartOid Level="0"/>
 	                    </dxl:ProjElem>
 	                  </dxl:ProjList>

--- a/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+SELECT *
+FROM customer, customer_demographics
+WHERE
+  exists(
+      SELECT *
+      FROM web_sales, date_dim
+      WHERE
+        c_customer_sk = ws_bill_customer_sk AND
+        ws_sold_date_sk = d_date_sk AND
+        d_year = 2002
+  )
+  OR
+  exists(
+      SELECT *
+      FROM catalog_sales, date_dim
+      WHERE c_customer_sk = cs_ship_customer_sk
+  )
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>

--- a/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
+++ b/data/dxl/minidump/EffectOfLocalPredOnJoin2.mdp
@@ -10304,7 +10304,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="42">
+	<dxl:Plan Id="0" SpaceSize="41">
 	  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
 	    <dxl:Properties>
 	      <dxl:Cost StartupCost="0" TotalCost="888.989563" Rows="3866.533707" Width="116"/>
@@ -10554,7 +10554,7 @@
 	          <dxl:ProjElem ColId="27" Alias="d_date_sk">
 	            <dxl:Ident ColId="27" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
 	          </dxl:ProjElem>
-	          <dxl:ProjElem ColId="68" Alias="ColRef_0068">
+	          <dxl:ProjElem ColId="67" Alias="ColRef_0067">
 	            <dxl:PartOid Level="0"/>
 	          </dxl:ProjElem>
 	        </dxl:ProjList>
@@ -10618,7 +10618,7 @@
 	                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
 	                </dxl:Properties>
 	                <dxl:ProjList>
-	                  <dxl:ProjElem ColId="67" Alias="ColRef_0067">
+	                  <dxl:ProjElem ColId="66" Alias="ColRef_0066">
 	                    <dxl:PartOid Level="0"/>
 	                  </dxl:ProjElem>
 	                </dxl:ProjList>

--- a/data/dxl/minidump/GroupByOuterRef.mdp
+++ b/data/dxl/minidump/GroupByOuterRef.mdp
@@ -301,7 +301,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="90">
+<dxl:Plan Id="0" SpaceSize="87">
   <dxl:HashJoin JoinType="In">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="4.187500" Rows="1.000000" Width="16"/>

--- a/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1409,7 +1409,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="10335">
+<dxl:Plan Id="0" SpaceSize="10075">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="17.551612" Rows="77.229878" Width="16"/>

--- a/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -682,7 +682,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="2772">
+<dxl:Plan Id="0" SpaceSize="2701">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="244.269531" Rows="999.000000" Width="12"/>

--- a/data/dxl/minidump/NestedProjectCountStarWithOuterRefs.mdp
+++ b/data/dxl/minidump/NestedProjectCountStarWithOuterRefs.mdp
@@ -762,7 +762,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="2">
+	<dxl:Plan Id="0" SpaceSize="1">
 	  <dxl:Result>
 	    <dxl:Properties>
 	      <dxl:Cost StartupCost="0" TotalCost="788.488300" Rows="10.000000" Width="8"/>

--- a/data/dxl/minidump/NullIf-With-Subquery.mdp
+++ b/data/dxl/minidump/NullIf-With-Subquery.mdp
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+SELECT NULLIF(x.i, (
+  SELECT count(*) FROM y
+  WHERE y.i = x.i
+  ), i + j
+FROM x
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/data/dxl/minidump/PartTbl-SQAny.mdp
+++ b/data/dxl/minidump/PartTbl-SQAny.mdp
@@ -340,199 +340,199 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-		<dxl:Plan Id="0" SpaceSize="23">
-	  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-	    <dxl:Properties>
-	      <dxl:Cost StartupCost="0" TotalCost="5.382812" Rows="1.000000" Width="16"/>
-	    </dxl:Properties>
-	    <dxl:ProjList>
-	      <dxl:ProjElem ColId="0" Alias="i">
-	        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-	      </dxl:ProjElem>
-	      <dxl:ProjElem ColId="1" Alias="d">
-	        <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
-	      </dxl:ProjElem>
-	    </dxl:ProjList>
-	    <dxl:Filter/>
-	    <dxl:SortingColumnList/>
-	    <dxl:HashJoin JoinType="In">
-	      <dxl:Properties>
-	        <dxl:Cost StartupCost="0" TotalCost="4.375000" Rows="1.000000" Width="16"/>
-	      </dxl:Properties>
-	      <dxl:ProjList>
-	        <dxl:ProjElem ColId="0" Alias="i">
-	          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-	        </dxl:ProjElem>
-	        <dxl:ProjElem ColId="1" Alias="d">
-	          <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
-	        </dxl:ProjElem>
-	      </dxl:ProjList>
-	      <dxl:Filter/>
-	      <dxl:JoinFilter>
-	        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.37.1.0">
-	          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-	          <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
-	        </dxl:Comparison>
-	      </dxl:JoinFilter>
-	      <dxl:HashCondList>
-	        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-	          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-	          <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-	        </dxl:Comparison>
-	      </dxl:HashCondList>
-	      <dxl:Sequence>
-	        <dxl:Properties>
-	          <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-	        </dxl:Properties>
-	        <dxl:ProjList>
-	          <dxl:ProjElem ColId="0" Alias="i">
-	            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-	          </dxl:ProjElem>
-	          <dxl:ProjElem ColId="1" Alias="d">
-	            <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
-	          </dxl:ProjElem>
-	        </dxl:ProjList>
-	        <dxl:PartitionSelector RelationMdid="0.24588.1.1" PartitionLevels="1" ScanId="1">
-	          <dxl:Properties>
-	            <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-	          </dxl:Properties>
-	          <dxl:ProjList>
-	            <dxl:ProjElem ColId="25" Alias="ColRef_0025">
-	              <dxl:PartOid Level="0"/>
-	            </dxl:ProjElem>
-	          </dxl:ProjList>
-	          <dxl:PartEqFilters>
-	            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	          </dxl:PartEqFilters>
-	          <dxl:PartFilters>
-	            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	          </dxl:PartFilters>
-	          <dxl:ResidualFilter>
-	            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	          </dxl:ResidualFilter>
-	          <dxl:PropagationExpression>
-	            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	          </dxl:PropagationExpression>
-	          <dxl:PrintableFilter>
-	            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	          </dxl:PrintableFilter>
-	        </dxl:PartitionSelector>
-	        <dxl:DynamicTableScan PartIndexId="1">
-	          <dxl:Properties>
-	            <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-	          </dxl:Properties>
-	          <dxl:ProjList>
-	            <dxl:ProjElem ColId="0" Alias="i">
-	              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="1" Alias="d">
-	              <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
-	            </dxl:ProjElem>
-	          </dxl:ProjList>
-	          <dxl:Filter/>
-	          <dxl:TableDescriptor Mdid="0.24588.1.1" TableName="smallt_part">
-	            <dxl:Columns>
-	              <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-	              <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
-	              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-	              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-	              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-	              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-	              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-	              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	            </dxl:Columns>
-	          </dxl:TableDescriptor>
-	        </dxl:DynamicTableScan>
-	      </dxl:Sequence>
-	      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-	        <dxl:Properties>
-	          <dxl:Cost StartupCost="0" TotalCost="2.140625" Rows="1.000000" Width="16"/>
-	        </dxl:Properties>
-	        <dxl:GroupingColumns>
-	          <dxl:GroupingColumn ColId="9"/>
-	          <dxl:GroupingColumn ColId="10"/>
-	        </dxl:GroupingColumns>
-	        <dxl:ProjList>
-	          <dxl:ProjElem ColId="18" Alias="count">
-	            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
-	          </dxl:ProjElem>
-	          <dxl:ProjElem ColId="9" Alias="i">
-	            <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-	          </dxl:ProjElem>
-	          <dxl:ProjElem ColId="10" Alias="d">
-	            <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
-	          </dxl:ProjElem>
-	        </dxl:ProjList>
-	        <dxl:Filter/>
-	        <dxl:Sequence>
-	          <dxl:Properties>
-	            <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-	          </dxl:Properties>
-	          <dxl:ProjList>
-	            <dxl:ProjElem ColId="9" Alias="i">
-	              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="10" Alias="d">
-	              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
-	            </dxl:ProjElem>
-	          </dxl:ProjList>
-	          <dxl:PartitionSelector RelationMdid="0.24756.1.1" PartitionLevels="1" ScanId="2">
-	            <dxl:Properties>
-	              <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-	            </dxl:Properties>
-	            <dxl:ProjList>
-	              <dxl:ProjElem ColId="26" Alias="ColRef_0026">
-	                <dxl:PartOid Level="0"/>
-	              </dxl:ProjElem>
-	            </dxl:ProjList>
-	            <dxl:PartEqFilters>
-	              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	            </dxl:PartEqFilters>
-	            <dxl:PartFilters>
-	              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	            </dxl:PartFilters>
-	            <dxl:ResidualFilter>
-	              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	            </dxl:ResidualFilter>
-	            <dxl:PropagationExpression>
-	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-	            </dxl:PropagationExpression>
-	            <dxl:PrintableFilter>
-	              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-	            </dxl:PrintableFilter>
-	          </dxl:PartitionSelector>
-	          <dxl:DynamicTableScan PartIndexId="2">
-	            <dxl:Properties>
-	              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
-	            </dxl:Properties>
-	            <dxl:ProjList>
-	              <dxl:ProjElem ColId="9" Alias="i">
-	                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
-	              </dxl:ProjElem>
-	              <dxl:ProjElem ColId="10" Alias="d">
-	                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
-	              </dxl:ProjElem>
-	            </dxl:ProjList>
-	            <dxl:Filter/>
-	            <dxl:TableDescriptor Mdid="0.24756.1.1" TableName="smallt2_part">
-	              <dxl:Columns>
-	                <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-	                <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
-	                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-	                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-	                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-	                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-	                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-	                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	              </dxl:Columns>
-	            </dxl:TableDescriptor>
-	          </dxl:DynamicTableScan>
-	        </dxl:Sequence>
-	      </dxl:Aggregate>
-	    </dxl:HashJoin>
-	  </dxl:GatherMotion>
-	</dxl:Plan>
+    <dxl:Plan Id="0" SpaceSize="21">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="5.382812" Rows="1.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="d">
+            <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="In">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="4.375000" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="d">
+              <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.37.1.0">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="d">
+                <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.24588.1.1" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="24" Alias="ColRef_0024">
+                  <dxl:PartOid Level="0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="d">
+                  <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1082.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.24588.1.1" TableName="smallt_part">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:Sequence>
+          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2.140625" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="9"/>
+              <dxl:GroupingColumn ColId="10"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="18" Alias="count">
+                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="i">
+                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="d">
+                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Sequence>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="i">
+                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="d">
+                  <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:PartitionSelector RelationMdid="0.24756.1.1" PartitionLevels="1" ScanId="2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="25" Alias="ColRef_0025">
+                    <dxl:PartOid Level="0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:PartEqFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                </dxl:PartEqFilters>
+                <dxl:PartFilters>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                </dxl:PartFilters>
+                <dxl:ResidualFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                </dxl:ResidualFilter>
+                <dxl:PropagationExpression>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+                </dxl:PropagationExpression>
+                <dxl:PrintableFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                </dxl:PrintableFilter>
+              </dxl:PartitionSelector>
+              <dxl:DynamicTableScan PartIndexId="2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.015625" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="i">
+                    <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="d">
+                    <dxl:Ident ColId="10" ColName="d" TypeMdid="0.1082.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.24756.1.1" TableName="smallt2_part">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.1082.1.0"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:DynamicTableScan>
+            </dxl:Sequence>
+          </dxl:Aggregate>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/data/dxl/minidump/ProjectCountStar.mdp
+++ b/data/dxl/minidump/ProjectCountStar.mdp
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+SELECT (SELECT 1 + count(*) FROM x) FROM y;
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
+++ b/data/dxl/minidump/PushSelectDownUnionAllOfCTG.mdp
@@ -197,7 +197,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="1052660">
+<dxl:Plan Id="0" SpaceSize="988020">
   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="14.421875" Rows="1.000000" Width="8"/>

--- a/data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp
+++ b/data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CREATE TABLE foo(a, b) AS VALUES (1, 1);
+CREATE TABLE bar(c int, d int);
+EXPLAIN SELECT (SELECT count(*) FROM bar where c = a) FROM foo;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:OptimizerConfig>
+    <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+    <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+    <dxl:CTEConfig CTEInliningCutoff="0"/>
+    <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+    <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
+    <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005,105000"/>
+  </dxl:OptimizerConfig>
+  <dxl:Metadata SystemIds="0.GPDB">
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:RelationStatistics Mdid="2.16396.1.1" Name="foo" Rows="1.000000" EmptyRelation="false"/>
+    <dxl:Relation Mdid="0.16396.1.1" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:Columns>
+        <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+      </dxl:Columns>
+      <dxl:Indexes/>
+      <dxl:Triggers/>
+      <dxl:CheckConstraints/>
+    </dxl:Relation>
+    <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+      <dxl:EqualityOp Mdid="0.91.1.0"/>
+      <dxl:InequalityOp Mdid="0.85.1.0"/>
+      <dxl:LessThanOp Mdid="0.58.1.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+      <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+      <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+      <dxl:ArrayType Mdid="0.1000.1.0"/>
+      <dxl:MinAgg Mdid="0.0.0.0"/>
+      <dxl:MaxAgg Mdid="0.0.0.0"/>
+      <dxl:AvgAgg Mdid="0.0.0.0"/>
+      <dxl:SumAgg Mdid="0.0.0.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+      <dxl:EqualityOp Mdid="0.410.1.0"/>
+      <dxl:InequalityOp Mdid="0.411.1.0"/>
+      <dxl:LessThanOp Mdid="0.412.1.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+      <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+      <dxl:ComparisonOp Mdid="0.351.1.0"/>
+      <dxl:ArrayType Mdid="0.1016.1.0"/>
+      <dxl:MinAgg Mdid="0.2131.1.0"/>
+      <dxl:MaxAgg Mdid="0.2115.1.0"/>
+      <dxl:AvgAgg Mdid="0.2100.1.0"/>
+      <dxl:SumAgg Mdid="0.2107.1.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:EqualityOp Mdid="0.96.1.0"/>
+      <dxl:InequalityOp Mdid="0.518.1.0"/>
+      <dxl:LessThanOp Mdid="0.97.1.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+      <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+      <dxl:ComparisonOp Mdid="0.351.1.0"/>
+      <dxl:ArrayType Mdid="0.1007.1.0"/>
+      <dxl:MinAgg Mdid="0.2132.1.0"/>
+      <dxl:MaxAgg Mdid="0.2116.1.0"/>
+      <dxl:AvgAgg Mdid="0.2101.1.0"/>
+      <dxl:SumAgg Mdid="0.2108.1.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:EqualityOp Mdid="0.607.1.0"/>
+      <dxl:InequalityOp Mdid="0.608.1.0"/>
+      <dxl:LessThanOp Mdid="0.609.1.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+      <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+      <dxl:ComparisonOp Mdid="0.356.1.0"/>
+      <dxl:ArrayType Mdid="0.1028.1.0"/>
+      <dxl:MinAgg Mdid="0.2118.1.0"/>
+      <dxl:MaxAgg Mdid="0.2134.1.0"/>
+      <dxl:AvgAgg Mdid="0.0.0.0"/>
+      <dxl:SumAgg Mdid="0.0.0.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:EqualityOp Mdid="0.387.1.0"/>
+      <dxl:InequalityOp Mdid="0.402.1.0"/>
+      <dxl:LessThanOp Mdid="0.2799.1.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+      <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+      <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+      <dxl:ArrayType Mdid="0.1010.1.0"/>
+      <dxl:MinAgg Mdid="0.2798.1.0"/>
+      <dxl:MaxAgg Mdid="0.2797.1.0"/>
+      <dxl:AvgAgg Mdid="0.0.0.0"/>
+      <dxl:SumAgg Mdid="0.0.0.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:EqualityOp Mdid="0.385.1.0"/>
+      <dxl:InequalityOp Mdid="0.0.0.0"/>
+      <dxl:LessThanOp Mdid="0.0.0.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+      <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+      <dxl:ComparisonOp Mdid="0.0.0.0"/>
+      <dxl:ArrayType Mdid="0.1012.1.0"/>
+      <dxl:MinAgg Mdid="0.0.0.0"/>
+      <dxl:MaxAgg Mdid="0.0.0.0"/>
+      <dxl:AvgAgg Mdid="0.0.0.0"/>
+      <dxl:SumAgg Mdid="0.0.0.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:EqualityOp Mdid="0.352.1.0"/>
+      <dxl:InequalityOp Mdid="0.0.0.0"/>
+      <dxl:LessThanOp Mdid="0.0.0.0"/>
+      <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+      <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+      <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+      <dxl:ComparisonOp Mdid="0.0.0.0"/>
+      <dxl:ArrayType Mdid="0.1011.1.0"/>
+      <dxl:MinAgg Mdid="0.0.0.0"/>
+      <dxl:MaxAgg Mdid="0.0.0.0"/>
+      <dxl:AvgAgg Mdid="0.0.0.0"/>
+      <dxl:SumAgg Mdid="0.0.0.0"/>
+      <dxl:CountAgg Mdid="0.2147.1.0"/>
+    </dxl:Type>
+    <dxl:RelationStatistics Mdid="2.16423.1.1" Name="bar" Rows="1.000000" EmptyRelation="false"/>
+    <dxl:Relation Mdid="0.16423.1.1" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+      <dxl:Columns>
+        <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+        <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+          <dxl:DefaultValue/>
+        </dxl:Column>
+      </dxl:Columns>
+      <dxl:Indexes/>
+      <dxl:Triggers/>
+      <dxl:CheckConstraints/>
+    </dxl:Relation>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+      <dxl:LeftType Mdid="0.23.1.0"/>
+      <dxl:RightType Mdid="0.23.1.0"/>
+      <dxl:ResultType Mdid="0.16.1.0"/>
+      <dxl:OpFunc Mdid="0.66.1.0"/>
+      <dxl:Commutator Mdid="0.521.1.0"/>
+      <dxl:InverseOp Mdid="0.525.1.0"/>
+      <dxl:OpClasses>
+        <dxl:OpClass Mdid="0.1976.1.0"/>
+        <dxl:OpClass Mdid="0.3027.1.0"/>
+      </dxl:OpClasses>
+    </dxl:GPDBScalarOp>
+    <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+      <dxl:LeftType Mdid="0.23.1.0"/>
+      <dxl:RightType Mdid="0.23.1.0"/>
+      <dxl:ResultType Mdid="0.16.1.0"/>
+      <dxl:OpFunc Mdid="0.65.1.0"/>
+      <dxl:Commutator Mdid="0.96.1.0"/>
+      <dxl:InverseOp Mdid="0.518.1.0"/>
+      <dxl:OpClasses>
+        <dxl:OpClass Mdid="0.1976.1.0"/>
+        <dxl:OpClass Mdid="0.1977.1.0"/>
+        <dxl:OpClass Mdid="0.3027.1.0"/>
+      </dxl:OpClasses>
+    </dxl:GPDBScalarOp>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:ColumnStatistics Mdid="1.16423.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+      <dxl:ResultType Mdid="0.20.1.0"/>
+      <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+    </dxl:GPDBAgg>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    <dxl:ColumnStatistics Mdid="1.16396.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+  </dxl:Metadata>
+  <dxl:Query>
+    <dxl:OutputColumns>
+      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.20.1.0"/>
+    </dxl:OutputColumns>
+    <dxl:CTEList/>
+    <dxl:LogicalProject>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="20" Alias="?column?">
+          <dxl:ScalarSubquery ColId="19">
+            <dxl:LogicalGroupBy>
+              <dxl:GroupingColumns/>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="19" Alias="count">
+                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:LogicalSelect>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.16423.1.1" TableName="bar">
+                    <dxl:Columns>
+                      <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+              </dxl:LogicalSelect>
+            </dxl:LogicalGroupBy>
+          </dxl:ScalarSubquery>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:LogicalGet>
+        <dxl:TableDescriptor Mdid="0.16396.1.1" TableName="foo">
+          <dxl:Columns>
+            <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:LogicalGet>
+    </dxl:LogicalProject>
+  </dxl:Query>
+  <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="862.000673" Rows="1.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="19" Alias="?column?">
+          <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:SortingColumnList/>
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000643" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="19" Alias="?column?">
+            <dxl:Coalesce TypeMdid="0.20.1.0">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+            </dxl:Coalesce>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="2.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:HashJoin JoinType="Left">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000635" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="18" Alias="count">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.16396.1.1" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="9"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="count">
+                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="c">
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="c">
+                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="c">
+                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.16423.1.1" TableName="bar">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:Sort>
+            </dxl:Aggregate>
+          </dxl:HashJoin>
+        </dxl:Result>
+      </dxl:Result>
+    </dxl:GatherMotion>
+  </dxl:Plan>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/ScalarSubqueryCountStar.mdp
+++ b/data/dxl/minidump/ScalarSubqueryCountStar.mdp
@@ -1,0 +1,482 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CREATE TEMP TABLE foo (a, b) AS SELECT i,i FROM generate_series(1,1) AS t(i) DISTRIBUTED BY(a);
+CREATE TEMP TABLE bar (c int, d int);
+EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.921975.1.1" Name="foo" Rows="1.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.921975.1.1" Name="foo" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:RelationStatistics Mdid="2.922002.1.1" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.922002.1.1" Name="bar" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.922002.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.921975.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="20" Alias="?column?">
+            <dxl:ScalarSubquery ColId="19">
+              <dxl:LogicalLimit>
+                <dxl:SortingColumnList/>
+                <dxl:LimitCount>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                </dxl:LimitCount>
+                <dxl:LimitOffset/>
+                <dxl:LogicalGroupBy>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="10"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="19" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:LogicalGet>
+                    <dxl:TableDescriptor Mdid="0.922002.1.1" TableName="bar">
+                      <dxl:Columns>
+                        <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:LogicalGet>
+                </dxl:LogicalGroupBy>
+              </dxl:LogicalLimit>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.921975.1.1" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="28">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1293.000585" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="19" Alias="?column?">
+            <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000555" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="19" Alias="?column?">
+              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000552" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000547" Rows="2.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="count">
+                  <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.921975.1.1" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:Materialize Eager="true">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000509" Rows="3.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="count">
+                    <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000501" Rows="3.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="count">
+                      <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Limit>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="18" Alias="count">
+                        <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="18" Alias="count">
+                          <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="18" Alias="count">
+                            <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="9"/>
+                          </dxl:GroupingColumns>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="18" Alias="count">
+                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="9" Alias="c">
+                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="9" Alias="c">
+                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="c">
+                                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.922002.1.1" TableName="bar">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Sort>
+                        </dxl:Aggregate>
+                      </dxl:Result>
+                    </dxl:GatherMotion>
+                    <dxl:LimitCount>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                    </dxl:LimitCount>
+                    <dxl:LimitOffset>
+                      <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                    </dxl:LimitOffset>
+                  </dxl:Limit>
+                </dxl:BroadcastMotion>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:Result>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -1,0 +1,645 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+// The subquery has COUNT(*) on both sides of the join,
+// and it outputs the computed column from COUNT(*) of right hand side (inner)
+// previously ORCA would not coalesce the output.
+// when we decorrelate the OUTER APPLY into LEFT OUTER JOIN
+// this would result in a wrong plan
+CREATE TABLE foo(a,b) AS VALUES (1,1);
+CREATE TABLE bar(c int, d int);
+CREATE TABLE jazz(e int, f int);
+
+// This should return 0, not NULL
+SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS bar, (SELECT count(*) FROM jazz WHERE e = a) AS jazz) FROM foo;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.1" Name="f" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.0" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.16396.1.1" Name="foo" Rows="1.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16396.1.1" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.16423.1.1" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16423.1.1" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.16450.1.1" Name="jazz" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16450.1.1" Name="jazz" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="e" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="f" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16450.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16423.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16396.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="30" ColName="?column?" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="30" Alias="?column?">
+            <dxl:ScalarSubquery ColId="29">
+              <dxl:LogicalJoin JoinType="Inner">
+                <dxl:LogicalLimit>
+                  <dxl:SortingColumnList/>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset/>
+                  <dxl:LogicalGroupBy>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="10"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.16423.1.1" TableName="bar">
+                        <dxl:Columns>
+                          <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                  </dxl:LogicalGroupBy>
+                </dxl:LogicalLimit>
+                <dxl:LogicalGroupBy>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="29" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:LogicalSelect>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="20" ColName="e" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.16450.1.1" TableName="jazz">
+                        <dxl:Columns>
+                          <dxl:Column ColId="20" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="21" Attno="2" ColName="f" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                  </dxl:LogicalSelect>
+                </dxl:LogicalGroupBy>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:LogicalJoin>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16396.1.1" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="488">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1724.000816" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="29" Alias="?column?">
+            <dxl:Ident ColId="29" ColName="?column?" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000786" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="29" Alias="?column?">
+              <dxl:Coalesce TypeMdid="0.20.1.0">
+                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+              </dxl:Coalesce>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000784" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:HashJoin JoinType="Left">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1724.000778" Rows="2.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="28" Alias="count">
+                  <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16396.1.1" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000183" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="19" Alias="e">
+                    <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="28" Alias="count">
+                    <dxl:Ident ColId="28" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                </dxl:JoinFilter>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="19"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="28" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="e">
+                      <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="e">
+                        <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="19" Alias="e">
+                          <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.16450.1.1" TableName="jazz">
+                        <dxl:Columns>
+                          <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="20" Attno="2" ColName="f" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+                <dxl:Materialize Eager="true">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Limit>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000037" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="9"/>
+                            </dxl:GroupingColumns>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="18" Alias="count">
+                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="9" Alias="c">
+                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:Sort SortDiscardDuplicates="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="c">
+                                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="c">
+                                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.16423.1.1" TableName="bar">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:Sort>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:GatherMotion>
+                      <dxl:LimitCount>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                      </dxl:LimitCount>
+                      <dxl:LimitOffset>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                      </dxl:LimitOffset>
+                    </dxl:Limit>
+                  </dxl:BroadcastMotion>
+                </dxl:Materialize>
+              </dxl:NestedLoopJoin>
+            </dxl:HashJoin>
+          </dxl:Result>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
+++ b/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
@@ -413,7 +413,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="82">
+    <dxl:Plan Id="0" SpaceSize="80">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="39.099609" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -427,7 +427,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="281382">
+<dxl:Plan Id="0" SpaceSize="279471">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="16.184570" Rows="1.000000" Width="8"/>

--- a/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
+++ b/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+SELECT generate_series((
+    SELECT count(*) FROM x
+    ),
+    16,
+    (
+    SELECT count(*) FROM x
+    ) / 2
+);
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -14866,66 +14866,13 @@ with results as
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="5404185348096">
-  <dxl:Result>
-    <dxl:Properties>
-      <dxl:Cost StartupCost="0" TotalCost="21949.272787" Rows="20.062500" Width="36"/>
-    </dxl:Properties>
-    <dxl:ProjList>
-      <dxl:ProjElem ColId="842" Alias="total_sum">
-        <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
-      </dxl:ProjElem>
-      <dxl:ProjElem ColId="843" Alias="s_state">
-        <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
-      </dxl:ProjElem>
-      <dxl:ProjElem ColId="844" Alias="s_county">
-        <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
-      </dxl:ProjElem>
-      <dxl:ProjElem ColId="847" Alias="lochierarchy">
-        <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
-      </dxl:ProjElem>
-      <dxl:ProjElem ColId="1478" Alias="rank_within_parent">
-        <dxl:Ident ColId="1478" ColName="rank" TypeMdid="0.20.1.0"/>
-      </dxl:ProjElem>
-    </dxl:ProjList>
-    <dxl:Filter/>
-    <dxl:OneTimeFilter/>
-    <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
-      <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="21949.272787" Rows="20.062500" Width="36"/>
-      </dxl:Properties>
-      <dxl:ProjList>
-        <dxl:ProjElem ColId="842" Alias="sum">
-          <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="843" Alias="s_state">
-          <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="844" Alias="s_county">
-          <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="847" Alias="lochierarchy">
-          <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="1478" Alias="rank">
-          <dxl:Ident ColId="1478" ColName="rank" TypeMdid="0.20.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="1479" Alias="?column?">
-          <dxl:Ident ColId="1479" ColName="?column?" TypeMdid="0.1042.1.0"/>
-        </dxl:ProjElem>
-      </dxl:ProjList>
-      <dxl:Filter/>
-      <dxl:SortingColumnList>
-        <dxl:SortingColumn ColId="847" SortOperatorMdid="0.521.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-        <dxl:SortingColumn ColId="1479" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-        <dxl:SortingColumn ColId="1478" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-      </dxl:SortingColumnList>
-      <dxl:Sort SortDiscardDuplicates="false">
+    <dxl:Plan Id="0" SpaceSize="4669921034496">
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="21949.270719" Rows="20.062500" Width="44"/>
+          <dxl:Cost StartupCost="0" TotalCost="21949.272787" Rows="20.062500" Width="36"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="842" Alias="sum">
+          <dxl:ProjElem ColId="842" Alias="total_sum">
             <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="843" Alias="s_state">
@@ -14937,24 +14884,15 @@ with results as
           <dxl:ProjElem ColId="847" Alias="lochierarchy">
             <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="1478" Alias="rank">
+          <dxl:ProjElem ColId="1478" Alias="rank_within_parent">
             <dxl:Ident ColId="1478" ColName="rank" TypeMdid="0.20.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1479" Alias="?column?">
-            <dxl:Ident ColId="1479" ColName="?column?" TypeMdid="0.1042.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:SortingColumnList>
-          <dxl:SortingColumn ColId="847" SortOperatorMdid="0.521.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-          <dxl:SortingColumn ColId="1479" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-          <dxl:SortingColumn ColId="1478" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-        </dxl:SortingColumnList>
-        <dxl:LimitCount/>
-        <dxl:LimitOffset/>
-        <dxl:Sequence>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="21949.270719" Rows="20.062500" Width="44"/>
+            <dxl:Cost StartupCost="0" TotalCost="21949.272787" Rows="20.062500" Width="36"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="842" Alias="sum">
@@ -14976,824 +14914,15 @@ with results as
               <dxl:Ident ColId="1479" ColName="?column?" TypeMdid="0.1042.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:CTEProducer CTEId="0" Columns="204,89,88,205,206">
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="847" SortOperatorMdid="0.521.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+            <dxl:SortingColumn ColId="1479" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            <dxl:SortingColumn ColId="1478" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="20656.270139" Rows="14.062500" Width="1"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="204" Alias="sum">
-                <dxl:Ident ColId="204" ColName="sum" TypeMdid="0.1700.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="89" Alias="s_state">
-                <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="88" Alias="s_county">
-                <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="205" Alias="gstate">
-                <dxl:Ident ColId="205" ColName="gstate" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="206" Alias="g_county">
-                <dxl:Ident ColId="206" ColName="g_county" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="20656.270139" Rows="14.062500" Width="32"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="204" Alias="sum">
-                  <dxl:Ident ColId="204" ColName="sum" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="89" Alias="s_state">
-                  <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="88" Alias="s_county">
-                  <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="205" Alias="gstate">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="206" Alias="g_county">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20656.270125" Rows="14.062500" Width="26"/>
-                </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="89"/>
-                  <dxl:GroupingColumn ColId="88"/>
-                </dxl:GroupingColumns>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="204" Alias="sum">
-                    <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                      <dxl:Ident ColId="1510" ColName="ColRef_1510" TypeMdid="0.1700.1.0"/>
-                    </dxl:AggFunc>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="88" Alias="s_county">
-                    <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="89" Alias="s_state">
-                    <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:Sort SortDiscardDuplicates="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="20656.270092" Rows="14.062500" Width="26"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="88" Alias="s_county">
-                      <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="89" Alias="s_state">
-                      <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1510" Alias="ColRef_1510">
-                      <dxl:Ident ColId="1510" ColName="ColRef_1510" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList>
-                    <dxl:SortingColumn ColId="89" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    <dxl:SortingColumn ColId="88" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  </dxl:SortingColumnList>
-                  <dxl:LimitCount/>
-                  <dxl:LimitOffset/>
-                  <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="20656.270092" Rows="14.062500" Width="26"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="88" Alias="s_county">
-                        <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="89" Alias="s_state">
-                        <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1510" Alias="ColRef_1510">
-                        <dxl:Ident ColId="1510" ColName="ColRef_1510" TypeMdid="0.1700.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.1042.1.0">
-                        <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                      </dxl:HashExpr>
-                      <dxl:HashExpr TypeMdid="0.1043.1.0">
-                        <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="20656.270045" Rows="14.062500" Width="26"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="88" Alias="s_county">
-                          <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="89" Alias="s_state">
-                          <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1510" Alias="ColRef_1510">
-                          <dxl:Ident ColId="1510" ColName="ColRef_1510" TypeMdid="0.1700.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="20656.270045" Rows="14.062500" Width="26"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="89"/>
-                          <dxl:GroupingColumn ColId="88"/>
-                        </dxl:GroupingColumns>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="1510" Alias="ColRef_1510">
-                            <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                              <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="88" Alias="s_county">
-                            <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="89" Alias="s_state">
-                            <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:HashJoin JoinType="Inner">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="20119.823355" Rows="67819601.064540" Width="26"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="22" Alias="ss_net_profit">
-                              <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="88" Alias="s_county">
-                              <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="89" Alias="s_state">
-                              <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:JoinFilter/>
-                          <dxl:HashCondList>
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                              <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                              <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:HashCondList>
-                          <dxl:HashJoin JoinType="Inner">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="8141.468548" Rows="169549002.661349" Width="12"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="7" Alias="ss_store_sk">
-                                <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="22" Alias="ss_net_profit">
-                                <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:JoinFilter/>
-                            <dxl:HashCondList>
-                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                              </dxl:Comparison>
-                            </dxl:HashCondList>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2572.718951" Rows="737331968.000000" Width="16"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
-                                  <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="7" Alias="ss_store_sk">
-                                  <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="22" Alias="ss_net_profit">
-                                  <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="0" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="1" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="2" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="3" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="4" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="5" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="6" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="7" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="8" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="9" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
-                                  <dxl:Column ColId="10" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="11" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="12" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="13" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="14" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="15" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="16" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="17" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="18" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="19" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="20" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="21" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="22" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                  <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                            <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.265982" Rows="13414.324949" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="30" Alias="d_date_sk">
-                                  <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.261117" Rows="419.197655" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="30" Alias="d_date_sk">
-                                    <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                    <dxl:Ident ColId="36" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2000"/>
-                                  </dxl:Comparison>
-                                </dxl:Filter>
-                                <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="30" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="31" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                                    <dxl:Column ColId="32" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
-                                    <dxl:Column ColId="33" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="34" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="35" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="36" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="37" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="38" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="39" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="40" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="41" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="42" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="43" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="44" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
-                                    <dxl:Column ColId="45" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="46" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="47" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="48" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="49" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="50" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="51" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="52" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="53" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="54" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="55" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="56" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="57" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                    <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:BroadcastMotion>
-                          </dxl:HashJoin>
-                          <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="10825.831361" Rows="4147.200000" Width="22"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="65" Alias="s_store_sk">
-                                <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="88" Alias="s_county">
-                                <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="89" Alias="s_state">
-                                <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:HashJoin JoinType="In">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="10825.823088" Rows="129.600000" Width="22"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="65" Alias="s_store_sk">
-                                  <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="88" Alias="s_county">
-                                  <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="89" Alias="s_state">
-                                  <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:JoinFilter/>
-                              <dxl:HashCondList>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                                  <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                  <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:HashCondList>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.001793" Rows="324.000000" Width="22"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="65" Alias="s_store_sk">
-                                    <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="88" Alias="s_county">
-                                    <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="89" Alias="s_state">
-                                    <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="65" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="66" Attno="2" ColName="s_store_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                                    <dxl:Column ColId="67" Attno="3" ColName="s_rec_start_date" TypeMdid="0.1082.1.0"/>
-                                    <dxl:Column ColId="68" Attno="4" ColName="s_rec_end_date" TypeMdid="0.1082.1.0"/>
-                                    <dxl:Column ColId="69" Attno="5" ColName="s_closed_date_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="70" Attno="6" ColName="s_store_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                    <dxl:Column ColId="71" Attno="7" ColName="s_number_employees" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="72" Attno="8" ColName="s_floor_space" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="73" Attno="9" ColName="s_hours" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                                    <dxl:Column ColId="74" Attno="10" ColName="s_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                                    <dxl:Column ColId="75" Attno="11" ColName="s_market_id" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="76" Attno="12" ColName="s_geography_class" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                                    <dxl:Column ColId="77" Attno="13" ColName="s_market_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                                    <dxl:Column ColId="78" Attno="14" ColName="s_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                                    <dxl:Column ColId="79" Attno="15" ColName="s_division_id" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="80" Attno="16" ColName="s_division_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                    <dxl:Column ColId="81" Attno="17" ColName="s_company_id" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="82" Attno="18" ColName="s_company_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                    <dxl:Column ColId="83" Attno="19" ColName="s_street_number" TypeMdid="0.1043.1.0" ColWidth="10"/>
-                                    <dxl:Column ColId="84" Attno="20" ColName="s_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                                    <dxl:Column ColId="85" Attno="21" ColName="s_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
-                                    <dxl:Column ColId="86" Attno="22" ColName="s_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                                    <dxl:Column ColId="87" Attno="23" ColName="s_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                                    <dxl:Column ColId="88" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
-                                    <dxl:Column ColId="89" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                                    <dxl:Column ColId="90" Attno="26" ColName="s_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                                    <dxl:Column ColId="91" Attno="27" ColName="s_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                    <dxl:Column ColId="92" Attno="28" ColName="s_gmt_offset" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="93" Attno="29" ColName="s_tax_precentage" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="94" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="95" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="96" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="97" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="98" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="99" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="100" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="10394.818337" Rows="64.000000" Width="3"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="155" Alias="s_state">
-                                    <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:Result>
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="10394.818059" Rows="2.000000" Width="3"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="155" Alias="s_state">
-                                      <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.420.1.0">
-                                      <dxl:Ident ColId="203" ColName="ranking" TypeMdid="0.20.1.0"/>
-                                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
-                                    </dxl:Comparison>
-                                  </dxl:Filter>
-                                  <dxl:OneTimeFilter/>
-                                  <dxl:Window PartitionColumns="155">
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="10394.818026" Rows="5.000000" Width="11"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="203" Alias="ranking">
-                                        <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="155" Alias="s_state">
-                                        <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="202" Alias="att_2">
-                                        <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:Sort SortDiscardDuplicates="false">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="10394.818015" Rows="5.000000" Width="11"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="202" Alias="att_2">
-                                          <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="155" Alias="s_state">
-                                          <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:SortingColumnList>
-                                        <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                        <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-                                      </dxl:SortingColumnList>
-                                      <dxl:LimitCount/>
-                                      <dxl:LimitOffset/>
-                                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                                        <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="10394.818015" Rows="5.000000" Width="11"/>
-                                        </dxl:Properties>
-                                        <dxl:GroupingColumns>
-                                          <dxl:GroupingColumn ColId="155"/>
-                                        </dxl:GroupingColumns>
-                                        <dxl:ProjList>
-                                          <dxl:ProjElem ColId="202" Alias="att_2">
-                                            <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                                              <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
-                                            </dxl:AggFunc>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="155" Alias="s_state">
-                                            <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                          </dxl:ProjElem>
-                                        </dxl:ProjList>
-                                        <dxl:Filter/>
-                                        <dxl:Sort SortDiscardDuplicates="false">
-                                          <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="10394.817997" Rows="5.000000" Width="11"/>
-                                          </dxl:Properties>
-                                          <dxl:ProjList>
-                                            <dxl:ProjElem ColId="155" Alias="s_state">
-                                              <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
-                                              <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
-                                            </dxl:ProjElem>
-                                          </dxl:ProjList>
-                                          <dxl:Filter/>
-                                          <dxl:SortingColumnList>
-                                            <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                          </dxl:SortingColumnList>
-                                          <dxl:LimitCount/>
-                                          <dxl:LimitOffset/>
-                                          <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                            <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="10394.817997" Rows="5.000000" Width="11"/>
-                                            </dxl:Properties>
-                                            <dxl:ProjList>
-                                              <dxl:ProjElem ColId="155" Alias="s_state">
-                                                <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                              </dxl:ProjElem>
-                                              <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
-                                                <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
-                                              </dxl:ProjElem>
-                                            </dxl:ProjList>
-                                            <dxl:Filter/>
-                                            <dxl:SortingColumnList/>
-                                            <dxl:HashExprList>
-                                              <dxl:HashExpr TypeMdid="0.1042.1.0">
-                                                <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                              </dxl:HashExpr>
-                                            </dxl:HashExprList>
-                                            <dxl:Result>
-                                              <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="10394.817985" Rows="5.000000" Width="11"/>
-                                              </dxl:Properties>
-                                              <dxl:ProjList>
-                                                <dxl:ProjElem ColId="155" Alias="s_state">
-                                                  <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
-                                                  <dxl:Ident ColId="1487" ColName="ColRef_1487" TypeMdid="0.1700.1.0"/>
-                                                </dxl:ProjElem>
-                                              </dxl:ProjList>
-                                              <dxl:Filter/>
-                                              <dxl:OneTimeFilter/>
-                                              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
-                                                <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="10394.817985" Rows="5.000000" Width="11"/>
-                                                </dxl:Properties>
-                                                <dxl:GroupingColumns>
-                                                  <dxl:GroupingColumn ColId="155"/>
-                                                </dxl:GroupingColumns>
-                                                <dxl:ProjList>
-                                                  <dxl:ProjElem ColId="1487" Alias="ColRef_1487">
-                                                    <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                                      <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                    </dxl:AggFunc>
-                                                  </dxl:ProjElem>
-                                                  <dxl:ProjElem ColId="155" Alias="s_state">
-                                                    <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                  </dxl:ProjElem>
-                                                </dxl:ProjList>
-                                                <dxl:Filter/>
-                                                <dxl:HashJoin JoinType="Inner">
-                                                  <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="9736.133355" Rows="169549002.661349" Width="11"/>
-                                                  </dxl:Properties>
-                                                  <dxl:ProjList>
-                                                    <dxl:ProjElem ColId="123" Alias="ss_net_profit">
-                                                      <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                    </dxl:ProjElem>
-                                                    <dxl:ProjElem ColId="155" Alias="s_state">
-                                                      <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                    </dxl:ProjElem>
-                                                  </dxl:ProjList>
-                                                  <dxl:Filter/>
-                                                  <dxl:JoinFilter/>
-                                                  <dxl:HashCondList>
-                                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                                      <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                      <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                                    </dxl:Comparison>
-                                                  </dxl:HashCondList>
-                                                  <dxl:HashJoin JoinType="Inner">
-                                                    <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="8141.468548" Rows="169549002.661349" Width="12"/>
-                                                    </dxl:Properties>
-                                                    <dxl:ProjList>
-                                                      <dxl:ProjElem ColId="108" Alias="ss_store_sk">
-                                                        <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                      </dxl:ProjElem>
-                                                      <dxl:ProjElem ColId="123" Alias="ss_net_profit">
-                                                        <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                      </dxl:ProjElem>
-                                                    </dxl:ProjList>
-                                                    <dxl:Filter/>
-                                                    <dxl:JoinFilter/>
-                                                    <dxl:HashCondList>
-                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                                        <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                                        <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                      </dxl:Comparison>
-                                                    </dxl:HashCondList>
-                                                    <dxl:TableScan>
-                                                      <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="2572.718951" Rows="737331968.000000" Width="16"/>
-                                                      </dxl:Properties>
-                                                      <dxl:ProjList>
-                                                        <dxl:ProjElem ColId="101" Alias="ss_sold_date_sk">
-                                                          <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                        <dxl:ProjElem ColId="108" Alias="ss_store_sk">
-                                                          <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                        <dxl:ProjElem ColId="123" Alias="ss_net_profit">
-                                                          <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                        </dxl:ProjElem>
-                                                      </dxl:ProjList>
-                                                      <dxl:Filter/>
-                                                      <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
-                                                        <dxl:Columns>
-                                                          <dxl:Column ColId="101" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="102" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="103" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="104" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="105" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="106" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="107" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="108" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="109" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="110" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
-                                                          <dxl:Column ColId="111" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="112" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="113" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="114" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="115" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="116" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="117" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="118" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="119" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="120" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="121" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="122" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="123" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="124" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                                          <dxl:Column ColId="125" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="126" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="127" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="128" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="129" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                                          <dxl:Column ColId="130" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                                        </dxl:Columns>
-                                                      </dxl:TableDescriptor>
-                                                    </dxl:TableScan>
-                                                    <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                                      <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="431.265982" Rows="13414.324949" Width="4"/>
-                                                      </dxl:Properties>
-                                                      <dxl:ProjList>
-                                                        <dxl:ProjElem ColId="167" Alias="d_date_sk">
-                                                          <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                      </dxl:ProjList>
-                                                      <dxl:Filter/>
-                                                      <dxl:SortingColumnList/>
-                                                      <dxl:TableScan>
-                                                        <dxl:Properties>
-                                                          <dxl:Cost StartupCost="0" TotalCost="431.261117" Rows="419.197655" Width="4"/>
-                                                        </dxl:Properties>
-                                                        <dxl:ProjList>
-                                                          <dxl:ProjElem ColId="167" Alias="d_date_sk">
-                                                            <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                          </dxl:ProjElem>
-                                                        </dxl:ProjList>
-                                                        <dxl:Filter>
-                                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                                            <dxl:Ident ColId="173" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2000"/>
-                                                          </dxl:Comparison>
-                                                        </dxl:Filter>
-                                                        <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
-                                                          <dxl:Columns>
-                                                            <dxl:Column ColId="167" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="168" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                                                            <dxl:Column ColId="169" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
-                                                            <dxl:Column ColId="170" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="171" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="172" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="173" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="174" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="175" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="176" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="177" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="178" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="179" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="180" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="181" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
-                                                            <dxl:Column ColId="182" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
-                                                            <dxl:Column ColId="183" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="184" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="185" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="186" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="187" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="188" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="189" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="190" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="191" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="192" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="193" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="194" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="195" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                                            <dxl:Column ColId="196" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                                            <dxl:Column ColId="197" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                                            <dxl:Column ColId="198" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                                            <dxl:Column ColId="199" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                                            <dxl:Column ColId="200" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                                            <dxl:Column ColId="201" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                                          </dxl:Columns>
-                                                        </dxl:TableDescriptor>
-                                                      </dxl:TableScan>
-                                                    </dxl:BroadcastMotion>
-                                                  </dxl:HashJoin>
-                                                  <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                                    <dxl:Properties>
-                                                      <dxl:Cost StartupCost="0" TotalCost="431.008506" Rows="10368.000000" Width="7"/>
-                                                    </dxl:Properties>
-                                                    <dxl:ProjList>
-                                                      <dxl:ProjElem ColId="131" Alias="s_store_sk">
-                                                        <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                                      </dxl:ProjElem>
-                                                      <dxl:ProjElem ColId="155" Alias="s_state">
-                                                        <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                      </dxl:ProjElem>
-                                                    </dxl:ProjList>
-                                                    <dxl:Filter/>
-                                                    <dxl:SortingColumnList/>
-                                                    <dxl:TableScan>
-                                                      <dxl:Properties>
-                                                        <dxl:Cost StartupCost="0" TotalCost="431.001793" Rows="324.000000" Width="7"/>
-                                                      </dxl:Properties>
-                                                      <dxl:ProjList>
-                                                        <dxl:ProjElem ColId="131" Alias="s_store_sk">
-                                                          <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                                        </dxl:ProjElem>
-                                                        <dxl:ProjElem ColId="155" Alias="s_state">
-                                                          <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                        </dxl:ProjElem>
-                                                      </dxl:ProjList>
-                                                      <dxl:Filter/>
-                                                      <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
-                                                        <dxl:Columns>
-                                                          <dxl:Column ColId="131" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="132" Attno="2" ColName="s_store_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                                                          <dxl:Column ColId="133" Attno="3" ColName="s_rec_start_date" TypeMdid="0.1082.1.0"/>
-                                                          <dxl:Column ColId="134" Attno="4" ColName="s_rec_end_date" TypeMdid="0.1082.1.0"/>
-                                                          <dxl:Column ColId="135" Attno="5" ColName="s_closed_date_sk" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="136" Attno="6" ColName="s_store_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                                          <dxl:Column ColId="137" Attno="7" ColName="s_number_employees" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="138" Attno="8" ColName="s_floor_space" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="139" Attno="9" ColName="s_hours" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                                                          <dxl:Column ColId="140" Attno="10" ColName="s_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                                                          <dxl:Column ColId="141" Attno="11" ColName="s_market_id" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="142" Attno="12" ColName="s_geography_class" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                                                          <dxl:Column ColId="143" Attno="13" ColName="s_market_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                                                          <dxl:Column ColId="144" Attno="14" ColName="s_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                                                          <dxl:Column ColId="145" Attno="15" ColName="s_division_id" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="146" Attno="16" ColName="s_division_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                                          <dxl:Column ColId="147" Attno="17" ColName="s_company_id" TypeMdid="0.23.1.0"/>
-                                                          <dxl:Column ColId="148" Attno="18" ColName="s_company_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                                          <dxl:Column ColId="149" Attno="19" ColName="s_street_number" TypeMdid="0.1043.1.0" ColWidth="10"/>
-                                                          <dxl:Column ColId="150" Attno="20" ColName="s_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                                                          <dxl:Column ColId="151" Attno="21" ColName="s_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
-                                                          <dxl:Column ColId="152" Attno="22" ColName="s_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                                                          <dxl:Column ColId="153" Attno="23" ColName="s_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                                                          <dxl:Column ColId="154" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
-                                                          <dxl:Column ColId="155" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                                                          <dxl:Column ColId="156" Attno="26" ColName="s_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                                                          <dxl:Column ColId="157" Attno="27" ColName="s_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                          <dxl:Column ColId="158" Attno="28" ColName="s_gmt_offset" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="159" Attno="29" ColName="s_tax_precentage" TypeMdid="0.1700.1.0"/>
-                                                          <dxl:Column ColId="160" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                                          <dxl:Column ColId="161" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="162" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="163" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                                          <dxl:Column ColId="164" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                                          <dxl:Column ColId="165" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                                          <dxl:Column ColId="166" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                                        </dxl:Columns>
-                                                      </dxl:TableDescriptor>
-                                                    </dxl:TableScan>
-                                                  </dxl:BroadcastMotion>
-                                                </dxl:HashJoin>
-                                              </dxl:Aggregate>
-                                            </dxl:Result>
-                                          </dxl:RedistributeMotion>
-                                        </dxl:Sort>
-                                      </dxl:Aggregate>
-                                    </dxl:Sort>
-                                    <dxl:WindowKeyList>
-                                      <dxl:WindowKey>
-                                        <dxl:SortingColumnList>
-                                          <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-                                        </dxl:SortingColumnList>
-                                      </dxl:WindowKey>
-                                    </dxl:WindowKeyList>
-                                  </dxl:Window>
-                                </dxl:Result>
-                              </dxl:BroadcastMotion>
-                            </dxl:HashJoin>
-                          </dxl:BroadcastMotion>
-                        </dxl:HashJoin>
-                      </dxl:Aggregate>
-                    </dxl:Result>
-                  </dxl:RedistributeMotion>
-                </dxl:Sort>
-              </dxl:Aggregate>
-            </dxl:Result>
-          </dxl:CTEProducer>
-          <dxl:Result>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000552" Rows="20.062500" Width="44"/>
+              <dxl:Cost StartupCost="0" TotalCost="21949.270719" Rows="20.062500" Width="44"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="842" Alias="sum">
@@ -15812,26 +14941,22 @@ with results as
                 <dxl:Ident ColId="1478" ColName="rank" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1479" Alias="?column?">
-                <dxl:If TypeMdid="0.1042.1.0">
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                  </dxl:Comparison>
-                  <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
-                </dxl:If>
+                <dxl:Ident ColId="1479" ColName="?column?" TypeMdid="0.1042.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Window PartitionColumns="847,1477">
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="847" SortOperatorMdid="0.521.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="1479" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="1478" SortOperatorMdid="0.412.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000524" Rows="20.062500" Width="31"/>
+                <dxl:Cost StartupCost="0" TotalCost="21949.270719" Rows="20.062500" Width="44"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="1478" Alias="rank">
-                  <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="842" Alias="sum">
                   <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
                 </dxl:ProjElem>
@@ -15844,14 +14969,831 @@ with results as
                 <dxl:ProjElem ColId="847" Alias="lochierarchy">
                   <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="1477" Alias="?column?">
-                  <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
+                <dxl:ProjElem ColId="1478" Alias="rank">
+                  <dxl:Ident ColId="1478" ColName="rank" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1479" Alias="?column?">
+                  <dxl:Ident ColId="1479" ColName="?column?" TypeMdid="0.1042.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:CTEProducer CTEId="0" Columns="204,89,88,205,206">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
+                  <dxl:Cost StartupCost="0" TotalCost="20656.270139" Rows="14.062500" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="204" Alias="sum">
+                    <dxl:Ident ColId="204" ColName="sum" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="89" Alias="s_state">
+                    <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="88" Alias="s_county">
+                    <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="205" Alias="gstate">
+                    <dxl:Ident ColId="205" ColName="gstate" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="206" Alias="g_county">
+                    <dxl:Ident ColId="206" ColName="g_county" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="20656.270139" Rows="14.062500" Width="32"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="204" Alias="sum">
+                      <dxl:Ident ColId="204" ColName="sum" TypeMdid="0.1700.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="89" Alias="s_state">
+                      <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="88" Alias="s_county">
+                      <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="205" Alias="gstate">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="206" Alias="g_county">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="20656.270125" Rows="14.062500" Width="26"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="89"/>
+                      <dxl:GroupingColumn ColId="88"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="204" Alias="sum">
+                        <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                          <dxl:Ident ColId="1503" ColName="ColRef_1503" TypeMdid="0.1700.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="88" Alias="s_county">
+                        <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="89" Alias="s_state">
+                        <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="20656.270092" Rows="14.062500" Width="26"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="88" Alias="s_county">
+                          <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="89" Alias="s_state">
+                          <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1503" Alias="ColRef_1503">
+                          <dxl:Ident ColId="1503" ColName="ColRef_1503" TypeMdid="0.1700.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="89" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="88" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="20656.270092" Rows="14.062500" Width="26"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="88" Alias="s_county">
+                            <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="89" Alias="s_state">
+                            <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1503" Alias="ColRef_1503">
+                            <dxl:Ident ColId="1503" ColName="ColRef_1503" TypeMdid="0.1700.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr TypeMdid="0.1042.1.0">
+                            <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                          </dxl:HashExpr>
+                          <dxl:HashExpr TypeMdid="0.1043.1.0">
+                            <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="20656.270045" Rows="14.062500" Width="26"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="88" Alias="s_county">
+                              <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="89" Alias="s_state">
+                              <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1503" Alias="ColRef_1503">
+                              <dxl:Ident ColId="1503" ColName="ColRef_1503" TypeMdid="0.1700.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="20656.270045" Rows="14.062500" Width="26"/>
+                            </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="89"/>
+                              <dxl:GroupingColumn ColId="88"/>
+                            </dxl:GroupingColumns>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="1503" Alias="ColRef_1503">
+                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                  <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                </dxl:AggFunc>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="88" Alias="s_county">
+                                <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="89" Alias="s_state">
+                                <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:HashJoin JoinType="Inner">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="20119.823355" Rows="67819601.064540" Width="26"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="22" Alias="ss_net_profit">
+                                  <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="88" Alias="s_county">
+                                  <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="89" Alias="s_state">
+                                  <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:JoinFilter/>
+                              <dxl:HashCondList>
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                  <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:HashCondList>
+                              <dxl:HashJoin JoinType="Inner">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="8141.468548" Rows="169549002.661349" Width="12"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="7" Alias="ss_store_sk">
+                                    <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="22" Alias="ss_net_profit">
+                                    <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:JoinFilter/>
+                                <dxl:HashCondList>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:HashCondList>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="2572.718951" Rows="737331968.000000" Width="16"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
+                                      <dxl:Ident ColId="0" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="7" Alias="ss_store_sk">
+                                      <dxl:Ident ColId="7" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="22" Alias="ss_net_profit">
+                                      <dxl:Ident ColId="22" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="0" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="1" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="2" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="3" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="4" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="5" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="6" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="7" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="8" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="9" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
+                                      <dxl:Column ColId="10" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="11" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="12" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="13" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="14" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="15" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="16" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="17" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="18" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="19" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="20" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="21" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="22" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                      <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                                <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.265982" Rows="13414.324949" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="30" Alias="d_date_sk">
+                                      <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.261117" Rows="419.197655" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="30" Alias="d_date_sk">
+                                        <dxl:Ident ColId="30" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="36" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2000"/>
+                                      </dxl:Comparison>
+                                    </dxl:Filter>
+                                    <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="30" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="31" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                                        <dxl:Column ColId="32" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
+                                        <dxl:Column ColId="33" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="34" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="35" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="36" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="37" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="38" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="39" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="40" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="41" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="42" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="43" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="44" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
+                                        <dxl:Column ColId="45" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="46" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="47" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="48" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="49" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="50" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="51" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="52" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="53" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="54" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="55" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="56" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="57" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                        <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        <dxl:Column ColId="59" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="60" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="61" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="62" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                        <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:BroadcastMotion>
+                              </dxl:HashJoin>
+                              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="10825.831361" Rows="4147.200000" Width="22"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="65" Alias="s_store_sk">
+                                    <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="88" Alias="s_county">
+                                    <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="89" Alias="s_state">
+                                    <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:HashJoin JoinType="In">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="10825.823088" Rows="129.600000" Width="22"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="65" Alias="s_store_sk">
+                                      <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="88" Alias="s_county">
+                                      <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="89" Alias="s_state">
+                                      <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:JoinFilter/>
+                                  <dxl:HashCondList>
+                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                                      <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                      <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                    </dxl:Comparison>
+                                  </dxl:HashCondList>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.001793" Rows="324.000000" Width="22"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="65" Alias="s_store_sk">
+                                        <dxl:Ident ColId="65" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="88" Alias="s_county">
+                                        <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="89" Alias="s_state">
+                                        <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="65" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="66" Attno="2" ColName="s_store_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                                        <dxl:Column ColId="67" Attno="3" ColName="s_rec_start_date" TypeMdid="0.1082.1.0"/>
+                                        <dxl:Column ColId="68" Attno="4" ColName="s_rec_end_date" TypeMdid="0.1082.1.0"/>
+                                        <dxl:Column ColId="69" Attno="5" ColName="s_closed_date_sk" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="70" Attno="6" ColName="s_store_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                                        <dxl:Column ColId="71" Attno="7" ColName="s_number_employees" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="72" Attno="8" ColName="s_floor_space" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="73" Attno="9" ColName="s_hours" TypeMdid="0.1042.1.0" ColWidth="20"/>
+                                        <dxl:Column ColId="74" Attno="10" ColName="s_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
+                                        <dxl:Column ColId="75" Attno="11" ColName="s_market_id" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="76" Attno="12" ColName="s_geography_class" TypeMdid="0.1043.1.0" ColWidth="100"/>
+                                        <dxl:Column ColId="77" Attno="13" ColName="s_market_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
+                                        <dxl:Column ColId="78" Attno="14" ColName="s_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
+                                        <dxl:Column ColId="79" Attno="15" ColName="s_division_id" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="80" Attno="16" ColName="s_division_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                                        <dxl:Column ColId="81" Attno="17" ColName="s_company_id" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="82" Attno="18" ColName="s_company_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                                        <dxl:Column ColId="83" Attno="19" ColName="s_street_number" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                                        <dxl:Column ColId="84" Attno="20" ColName="s_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                        <dxl:Column ColId="85" Attno="21" ColName="s_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
+                                        <dxl:Column ColId="86" Attno="22" ColName="s_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                                        <dxl:Column ColId="87" Attno="23" ColName="s_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                        <dxl:Column ColId="88" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                        <dxl:Column ColId="89" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                                        <dxl:Column ColId="90" Attno="26" ColName="s_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                                        <dxl:Column ColId="91" Attno="27" ColName="s_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
+                                        <dxl:Column ColId="92" Attno="28" ColName="s_gmt_offset" TypeMdid="0.1700.1.0"/>
+                                        <dxl:Column ColId="93" Attno="29" ColName="s_tax_precentage" TypeMdid="0.1700.1.0"/>
+                                        <dxl:Column ColId="94" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        <dxl:Column ColId="95" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="96" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="97" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                        <dxl:Column ColId="98" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                        <dxl:Column ColId="99" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                        <dxl:Column ColId="100" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="10394.818337" Rows="64.000000" Width="3"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="155" Alias="s_state">
+                                        <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="10394.818059" Rows="2.000000" Width="3"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="155" Alias="s_state">
+                                          <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter>
+                                        <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.420.1.0">
+                                          <dxl:Ident ColId="203" ColName="ranking" TypeMdid="0.20.1.0"/>
+                                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
+                                        </dxl:Comparison>
+                                      </dxl:Filter>
+                                      <dxl:OneTimeFilter/>
+                                      <dxl:Window PartitionColumns="155">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="10394.818026" Rows="5.000000" Width="11"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="203" Alias="ranking">
+                                            <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="155" Alias="s_state">
+                                            <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="202" Alias="att_2">
+                                            <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:Sort SortDiscardDuplicates="false">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="10394.818015" Rows="5.000000" Width="11"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="202" Alias="att_2">
+                                              <dxl:Ident ColId="202" ColName="att_2" TypeMdid="0.1700.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="155" Alias="s_state">
+                                              <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:SortingColumnList>
+                                            <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                            <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+                                          </dxl:SortingColumnList>
+                                          <dxl:LimitCount/>
+                                          <dxl:LimitOffset/>
+                                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="10394.818015" Rows="5.000000" Width="11"/>
+                                            </dxl:Properties>
+                                            <dxl:GroupingColumns>
+                                              <dxl:GroupingColumn ColId="155"/>
+                                            </dxl:GroupingColumns>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="202" Alias="att_2">
+                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                                                  <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                </dxl:AggFunc>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="155" Alias="s_state">
+                                                <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:Sort SortDiscardDuplicates="false">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="10394.817997" Rows="5.000000" Width="11"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="155" Alias="s_state">
+                                                  <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                  <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:SortingColumnList>
+                                                <dxl:SortingColumn ColId="155" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                              </dxl:SortingColumnList>
+                                              <dxl:LimitCount/>
+                                              <dxl:LimitOffset/>
+                                              <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="10394.817997" Rows="5.000000" Width="11"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="155" Alias="s_state">
+                                                    <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                    <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:SortingColumnList/>
+                                                <dxl:HashExprList>
+                                                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                                    <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                  </dxl:HashExpr>
+                                                </dxl:HashExprList>
+                                                <dxl:Result>
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="10394.817985" Rows="5.000000" Width="11"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="155" Alias="s_state">
+                                                      <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                      <dxl:Ident ColId="1486" ColName="ColRef_1486" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:OneTimeFilter/>
+                                                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="10394.817985" Rows="5.000000" Width="11"/>
+                                                    </dxl:Properties>
+                                                    <dxl:GroupingColumns>
+                                                      <dxl:GroupingColumn ColId="155"/>
+                                                    </dxl:GroupingColumns>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="1486" Alias="ColRef_1486">
+                                                        <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                                          <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                        </dxl:AggFunc>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="155" Alias="s_state">
+                                                        <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:HashJoin JoinType="Inner">
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="9736.133355" Rows="169549002.661349" Width="11"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                          <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="155" Alias="s_state">
+                                                          <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:JoinFilter/>
+                                                      <dxl:HashCondList>
+                                                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                          <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                          <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                        </dxl:Comparison>
+                                                      </dxl:HashCondList>
+                                                      <dxl:HashJoin JoinType="Inner">
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="8141.468548" Rows="169549002.661349" Width="12"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="108" Alias="ss_store_sk">
+                                                            <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                            <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:JoinFilter/>
+                                                        <dxl:HashCondList>
+                                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                            <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                          </dxl:Comparison>
+                                                        </dxl:HashCondList>
+                                                        <dxl:TableScan>
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="2572.718951" Rows="737331968.000000" Width="16"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="101" Alias="ss_sold_date_sk">
+                                                              <dxl:Ident ColId="101" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="108" Alias="ss_store_sk">
+                                                              <dxl:Ident ColId="108" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="123" Alias="ss_net_profit">
+                                                              <dxl:Ident ColId="123" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:TableDescriptor Mdid="0.8403512.1.1" TableName="store_sales">
+                                                            <dxl:Columns>
+                                                              <dxl:Column ColId="101" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="102" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="103" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="104" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="105" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="106" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="107" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="108" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="109" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="110" Attno="10" ColName="ss_ticket_number" TypeMdid="0.20.1.0"/>
+                                                              <dxl:Column ColId="111" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="112" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="113" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="114" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="115" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="116" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="117" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="118" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="119" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="120" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="121" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="122" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="123" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="124" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                              <dxl:Column ColId="125" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="126" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="127" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="128" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="129" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                              <dxl:Column ColId="130" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                          </dxl:TableDescriptor>
+                                                        </dxl:TableScan>
+                                                        <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.265982" Rows="13414.324949" Width="4"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="167" Alias="d_date_sk">
+                                                              <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:SortingColumnList/>
+                                                          <dxl:TableScan>
+                                                            <dxl:Properties>
+                                                              <dxl:Cost StartupCost="0" TotalCost="431.261117" Rows="419.197655" Width="4"/>
+                                                            </dxl:Properties>
+                                                            <dxl:ProjList>
+                                                              <dxl:ProjElem ColId="167" Alias="d_date_sk">
+                                                                <dxl:Ident ColId="167" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                              </dxl:ProjElem>
+                                                            </dxl:ProjList>
+                                                            <dxl:Filter>
+                                                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                                <dxl:Ident ColId="173" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2000"/>
+                                                              </dxl:Comparison>
+                                                            </dxl:Filter>
+                                                            <dxl:TableDescriptor Mdid="0.8402992.1.1" TableName="date_dim">
+                                                              <dxl:Columns>
+                                                                <dxl:Column ColId="167" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="168" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                                                                <dxl:Column ColId="169" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
+                                                                <dxl:Column ColId="170" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="171" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="172" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="173" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="174" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="175" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="176" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="177" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="178" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="179" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="180" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="181" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
+                                                                <dxl:Column ColId="182" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
+                                                                <dxl:Column ColId="183" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="184" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="185" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="186" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="187" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="188" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="189" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+                                                                <dxl:Column ColId="190" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="191" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="192" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="193" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="194" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                                                <dxl:Column ColId="195" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                                <dxl:Column ColId="196" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                                <dxl:Column ColId="197" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                                <dxl:Column ColId="198" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                                <dxl:Column ColId="199" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                                <dxl:Column ColId="200" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                                <dxl:Column ColId="201" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                              </dxl:Columns>
+                                                            </dxl:TableDescriptor>
+                                                          </dxl:TableScan>
+                                                        </dxl:BroadcastMotion>
+                                                      </dxl:HashJoin>
+                                                      <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="431.008506" Rows="10368.000000" Width="7"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="131" Alias="s_store_sk">
+                                                            <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="155" Alias="s_state">
+                                                            <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:SortingColumnList/>
+                                                        <dxl:TableScan>
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.001793" Rows="324.000000" Width="7"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="131" Alias="s_store_sk">
+                                                              <dxl:Ident ColId="131" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="155" Alias="s_state">
+                                                              <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:TableDescriptor Mdid="0.8403408.1.1" TableName="store">
+                                                            <dxl:Columns>
+                                                              <dxl:Column ColId="131" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="132" Attno="2" ColName="s_store_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                                                              <dxl:Column ColId="133" Attno="3" ColName="s_rec_start_date" TypeMdid="0.1082.1.0"/>
+                                                              <dxl:Column ColId="134" Attno="4" ColName="s_rec_end_date" TypeMdid="0.1082.1.0"/>
+                                                              <dxl:Column ColId="135" Attno="5" ColName="s_closed_date_sk" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="136" Attno="6" ColName="s_store_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                                                              <dxl:Column ColId="137" Attno="7" ColName="s_number_employees" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="138" Attno="8" ColName="s_floor_space" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="139" Attno="9" ColName="s_hours" TypeMdid="0.1042.1.0" ColWidth="20"/>
+                                                              <dxl:Column ColId="140" Attno="10" ColName="s_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
+                                                              <dxl:Column ColId="141" Attno="11" ColName="s_market_id" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="142" Attno="12" ColName="s_geography_class" TypeMdid="0.1043.1.0" ColWidth="100"/>
+                                                              <dxl:Column ColId="143" Attno="13" ColName="s_market_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
+                                                              <dxl:Column ColId="144" Attno="14" ColName="s_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
+                                                              <dxl:Column ColId="145" Attno="15" ColName="s_division_id" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="146" Attno="16" ColName="s_division_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                                                              <dxl:Column ColId="147" Attno="17" ColName="s_company_id" TypeMdid="0.23.1.0"/>
+                                                              <dxl:Column ColId="148" Attno="18" ColName="s_company_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                                                              <dxl:Column ColId="149" Attno="19" ColName="s_street_number" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                                                              <dxl:Column ColId="150" Attno="20" ColName="s_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                                              <dxl:Column ColId="151" Attno="21" ColName="s_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
+                                                              <dxl:Column ColId="152" Attno="22" ColName="s_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                                                              <dxl:Column ColId="153" Attno="23" ColName="s_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                                              <dxl:Column ColId="154" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                                              <dxl:Column ColId="155" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                                                              <dxl:Column ColId="156" Attno="26" ColName="s_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                                                              <dxl:Column ColId="157" Attno="27" ColName="s_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
+                                                              <dxl:Column ColId="158" Attno="28" ColName="s_gmt_offset" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="159" Attno="29" ColName="s_tax_precentage" TypeMdid="0.1700.1.0"/>
+                                                              <dxl:Column ColId="160" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                              <dxl:Column ColId="161" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="162" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="163" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                              <dxl:Column ColId="164" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                              <dxl:Column ColId="165" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                              <dxl:Column ColId="166" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                          </dxl:TableDescriptor>
+                                                        </dxl:TableScan>
+                                                      </dxl:BroadcastMotion>
+                                                    </dxl:HashJoin>
+                                                  </dxl:Aggregate>
+                                                </dxl:Result>
+                                              </dxl:RedistributeMotion>
+                                            </dxl:Sort>
+                                          </dxl:Aggregate>
+                                        </dxl:Sort>
+                                        <dxl:WindowKeyList>
+                                          <dxl:WindowKey>
+                                            <dxl:SortingColumnList>
+                                              <dxl:SortingColumn ColId="202" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+                                            </dxl:SortingColumnList>
+                                          </dxl:WindowKey>
+                                        </dxl:WindowKeyList>
+                                      </dxl:Window>
+                                    </dxl:Result>
+                                  </dxl:BroadcastMotion>
+                                </dxl:HashJoin>
+                              </dxl:BroadcastMotion>
+                            </dxl:HashJoin>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:CTEProducer>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000552" Rows="20.062500" Width="44"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="842" Alias="sum">
@@ -15866,23 +15808,30 @@ with results as
                   <dxl:ProjElem ColId="847" Alias="lochierarchy">
                     <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1477" Alias="?column?">
-                    <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
+                  <dxl:ProjElem ColId="1478" Alias="rank">
+                    <dxl:Ident ColId="1478" ColName="rank" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1479" Alias="?column?">
+                    <dxl:If TypeMdid="0.1042.1.0">
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                      </dxl:Comparison>
+                      <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                    </dxl:If>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  <dxl:SortingColumn ColId="1477" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                <dxl:OneTimeFilter/>
+                <dxl:Window PartitionColumns="847,1477">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000524" Rows="20.062500" Width="31"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="1478" Alias="rank">
+                      <dxl:WindowFunc Mdid="0.7001.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="842" Alias="sum">
                       <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
                     </dxl:ProjElem>
@@ -15900,18 +15849,9 @@ with results as
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
-                      <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.1042.1.0">
-                      <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
+                  <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="842" Alias="sum">
@@ -15931,22 +15871,18 @@ with results as
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="1477" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000505" Rows="20.062500" Width="31"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="1477" Alias="?column?">
-                          <dxl:If TypeMdid="0.1042.1.0">
-                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                              <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                            </dxl:Comparison>
-                            <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
-                          </dxl:If>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="842" Alias="sum">
                           <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
                         </dxl:ProjElem>
@@ -15959,21 +15895,24 @@ with results as
                         <dxl:ProjElem ColId="847" Alias="lochierarchy">
                           <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1477" Alias="?column?">
+                          <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
+                        </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                        <dxl:HashExpr TypeMdid="0.1042.1.0">
+                          <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.000424" Rows="20.062500" Width="34"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="842"/>
-                          <dxl:GroupingColumn ColId="843"/>
-                          <dxl:GroupingColumn ColId="844"/>
-                          <dxl:GroupingColumn ColId="845"/>
-                          <dxl:GroupingColumn ColId="846"/>
-                          <dxl:GroupingColumn ColId="847"/>
-                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="842" Alias="sum">
                             <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
@@ -15984,22 +15923,30 @@ with results as
                           <dxl:ProjElem ColId="844" Alias="s_county">
                             <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="846" Alias="g_county">
-                            <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
                           <dxl:ProjElem ColId="847" Alias="lochierarchy">
                             <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="845" Alias="g_state">
-                            <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="1477" Alias="?column?">
+                            <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:OneTimeFilter/>
+                        <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.000444" Rows="20.062500" Width="31"/>
                           </dxl:Properties>
                           <dxl:ProjList>
+                            <dxl:ProjElem ColId="1477" Alias="?column?">
+                              <dxl:If TypeMdid="0.1042.1.0">
+                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                  <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                </dxl:Comparison>
+                                <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                              </dxl:If>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="842" Alias="sum">
                               <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
                             </dxl:ProjElem>
@@ -16009,31 +15956,24 @@ with results as
                             <dxl:ProjElem ColId="844" Alias="s_county">
                               <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="845" Alias="g_state">
-                              <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="846" Alias="g_county">
-                              <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="847" Alias="lochierarchy">
                               <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="843" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="844" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="845" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="846" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:LimitCount/>
-                          <dxl:LimitOffset/>
-                          <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.000424" Rows="20.062500" Width="34"/>
                             </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="842"/>
+                              <dxl:GroupingColumn ColId="843"/>
+                              <dxl:GroupingColumn ColId="844"/>
+                              <dxl:GroupingColumn ColId="845"/>
+                              <dxl:GroupingColumn ColId="846"/>
+                              <dxl:GroupingColumn ColId="847"/>
+                            </dxl:GroupingColumns>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="842" Alias="sum">
                                 <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
@@ -16044,50 +15984,21 @@ with results as
                               <dxl:ProjElem ColId="844" Alias="s_county">
                                 <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="845" Alias="g_state">
-                                <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="846" Alias="g_county">
                                 <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="847" Alias="lochierarchy">
                                 <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
+                              <dxl:ProjElem ColId="845" Alias="g_state">
+                                <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.1700.1.0">
-                                <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
-                              </dxl:HashExpr>
-                              <dxl:HashExpr TypeMdid="0.1042.1.0">
-                                <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                              </dxl:HashExpr>
-                              <dxl:HashExpr TypeMdid="0.1043.1.0">
-                                <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                              </dxl:HashExpr>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
-                                <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
-                                <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
-                                <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
-                              </dxl:HashExpr>
-                            </dxl:HashExprList>
-                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                            <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1293.000289" Rows="20.062500" Width="38"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
                               </dxl:Properties>
-                              <dxl:GroupingColumns>
-                                <dxl:GroupingColumn ColId="842"/>
-                                <dxl:GroupingColumn ColId="843"/>
-                                <dxl:GroupingColumn ColId="844"/>
-                                <dxl:GroupingColumn ColId="845"/>
-                                <dxl:GroupingColumn ColId="846"/>
-                                <dxl:GroupingColumn ColId="847"/>
-                              </dxl:GroupingColumns>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="842" Alias="sum">
                                   <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
@@ -16109,9 +16020,19 @@ with results as
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:Sort SortDiscardDuplicates="false">
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="843" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="844" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="845" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="846" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="1293.000374" Rows="20.062500" Width="38"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="842" Alias="sum">
@@ -16134,20 +16055,39 @@ with results as
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:SortingColumnList>
-                                  <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                  <dxl:SortingColumn ColId="843" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                  <dxl:SortingColumn ColId="844" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                  <dxl:SortingColumn ColId="845" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                  <dxl:SortingColumn ColId="846" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                  <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                </dxl:SortingColumnList>
-                                <dxl:LimitCount/>
-                                <dxl:LimitOffset/>
-                                <dxl:Append IsTarget="false" IsZapped="false">
+                                <dxl:SortingColumnList/>
+                                <dxl:HashExprList>
+                                  <dxl:HashExpr TypeMdid="0.1700.1.0">
+                                    <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                    <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                                    <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                                    <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
+                                  </dxl:HashExpr>
+                                </dxl:HashExprList>
+                                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="1293.000289" Rows="20.062500" Width="38"/>
                                   </dxl:Properties>
+                                  <dxl:GroupingColumns>
+                                    <dxl:GroupingColumn ColId="842"/>
+                                    <dxl:GroupingColumn ColId="843"/>
+                                    <dxl:GroupingColumn ColId="844"/>
+                                    <dxl:GroupingColumn ColId="845"/>
+                                    <dxl:GroupingColumn ColId="846"/>
+                                    <dxl:GroupingColumn ColId="847"/>
+                                  </dxl:GroupingColumns>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="842" Alias="sum">
                                       <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
@@ -16169,9 +16109,9 @@ with results as
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:Result>
+                                  <dxl:Sort SortDiscardDuplicates="false">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="14.062500" Width="38"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="842" Alias="sum">
@@ -16184,20 +16124,29 @@ with results as
                                         <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                                       </dxl:ProjElem>
                                       <dxl:ProjElem ColId="845" Alias="g_state">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                        <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                       <dxl:ProjElem ColId="846" Alias="g_county">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                        <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                       <dxl:ProjElem ColId="847" Alias="lochierarchy">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                        <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:CTEConsumer CTEId="0" Columns="842,843,844,848,849">
+                                    <dxl:SortingColumnList>
+                                      <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="843" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="844" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="845" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="846" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                      <dxl:SortingColumn ColId="847" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    </dxl:SortingColumnList>
+                                    <dxl:LimitCount/>
+                                    <dxl:LimitOffset/>
+                                    <dxl:Append IsTarget="false" IsZapped="false">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="14.062500" Width="26"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="1293.000251" Rows="20.062500" Width="38"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="842" Alias="sum">
@@ -16209,99 +16158,113 @@ with results as
                                         <dxl:ProjElem ColId="844" Alias="s_county">
                                           <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                                         </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="848" Alias="gstate">
-                                          <dxl:Ident ColId="848" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                        <dxl:ProjElem ColId="845" Alias="g_state">
+                                          <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="849" Alias="g_county">
-                                          <dxl:Ident ColId="849" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                        <dxl:ProjElem ColId="846" Alias="g_county">
+                                          <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                    </dxl:CTEConsumer>
-                                  </dxl:Result>
-                                  <dxl:Result>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="5.000000" Width="31"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="1259" Alias="sum">
-                                        <dxl:Ident ColId="1259" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1053" Alias="s_state">
-                                        <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1260" Alias="s_county">
-                                        <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1261" Alias="g_state">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1262" Alias="g_county">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1263" Alias="lochierarchy">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="5.000000" Width="11"/>
-                                      </dxl:Properties>
-                                      <dxl:GroupingColumns>
-                                        <dxl:GroupingColumn ColId="1053"/>
-                                      </dxl:GroupingColumns>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="1259" Alias="sum">
-                                          <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                                            <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
-                                          </dxl:AggFunc>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="1053" Alias="s_state">
-                                          <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                        <dxl:ProjElem ColId="847" Alias="lochierarchy">
+                                          <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
-                                      <dxl:Sort SortDiscardDuplicates="false">
+                                      <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000101" Rows="14.062500" Width="38"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
-                                          <dxl:ProjElem ColId="1053" Alias="s_state">
-                                            <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                          <dxl:ProjElem ColId="842" Alias="sum">
+                                            <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
                                           </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
-                                            <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                          <dxl:ProjElem ColId="843" Alias="s_state">
+                                            <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="844" Alias="s_county">
+                                            <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="845" Alias="g_state">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="846" Alias="g_county">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="847" Alias="lochierarchy">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:SortingColumnList>
-                                          <dxl:SortingColumn ColId="1053" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                        </dxl:SortingColumnList>
-                                        <dxl:LimitCount/>
-                                        <dxl:LimitOffset/>
-                                        <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:CTEConsumer CTEId="0" Columns="842,843,844,848,849">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="14.062500" Width="26"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
+                                            <dxl:ProjElem ColId="842" Alias="sum">
+                                              <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="843" Alias="s_state">
+                                              <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="844" Alias="s_county">
+                                              <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="848" Alias="gstate">
+                                              <dxl:Ident ColId="848" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="849" Alias="g_county">
+                                              <dxl:Ident ColId="849" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                        </dxl:CTEConsumer>
+                                      </dxl:Result>
+                                      <dxl:Result>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="5.000000" Width="31"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="1259" Alias="sum">
+                                            <dxl:Ident ColId="1259" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1053" Alias="s_state">
+                                            <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1260" Alias="s_county">
+                                            <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1261" Alias="g_state">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1262" Alias="g_county">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1263" Alias="lochierarchy">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="5.000000" Width="11"/>
+                                          </dxl:Properties>
+                                          <dxl:GroupingColumns>
+                                            <dxl:GroupingColumn ColId="1053"/>
+                                          </dxl:GroupingColumns>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="1259" Alias="sum">
+                                              <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                                                <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                              </dxl:AggFunc>
+                                            </dxl:ProjElem>
                                             <dxl:ProjElem ColId="1053" Alias="s_state">
                                               <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                             </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
-                                              <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
-                                            </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
-                                          <dxl:SortingColumnList/>
-                                          <dxl:HashExprList>
-                                            <dxl:HashExpr TypeMdid="0.1042.1.0">
-                                              <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                            </dxl:HashExpr>
-                                          </dxl:HashExprList>
-                                          <dxl:Result>
+                                          <dxl:Sort SortDiscardDuplicates="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
                                               <dxl:ProjElem ColId="1053" Alias="s_state">
@@ -16312,205 +16275,242 @@ with results as
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:OneTimeFilter/>
-                                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                            <dxl:SortingColumnList>
+                                              <dxl:SortingColumn ColId="1053" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                            </dxl:SortingColumnList>
+                                            <dxl:LimitCount/>
+                                            <dxl:LimitOffset/>
+                                            <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="5.000000" Width="11"/>
                                               </dxl:Properties>
-                                              <dxl:GroupingColumns>
-                                                <dxl:GroupingColumn ColId="1053"/>
-                                              </dxl:GroupingColumns>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
-                                                  <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                                    <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                                  </dxl:AggFunc>
-                                                </dxl:ProjElem>
                                                 <dxl:ProjElem ColId="1053" Alias="s_state">
                                                   <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                 </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                  <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
+                                                </dxl:ProjElem>
                                               </dxl:ProjList>
                                               <dxl:Filter/>
-                                              <dxl:Sort SortDiscardDuplicates="false">
+                                              <dxl:SortingColumnList/>
+                                              <dxl:HashExprList>
+                                                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                                  <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                </dxl:HashExpr>
+                                              </dxl:HashExprList>
+                                              <dxl:Result>
                                                 <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="14.062500" Width="11"/>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
                                                 </dxl:Properties>
                                                 <dxl:ProjList>
-                                                  <dxl:ProjElem ColId="1052" Alias="sum">
-                                                    <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                                  </dxl:ProjElem>
                                                   <dxl:ProjElem ColId="1053" Alias="s_state">
                                                     <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                   </dxl:ProjElem>
-                                                  <dxl:ProjElem ColId="1054" Alias="s_county">
-                                                    <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                                  </dxl:ProjElem>
-                                                  <dxl:ProjElem ColId="1055" Alias="gstate">
-                                                    <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
-                                                  </dxl:ProjElem>
-                                                  <dxl:ProjElem ColId="1056" Alias="g_county">
-                                                    <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                  <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                    <dxl:Ident ColId="1481" ColName="ColRef_1481" TypeMdid="0.1700.1.0"/>
                                                   </dxl:ProjElem>
                                                 </dxl:ProjList>
                                                 <dxl:Filter/>
-                                                <dxl:SortingColumnList>
-                                                  <dxl:SortingColumn ColId="1053" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                                </dxl:SortingColumnList>
-                                                <dxl:LimitCount/>
-                                                <dxl:LimitOffset/>
-                                                <dxl:CTEConsumer CTEId="0" Columns="1052,1053,1054,1055,1056">
+                                                <dxl:OneTimeFilter/>
+                                                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                                                   <dxl:Properties>
-                                                    <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="14.062500" Width="11"/>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="5.000000" Width="11"/>
                                                   </dxl:Properties>
+                                                  <dxl:GroupingColumns>
+                                                    <dxl:GroupingColumn ColId="1053"/>
+                                                  </dxl:GroupingColumns>
                                                   <dxl:ProjList>
-                                                    <dxl:ProjElem ColId="1052" Alias="sum">
-                                                      <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                    <dxl:ProjElem ColId="1481" Alias="ColRef_1481">
+                                                      <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                                        <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                      </dxl:AggFunc>
                                                     </dxl:ProjElem>
                                                     <dxl:ProjElem ColId="1053" Alias="s_state">
                                                       <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                                     </dxl:ProjElem>
-                                                    <dxl:ProjElem ColId="1054" Alias="s_county">
-                                                      <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                                    </dxl:ProjElem>
-                                                    <dxl:ProjElem ColId="1055" Alias="gstate">
-                                                      <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
-                                                    </dxl:ProjElem>
-                                                    <dxl:ProjElem ColId="1056" Alias="g_county">
-                                                      <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
-                                                    </dxl:ProjElem>
                                                   </dxl:ProjList>
-                                                </dxl:CTEConsumer>
-                                              </dxl:Sort>
-                                            </dxl:Aggregate>
-                                          </dxl:Result>
-                                        </dxl:RedistributeMotion>
-                                      </dxl:Sort>
-                                    </dxl:Aggregate>
-                                  </dxl:Result>
-                                  <dxl:Result>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="36"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="1471" Alias="sum">
-                                        <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1472" Alias="s_state">
-                                        <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1473" Alias="s_county">
-                                        <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1474" Alias="g_state">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1475" Alias="g_county">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="1476" Alias="lochierarchy">
-                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="8"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="1471" Alias="sum">
-                                          <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:SortingColumnList/>
-                                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                                  <dxl:Filter/>
+                                                  <dxl:Sort SortDiscardDuplicates="false">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="14.062500" Width="11"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="1052" Alias="sum">
+                                                        <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1053" Alias="s_state">
+                                                        <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1054" Alias="s_county">
+                                                        <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1055" Alias="gstate">
+                                                        <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="1056" Alias="g_county">
+                                                        <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:SortingColumnList>
+                                                      <dxl:SortingColumn ColId="1053" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                    </dxl:SortingColumnList>
+                                                    <dxl:LimitCount/>
+                                                    <dxl:LimitOffset/>
+                                                    <dxl:CTEConsumer CTEId="0" Columns="1052,1053,1054,1055,1056">
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="14.062500" Width="11"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="1052" Alias="sum">
+                                                          <dxl:Ident ColId="1052" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1053" Alias="s_state">
+                                                          <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1054" Alias="s_county">
+                                                          <dxl:Ident ColId="1054" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1055" Alias="gstate">
+                                                          <dxl:Ident ColId="1055" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="1056" Alias="g_county">
+                                                          <dxl:Ident ColId="1056" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                    </dxl:CTEConsumer>
+                                                  </dxl:Sort>
+                                                </dxl:Aggregate>
+                                              </dxl:Result>
+                                            </dxl:RedistributeMotion>
+                                          </dxl:Sort>
+                                        </dxl:Aggregate>
+                                      </dxl:Result>
+                                      <dxl:Result>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000048" Rows="1.000000" Width="36"/>
                                         </dxl:Properties>
-                                        <dxl:GroupingColumns/>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="1471" Alias="sum">
-                                            <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
-                                              <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
-                                            </dxl:AggFunc>
+                                            <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1472" Alias="s_state">
+                                            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1473" Alias="s_county">
+                                            <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1474" Alias="g_state">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1475" Alias="g_county">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1476" Alias="lochierarchy">
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
                                         <dxl:Filter/>
-                                        <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
+                                        <dxl:OneTimeFilter/>
+                                        <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31">
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="8"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
-                                            <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
-                                              <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
+                                            <dxl:ProjElem ColId="1471" Alias="sum">
+                                              <dxl:Ident ColId="1471" ColName="sum" TypeMdid="0.1700.1.0"/>
                                             </dxl:ProjElem>
                                           </dxl:ProjList>
                                           <dxl:Filter/>
                                           <dxl:SortingColumnList/>
                                           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="8"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="8"/>
                                             </dxl:Properties>
                                             <dxl:GroupingColumns/>
                                             <dxl:ProjList>
-                                              <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
-                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
-                                                  <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                              <dxl:ProjElem ColId="1471" Alias="sum">
+                                                <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                                                  <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
                                                 </dxl:AggFunc>
                                               </dxl:ProjElem>
                                             </dxl:ProjList>
                                             <dxl:Filter/>
-                                            <dxl:CTEConsumer CTEId="0" Columns="1264,1265,1266,1267,1268">
+                                            <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" OutputSegments="-1">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="14.062500" Width="8"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
-                                                <dxl:ProjElem ColId="1264" Alias="sum">
-                                                  <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1265" Alias="s_state">
-                                                  <dxl:Ident ColId="1265" ColName="s_state" TypeMdid="0.1042.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1266" Alias="s_county">
-                                                  <dxl:Ident ColId="1266" ColName="s_county" TypeMdid="0.1043.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1267" Alias="gstate">
-                                                  <dxl:Ident ColId="1267" ColName="gstate" TypeMdid="0.23.1.0"/>
-                                                </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="1268" Alias="g_county">
-                                                  <dxl:Ident ColId="1268" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
+                                                  <dxl:Ident ColId="1480" ColName="ColRef_1480" TypeMdid="0.1700.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
-                                            </dxl:CTEConsumer>
+                                              <dxl:Filter/>
+                                              <dxl:SortingColumnList/>
+                                              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="8"/>
+                                                </dxl:Properties>
+                                                <dxl:GroupingColumns/>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="1480" Alias="ColRef_1480">
+                                                    <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                                                      <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:AggFunc>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:CTEConsumer CTEId="0" Columns="1264,1265,1266,1267,1268">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="14.062500" Width="8"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="1264" Alias="sum">
+                                                      <dxl:Ident ColId="1264" ColName="sum" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1265" Alias="s_state">
+                                                      <dxl:Ident ColId="1265" ColName="s_state" TypeMdid="0.1042.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1266" Alias="s_county">
+                                                      <dxl:Ident ColId="1266" ColName="s_county" TypeMdid="0.1043.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1267" Alias="gstate">
+                                                      <dxl:Ident ColId="1267" ColName="gstate" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1268" Alias="g_county">
+                                                      <dxl:Ident ColId="1268" ColName="g_county" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                </dxl:CTEConsumer>
+                                              </dxl:Aggregate>
+                                            </dxl:GatherMotion>
                                           </dxl:Aggregate>
-                                        </dxl:GatherMotion>
-                                      </dxl:Aggregate>
-                                    </dxl:RandomMotion>
-                                  </dxl:Result>
-                                </dxl:Append>
-                              </dxl:Sort>
-                            </dxl:Aggregate>
-                          </dxl:RedistributeMotion>
-                        </dxl:Sort>
-                      </dxl:Aggregate>
-                    </dxl:Result>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
-              <dxl:WindowKeyList>
-                <dxl:WindowKey>
-                  <dxl:SortingColumnList>
-                    <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
-                  </dxl:SortingColumnList>
-                </dxl:WindowKey>
-              </dxl:WindowKeyList>
-            </dxl:Window>
-          </dxl:Result>
-        </dxl:Sequence>
-      </dxl:Sort>
-    </dxl:GatherMotion>
-  </dxl:Result>
-</dxl:Plan>
+                                        </dxl:RandomMotion>
+                                      </dxl:Result>
+                                    </dxl:Append>
+                                  </dxl:Sort>
+                                </dxl:Aggregate>
+                              </dxl:RedistributeMotion>
+                            </dxl:Sort>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                      </dxl:Result>
+                    </dxl:RedistributeMotion>
+                  </dxl:Sort>
+                  <dxl:WindowKeyList>
+                    <dxl:WindowKey>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="842" SortOperatorMdid="0.1756.1.0" SortOperatorName="&gt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                    </dxl:WindowKey>
+                  </dxl:WindowKeyList>
+                </dxl:Window>
+              </dxl:Result>
+            </dxl:Sequence>
+          </dxl:Sort>
+        </dxl:GatherMotion>
+      </dxl:Result>
+    </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/data/dxl/minidump/Union-OuterRefs-Casting-Output.mdp
+++ b/data/dxl/minidump/Union-OuterRefs-Casting-Output.mdp
@@ -392,7 +392,7 @@ select * from x2 where a in (select a from y union select 1::int8);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="48">
+	<dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="173.419434" Rows="10.000000" Width="2"/>

--- a/data/dxl/minidump/Union-OuterRefs-Output.mdp
+++ b/data/dxl/minidump/Union-OuterRefs-Output.mdp
@@ -373,7 +373,7 @@ select * from x where a in (select a from y union select 1);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="48">
+	<dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="328.122559" Rows="10.000000" Width="4"/>

--- a/data/dxl/minidump/UnionWithOuterRefs.mdp
+++ b/data/dxl/minidump/UnionWithOuterRefs.mdp
@@ -725,7 +725,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="1652">
+<dxl:Plan Id="0" SpaceSize="1582">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="7591.314542" Rows="14284.022774" Width="8"/>

--- a/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+SELECT *
+FROM pg_am, pg_opclass, pg_amop AS outer
+WHERE
+  opcamid = pg_am.oid AND
+  amopclaid = pg_opclass.oid AND
+  amname <> 'btree' AND /* we don't really know, but any value should be good */
+  amname <> 'bitmap' AND /* again, we don't know ... */
+  amstrategies <> (
+    SELECT count(*)
+    FROM pg_amop AS inner
+    WHERE
+      amopclaid = pgopclass.oid AND
+      inner.amopsubtype = outer.amopsubtype
+  )
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:Stacktrace/>

--- a/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -760,92 +760,36 @@
         </dxl:LogicalProject>
       </dxl:LogicalUpdate>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="70">
-  <dxl:DMLUpdate Columns="0,18" ActionCol="24" OidCol="25" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
-    <dxl:Properties>
-      <dxl:Cost StartupCost="0" TotalCost="56.976562" Rows="100.000000" Width="1"/>
-    </dxl:Properties>
-    <dxl:DirectDispatchInfo/>
-    <dxl:ProjList>
-      <dxl:ProjElem ColId="0" Alias="a">
-        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-      </dxl:ProjElem>
-      <dxl:ProjElem ColId="18" Alias="b">
-        <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
-      </dxl:ProjElem>
-    </dxl:ProjList>
-    <dxl:TableDescriptor Mdid="0.284632.1.1" TableName="r">
-      <dxl:Columns>
-        <dxl:Column ColId="26" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-        <dxl:Column ColId="27" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-        <dxl:Column ColId="28" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-        <dxl:Column ColId="29" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-        <dxl:Column ColId="30" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-        <dxl:Column ColId="31" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-        <dxl:Column ColId="32" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-        <dxl:Column ColId="33" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-        <dxl:Column ColId="34" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-      </dxl:Columns>
-    </dxl:TableDescriptor>
-    <dxl:Result>
-      <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="45.820312" Rows="200.000000" Width="26"/>
-      </dxl:Properties>
-      <dxl:ProjList>
-        <dxl:ProjElem ColId="0" Alias="a">
-          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="18" Alias="b">
-          <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="2" Alias="ctid">
-          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-          <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
-        </dxl:ProjElem>
-        <dxl:ProjElem ColId="25" Alias="ColRef_0025">
-          <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="false" IsByValue="true" Value="284632"/>
-        </dxl:ProjElem>
-      </dxl:ProjList>
-      <dxl:Filter/>
-      <dxl:OneTimeFilter/>
-      <dxl:Assert ErrorCode="23502">
+    <dxl:Plan Id="0" SpaceSize="68">
+      <dxl:DMLUpdate Columns="0,18" ActionCol="23" OidCol="24" CtidCol="2" SegmentIdCol="8" InputSorted="false" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="39.742188" Rows="200.000000" Width="22"/>
+          <dxl:Cost StartupCost="0" TotalCost="56.976562" Rows="100.000000" Width="1"/>
         </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="ctid">
-            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
           <dxl:ProjElem ColId="18" Alias="b">
             <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
-          <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-            <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:AssertConstraintList>
-          <dxl:AssertConstraint ErrorMessage="Not null constraint for column a of table r was violated">
-            <dxl:Not>
-              <dxl:IsNull>
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:IsNull>
-            </dxl:Not>
-          </dxl:AssertConstraint>
-        </dxl:AssertConstraintList>
-        <dxl:Split DeleteColumns="0,1" InsertColumns="0,18" ActionCol="24" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+        <dxl:TableDescriptor Mdid="0.284632.1.1" TableName="r">
+          <dxl:Columns>
+            <dxl:Column ColId="25" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="26" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="27" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="28" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="29" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="30" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="31" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="32" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="33" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="34.445312" Rows="200.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="45.820312" Rows="200.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -860,26 +804,22 @@
             <dxl:ProjElem ColId="8" Alias="gp_segment_id">
               <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
+            <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+              <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="24" Alias="ColRef_0024">
-              <dxl:DMLAction/>
+              <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="false" IsByValue="true" Value="284632"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Result>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Assert ErrorCode="23502">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="29.148438" Rows="100.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="39.742188" Rows="200.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="18" Alias="b">
-                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                </dxl:OpExpr>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="ctid">
                 <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -887,19 +827,32 @@
               <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="b">
+                <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:HashJoin JoinType="In">
+            <dxl:AssertConstraintList>
+              <dxl:AssertConstraint ErrorMessage="Not null constraint for column a of table r was violated">
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+              </dxl:AssertConstraint>
+            </dxl:AssertConstraintList>
+            <dxl:Split DeleteColumns="0,1" InsertColumns="0,18" ActionCol="23" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="26.000000" Rows="100.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="34.445312" Rows="200.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="18" Alias="b">
+                  <dxl:Ident ColId="18" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="ctid">
                   <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -907,18 +860,13 @@
                 <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                   <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="23" Alias="ColRef_0023">
+                  <dxl:DMLAction/>
+                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
+              <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.171875" Rows="100.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="29.148438" Rows="100.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -926,6 +874,12 @@
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="1" Alias="b">
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="18" Alias="b">
+                    <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                    </dxl:OpExpr>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="ctid">
                     <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
@@ -935,50 +889,96 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.284632.1.1" TableName="r">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1.953125" Rows="1000.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="a">
-                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.284678.1.1" TableName="s">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:HashJoin>
-          </dxl:Result>
-        </dxl:Split>
-      </dxl:Assert>
-    </dxl:Result>
-  </dxl:DMLUpdate>
-</dxl:Plan>
+                <dxl:OneTimeFilter/>
+                <dxl:HashJoin JoinType="In">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="26.000000" Rows="100.000000" Width="24"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="ctid">
+                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1.171875" Rows="100.000000" Width="24"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="ctid">
+                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.284632.1.1" TableName="r">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1.953125" Rows="1000.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="a">
+                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.284678.1.1" TableName="s">
+                      <dxl:Columns>
+                        <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:HashJoin>
+              </dxl:Result>
+            </dxl:Split>
+          </dxl:Assert>
+        </dxl:Result>
+      </dxl:DMLUpdate>
+    </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -44,6 +44,7 @@ namespace gpopt
 	class CDistributionSpec;
 	class IConstExprEvaluator;
 	class CLogical;
+	class CLogicalGbAgg;
 
 	//---------------------------------------------------------------------------
 	//	@class:
@@ -251,6 +252,10 @@ namespace gpopt
 			// check if given expression has a count(*)/count(Any) agg
 			static
 			BOOL FHasCountAgg(CExpression *pexpr, CColRef **ppcrCount);
+
+			// check if given expression has count matching the given column, returns the Logical GroupBy Agg above
+			static
+			BOOL FHasCountAggMatchingColumn(const CExpression *pexpr, const CColRef *pcr, const CLogicalGbAgg** ppgbAgg);
 
 			// generate a GbAgg with count(*) and sum(col) over the given expression
 			static

--- a/server/src/unittest/gpopt/minidump/CAggTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CAggTest.cpp
@@ -28,6 +28,9 @@ ULONG CAggTest::m_ulAggTestCounter = 0;  // start from first test
 // minidump files
 const CHAR *rgszAggFileNames[] =
 {
+	"../data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp",
+	"../data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp",
+	"../data/dxl/minidump/ScalarSubqueryCountStar.mdp",
 	"../data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp",
 	"../data/dxl/minidump/DQA-SplitScalarWithGuc.mdp",
 	"../data/dxl/minidump/DQA-SplitScalar.mdp",


### PR DESCRIPTION
## Do not COALESCE the result of COUNT with GROUP BY in a scalar subquery

Given DDL
```
CREATE TABLE foo (a, b) AS VALUES (1,1);
CREATE TABLE bar (c int, d int);
```
and a query projecting a scalar sub-query, e.g.
```
SELECT (SELECT avg(d) FROM bar WHERE c = a) FROM foo;
```
ORCA will try to decorrelate the subquery à la
```
SELECT avg
FROM foo LEFT OUTER JOIN (
  SELECT avg(d), c FROM bar
  GROUP BY c
) AS bar
ON c = a;
```
For a query containing `count`, special care needs to be taken because
`count` returns `0` on an empty relation where other queries will return
`NULL`.

For example, `SELECT (SELECT count(d) FROM bar WHERE c = a) FROM foo;`
will be transformed into
```
SELECT COALESCE(count, 0) as count
FROM foo LEFT OUTER JOIN (
  SELECT count(d), c FROM bar
  GROUP BY c
) AS bar
ON c = a;
```
Notice the `COALESCE` here is important because in cases where the
sub-query executes on an empty relation, the outer query expects a zero
instead of a `NULL`.

This treatment has a problem though: we don't expect a zero in all cases
with a scalar subquery that uses `count`: when we had a GROUP BY
clause in the subquery, e.g.
```
SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
```
ORCA used to produce the incorrect decorrelation:
```
SELECT COALESCE(count, 0) as count
FROM foo LEFT OUTER JOIN (
  SELECT count(*)
  FROM bar
  GROUP BY c
  LIMIT 1
) AS bar
ON true;
```
Notice the `COALESCE` above, it's harmful when `bar` is an empty
relation, and it's extraneous otherwise.

This commit resolves that issue.

This commit also fixes a related, but more nuanced bug where we failed
to correctly detect `COUNT` in scalar subqueries, and we generated plans
without `COALESCE` where it was actually desirable, an example victim
query is as follows:
```
SELECT (
  SELECT jazz.count
  FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS bar,
  	(SELECT count(*) FROM jazz WHERE e = a) AS jazz
)
FROM foo;
```

With an empty table `jazz` and non-empty tables `bar`, and `foo`,
the expected output should be zeroes, not `NULL`s.

This exposes another bug in ORCA though, when we have empty tables
`bar` and `jazz`, but nonempty table `foo`. We will return zeroes,
whereas the expected output should be `NULL`s.

See also commit deae737 .