### PR TITLE
Don't replace filter child when the correlated outer is sequence while translating expr to dxl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 669)
+set(GPORCA_VERSION_MINOR 670)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.669
+LIB_VERSION = 1.670
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
+++ b/data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table t2(c int, d int);
+create table h(j int, i int) DISTRIBUTED BY (i) PARTITION by RANGE(j) (START (1) END (3) EVERY (1));
+insert into t2 values (1,1);
+insert into h values (2,NULL);
+
+select (select h.i from t2) from h where h.j = 1;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.1" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.16585.1.1" Name="t2" Rows="1.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16585.1.1" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.16612.1.1" Name="h" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16612.1.1" Name="h" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" Keys="7,8,2" PartitionColumns="0" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="i" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16585.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16612.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="19" Alias="?column?">
+            <dxl:ScalarSubquery ColId="2">
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.16585.1.1" TableName="t2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalSelect>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          </dxl:Comparison>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.16612.1.1" TableName="h">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1293.007275" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="18" Alias="?column?">
+            <dxl:Ident ColId="18" ColName="?column?" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1293.007260" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="18" Alias="?column?">
+              <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList>
+                  <dxl:Param ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ParamList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                      <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Materialize Eager="true">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="3.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="3.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.16585.1.1" TableName="t2">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:BroadcastMotion>
+                  </dxl:Materialize>
+                </dxl:Result>
+              </dxl:SubPlan>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="j">
+                <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="i">
+                <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.16612.1.1" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                  <dxl:PartOid Level="0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                </dxl:Comparison>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="j">
+                  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="i">
+                  <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.16612.1.1" TableName="h">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:Sequence>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3449,10 +3449,19 @@ CTranslatorExprToDXL::PdxlnResultFromNLJoinOuter
 	// create a result node from the input expression
 	CDXLNode *pdxlnResult = PdxlnResult(pexprRelational, pdrgpcr, pdrgpdsBaseTables, pulNonGatherMotions, pfDML, pdxlprop);
 
-	// add the new filter to the result replacing its original
-	// empty filter
-	CDXLNode *pdxlnFilter = PdxlnFilter(pdxlnCond);
-	pdxlnResult->ReplaceChild(EdxltsIndexFilter /*ulPos*/, pdxlnFilter);
+	// In case the OuterChild is a physical sequence, it will already have the filter in the partition selector and
+	// dynamic scan, thus we should not replace the filter.
+	if(EdxlopPhysicalSequence != pdxlnResult->Pdxlop()->Edxlop())
+	{
+		// add the new filter to the result replacing its original
+		// empty filter
+		CDXLNode *pdxlnFilter = PdxlnFilter(pdxlnCond);
+		pdxlnResult->ReplaceChild(EdxltsIndexFilter /*ulPos*/, pdxlnFilter);
+	}
+	else
+	{
+		pdxlnCond->Release();
+	}
 
 	return pdxlnResult;
 }

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3503,7 +3503,7 @@ CTranslatorExprToDXL::PdxlnNLJoin
 	(
 	CExpression *pexprInnerNLJ,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -3513,7 +3513,7 @@ CTranslatorExprToDXL::PdxlnNLJoin
 
 	// extract components
 	CPhysical *pop = CPhysical::PopConvert(pexprInnerNLJ->Pop());
-	
+
 	CExpression *pexprOuterChild = (*pexprInnerNLJ)[0];
 	CExpression *pexprInnerChild = (*pexprInnerNLJ)[1];
 	CExpression *pexprScalar = (*pexprInnerNLJ)[2];
@@ -3544,19 +3544,19 @@ CTranslatorExprToDXL::PdxlnNLJoin
 			fIndexNLJ = true;
 			StoreIndexNLJOuterRefs(pop);
 			break;
-	
+
 		case COperator::EopPhysicalLeftOuterNLJoin:
 			edxljt = EdxljtLeft;
 			break;
-		
+
 		case COperator::EopPhysicalLeftSemiNLJoin:
 			edxljt = EdxljtIn;
 			break;
-					
+
 		case COperator::EopPhysicalLeftAntiSemiNLJoin:
 			edxljt = EdxljtLeftAntiSemijoin;
 			break;
-		
+
 		case COperator::EopPhysicalLeftAntiSemiNLJoinNotIn:
 			edxljt = EdxljtLeftAntiSemijoinNotIn;
 			break;
@@ -3584,12 +3584,12 @@ CTranslatorExprToDXL::PdxlnNLJoin
 	GPOS_ASSERT(NULL != pexprInnerNLJ->Prpp());
 	CColRefSet *pcrsOutput = pexprInnerNLJ->Prpp()->PcrsRequired();
 
-	CDXLNode *pdxlnProjList = PdxlnProjList(pcrsOutput, pdrgpcr);	
+	CDXLNode *pdxlnProjList = PdxlnProjList(pcrsOutput, pdrgpcr);
 
 	CDXLNode *pdxlnNLJ = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopNLJ);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexprInnerNLJ);
 	pdxlnNLJ->SetProperties(pdxlprop);
-	
+
 	// construct an empty plan filter
 	CDXLNode *pdxlnFilter = PdxlnFilter(NULL);
 
@@ -3658,7 +3658,7 @@ CTranslatorExprToDXL::PdxlnHashJoin
 	(
 	CExpression *pexprHJ,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -3769,7 +3769,7 @@ CTranslatorExprToDXL::PdxlnHashJoin
 	GPOS_ASSERT(NULL != pexprHJ->Prpp());
 	CColRefSet *pcrsOutput = pexprHJ->Prpp()->PcrsRequired();
 	CDXLNode *pdxlnProjList = PdxlnProjList(pcrsOutput, pdrgpcr);
-	
+
 	CDXLNode *pdxlnHJ = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopHJ);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexprHJ);
 	pdxlnHJ->SetProperties(pdxlprop);
@@ -3784,7 +3784,7 @@ CTranslatorExprToDXL::PdxlnHashJoin
 	pdxlnHJ->AddChild(pdxlnHashCondList);
 	pdxlnHJ->AddChild(pdxlnOuterChild);
 	pdxlnHJ->AddChild(pdxlnInnerChild);
-	
+
 	// cleanup 
 	pdrgpexprPredicates->Release();
 
@@ -3834,7 +3834,7 @@ CTranslatorExprToDXL::PdxlnMotion
 	(
 	CExpression *pexprMotion,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -3856,45 +3856,45 @@ CTranslatorExprToDXL::PdxlnMotion
 		case COperator::EopPhysicalMotionGather:
 			pdxlopMotion = GPOS_NEW(m_pmp) CDXLPhysicalGatherMotion(m_pmp);
 			break;
-		
+
 		case COperator::EopPhysicalMotionBroadcast:
 			pdxlopMotion = GPOS_NEW(m_pmp) CDXLPhysicalBroadcastMotion(m_pmp);
 			break;
-		
+
 		case COperator::EopPhysicalMotionHashDistribute:
 			pdxlopMotion = GPOS_NEW(m_pmp) CDXLPhysicalRedistributeMotion(m_pmp, fDuplicateHazardMotion);
 			break;
-			
+
 		case COperator::EopPhysicalMotionRandom:
 			pdxlopMotion = GPOS_NEW(m_pmp) CDXLPhysicalRandomMotion(m_pmp, fDuplicateHazardMotion);
 			break;
-		
+
 		case COperator::EopPhysicalMotionRoutedDistribute:
 			{
-				CPhysicalMotionRoutedDistribute *popMotion = 
-						CPhysicalMotionRoutedDistribute::PopConvert(pexprMotion->Pop()); 
+				CPhysicalMotionRoutedDistribute *popMotion =
+						CPhysicalMotionRoutedDistribute::PopConvert(pexprMotion->Pop());
 				CColRef *pcrSegmentId = dynamic_cast<const CDistributionSpecRouted* >(popMotion->Pds())->Pcr();
-				
+
 				pdxlopMotion = GPOS_NEW(m_pmp) CDXLPhysicalRoutedDistributeMotion(m_pmp, pcrSegmentId->UlId());
 				break;
 			}
 		default:
 			GPOS_ASSERT(!"Unrecognized motion type");
 	}
-	
+
 	if (COperator::EopPhysicalMotionGather != pexprMotion->Pop()->Eopid())
 	{
 		(*pulNonGatherMotions)++;
 	}
-	
+
 	GPOS_ASSERT(NULL != pdxlopMotion);
-	
+
 	// construct project list from child project list
 	GPOS_ASSERT(NULL != pdxlnChild && 1 <= pdxlnChild->UlArity());
 	CDXLNode *pdxlnProjListChild = (*pdxlnChild)[0];
-	
+
 	CDXLNode *pdxlnProjList = CTranslatorExprToDXLUtils::PdxlnProjListFromChildProjList(m_pmp, m_pcf, m_phmcrdxln, pdxlnProjListChild);
-	
+
 	// set input and output segment information
 	pdxlopMotion->SetSegmentInfo(PdrgpiInputSegIds(pexprMotion), PdrgpiOutputSegIds(pexprMotion));
 
@@ -3914,7 +3914,7 @@ CTranslatorExprToDXL::PdxlnMotion
 	pdxlnMotion->AddChild(pdxlnProjList);
 	pdxlnMotion->AddChild(pdxlnFilter);
 	pdxlnMotion->AddChild(pdxlnSortColList);
-	
+
 	if (COperator::EopPhysicalMotionHashDistribute == pexprMotion->Pop()->Eopid())
 	{
 		// construct a hash expr list node
@@ -3923,7 +3923,7 @@ CTranslatorExprToDXL::PdxlnMotion
 		CDXLNode *pdxlnHashExprList = PdxlnHashExprList(pdsHashed->Pdrgpexpr());
 		pdxlnMotion->AddChild(pdxlnHashExprList);
 	}
-	
+
 	pdxlnMotion->AddChild(pdxlnChild);
 
 #ifdef GPOS_DEBUG
@@ -3946,7 +3946,7 @@ CTranslatorExprToDXL::PdxlnMaterialize
 	(
 	CExpression *pexprSpool,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -3968,14 +3968,14 @@ CTranslatorExprToDXL::PdxlnMaterialize
 	GPOS_ASSERT(NULL != pdxlnChild && 1 <= pdxlnChild->UlArity());
 	CDXLNode *pdxlnProjListChild = (*pdxlnChild)[0];
 	CDXLNode *pdxlnProjList = CTranslatorExprToDXLUtils::PdxlnProjListFromChildProjList(m_pmp, m_pcf, m_phmcrdxln, pdxlnProjListChild);
-	
+
 	CDXLNode *pdxlnMaterialize = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopMat);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexprSpool);
 	pdxlnMaterialize->SetProperties(pdxlprop);
-	
+
 	// construct an empty filter node
 	CDXLNode *pdxlnFilter = PdxlnFilter(NULL /* pdxlnCond */);
-	
+
 	// add children
 	pdxlnMaterialize->AddChild(pdxlnProjList);
 	pdxlnMaterialize->AddChild(pdxlnFilter);
@@ -4001,7 +4001,7 @@ CTranslatorExprToDXL::PdxlnSequence
 	(
 	CExpression *pexprSequence,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -4012,36 +4012,36 @@ CTranslatorExprToDXL::PdxlnSequence
 	GPOS_ASSERT(0 < ulArity);
 
 	// construct sequence node
-	CDXLPhysicalSequence *pdxlopSequence = GPOS_NEW(m_pmp) CDXLPhysicalSequence(m_pmp);	
+	CDXLPhysicalSequence *pdxlopSequence = GPOS_NEW(m_pmp) CDXLPhysicalSequence(m_pmp);
 	CDXLNode *pdxlnSequence = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopSequence);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexprSequence);
 	pdxlnSequence->SetProperties(pdxlprop);
 
 	// translate children
 	DrgPdxln *pdrgpdxlnChildren = GPOS_NEW(m_pmp) DrgPdxln(m_pmp);
-	
+
 	for (ULONG ul = 0; ul < ulArity; ul++)
 	{
 		CExpression *pexprChild = (*pexprSequence)[ul];
-		
+
 		DrgPcr *pdrgpcrChildOutput = NULL;
 		if (ul == ulArity - 1)
 		{
 			// impose output columns on last child
 			pdrgpcrChildOutput = pdrgpcr;
 		}
-		
+
 		CDXLNode *pdxlnChild = Pdxln(pexprChild, pdrgpcrChildOutput, pdrgpdsBaseTables, pulNonGatherMotions, pfDML, false /*fRemap*/, false /*fRoot*/);
 		pdrgpdxlnChildren->Append(pdxlnChild);
 	}
-	
+
 	// construct project list from the project list of the last child
 	CDXLNode *pdxlnLastChild = (*pdrgpdxlnChildren)[ulArity - 1];
 	CDXLNode *pdxlnProjListChild = (*pdxlnLastChild)[0];
-	
+
 	CDXLNode *pdxlnProjList = CTranslatorExprToDXLUtils::PdxlnProjListFromChildProjList(m_pmp, m_pcf, m_phmcrdxln, pdxlnProjListChild);
 	pdxlnSequence->AddChild(pdxlnProjList);
-	
+
 	// add children
 	for (ULONG ul = 0; ul < ulArity; ul++)
 	{
@@ -4049,9 +4049,9 @@ CTranslatorExprToDXL::PdxlnSequence
 		pdxlnChid->AddRef();
 		pdxlnSequence->AddChild(pdxlnChid);
 	}
-	
+
 	pdrgpdxlnChildren->Release();
-	
+
 #ifdef GPOS_DEBUG
 	pdxlopSequence->AssertValid(pdxlnSequence, false /* fValidateChildren */);
 #endif
@@ -4072,7 +4072,7 @@ CTranslatorExprToDXL::PdxlnPartitionSelector
 	(
 	CExpression *pexpr,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -4093,7 +4093,7 @@ CTranslatorExprToDXL::PdxlnPartitionSelector
 	(
 	CExpression *pexpr,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML,
 	CExpression *pexprScalarCond,
@@ -4125,7 +4125,7 @@ CTranslatorExprToDXL::PdxlnPartitionSelectorDML
 	(
 	CExpression *pexpr,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -4266,7 +4266,7 @@ CTranslatorExprToDXL::PdxlnPartitionSelectorExpand
 	(
 	CExpression *pexpr,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML,
 	CExpression *pexprScalarCond,
@@ -4280,19 +4280,19 @@ CTranslatorExprToDXL::PdxlnPartitionSelectorExpand
 
 	GPOS_ASSERT_IMP
 		(
-		NULL != pexprScalarCond, 
+		NULL != pexprScalarCond,
 		(COperator::EopPhysicalDynamicTableScan == pexprChild->Pop()->Eopid() ||
 		 COperator::EopPhysicalDynamicIndexScan == pexprChild->Pop()->Eopid() ||
 		 COperator::EopPhysicalDynamicBitmapTableScan == pexprChild->Pop()->Eopid())
 		&& "Inlining predicates only allowed in DynamicTableScan, DynamicIndexScan and DynamicBitmapTableScan"
 		);
-	
+
 	CPhysicalPartitionSelector *popSelector = CPhysicalPartitionSelector::PopConvert(pexpr->Pop());
 	const ULONG ulLevels = popSelector->UlPartLevels();
-		
+
 	// translate child
 	CDXLNode *pdxlnChild = PdxlnPartitionSelectorChild(pexprChild, pexprScalarCond, pdxlprop, pdrgpcr, pdrgpdsBaseTables, pulNonGatherMotions, pfDML);
-	
+
 	// project list
 	CDXLNode *pdxlnPrL = CTranslatorExprToDXLUtils::PdxlnPrLPartitionSelector
 							(
@@ -4356,15 +4356,15 @@ CTranslatorExprToDXL::PdxlnPartitionSelectorExpand
 
 	CDXLPhysicalProperties *pdxlpropSeq = CTranslatorExprToDXLUtils::PdxlpropCopy(m_pmp, pdxlnChild);
 	pdxlnSequence->SetProperties(pdxlpropSeq);
-	
+
 	// construct sequence's project list from the project list of the last child
 	CDXLNode *pdxlnPrLChild = (*pdxlnChild)[0];
 	CDXLNode *pdxlnPrLSequence = CTranslatorExprToDXLUtils::PdxlnProjListFromChildProjList(m_pmp, m_pcf, m_phmcrdxln, pdxlnPrLChild);
-	
+
 	pdxlnSequence->AddChild(pdxlnPrLSequence);
 	pdxlnSequence->AddChild(pdxlnSelector);
 	pdxlnSequence->AddChild(pdxlnChild);
-	
+
 #ifdef GPOS_DEBUG
 	pdxlopSequence->AssertValid(pdxlnSequence, false /* fValidateChildren */);
 #endif
@@ -4385,7 +4385,7 @@ CTranslatorExprToDXL::PdxlnPartitionSelectorFilter
 	(
 	CExpression *pexpr,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML,
 	CExpression *pexprScalarCond,
@@ -4738,7 +4738,7 @@ CTranslatorExprToDXL::PdxlnPredOnPartKey
 	{
 		return PdxlnScCmpPartKey(pexprPred, pcrPartKey, pmdidTypePartKey, ulPartLevel, pfLTComparison, pfGTComparison, pfEQComparison);
 	}
-	
+
 	if (CUtils::FScalarNullTest(pexprPred))
 	{
 #ifdef GPOS_DEBUG
@@ -4838,7 +4838,7 @@ CTranslatorExprToDXL::PdxlnConjDisjOnPartKey
 	)
 {
 	GPOS_ASSERT(CPredicateUtils::FOr(pexprPred) || CPredicateUtils::FAnd(pexprPred));
-	
+
 	DrgPexpr *pdrgpexprChildren = NULL;
 	EdxlBoolExprType edxlbet = Edxland;
 	if (CPredicateUtils::FAnd(pexprPred))
@@ -4852,13 +4852,13 @@ CTranslatorExprToDXL::PdxlnConjDisjOnPartKey
 	}
 
 	const ULONG ulChildren = pdrgpexprChildren->UlLength();
-	
+
 	CDXLNode *pdxlnPred = NULL;
 	for (ULONG ul = 0; ul < ulChildren; ul++)
 	{
 		CExpression *pexprChild = (*pdrgpexprChildren)[ul];
 		CDXLNode *pdxlnChild = PdxlnPredOnPartKey(pexprChild, pcrPartKey, pmdidTypePartKey, ulPartLevel, pfLTComparison, pfGTComparison, pfEQComparison);
-		
+
 		if (NULL == pdxlnPred)
 		{
 			pdxlnPred = pdxlnChild;
@@ -4868,9 +4868,9 @@ CTranslatorExprToDXL::PdxlnConjDisjOnPartKey
 			pdxlnPred = CTranslatorExprToDXLUtils::PdxlnCombineBoolean(m_pmp, pdxlnPred, pdxlnChild, edxlbet);
 		}
 	}
-	
+
 	pdrgpexprChildren->Release();
-	
+
 	return pdxlnPred;
 }
 
@@ -5011,18 +5011,18 @@ CTranslatorExprToDXL::PdxlnPartitionSelectorChild
 	CExpression *pexprScalarCond,
 	CDXLPhysicalProperties *pdxlprop,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
 {
 	GPOS_ASSERT_IFF(NULL != pexprScalarCond, NULL != pdxlprop);
-	
+
 	if (NULL == pexprScalarCond)
 	{
 		return Pdxln(pexprChild, pdrgpcr, pdrgpdsBaseTables, pulNonGatherMotions, pfDML, true, false);
 	}
-	
+
 	switch(pexprChild->Pop()->Eopid())
 	{
 		case COperator::EopPhysicalDynamicTableScan:
@@ -5048,14 +5048,14 @@ CTranslatorExprToDXL::PdxlnDML
 	(
 	CExpression *pexpr,
 	DrgPcr *,// pdrgpcr
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
 {
 	GPOS_ASSERT(NULL != pexpr);
 	GPOS_ASSERT(1 == pexpr->UlArity());
-	
+
 	ULONG ulAction = 0;
 	ULONG ulOid = 0;
 	ULONG ulCtid = 0;
@@ -5068,7 +5068,7 @@ CTranslatorExprToDXL::PdxlnDML
 	{
 		return PdxlnCTAS(pexpr, pdrgpdsBaseTables, pulNonGatherMotions, pfDML);
 	}
-	
+
 	EdxlDmlType edxldmltype = Edxldmloptype(popDML->Edmlop());
 
 	CExpression *pexprChild = (*pexpr)[0];
@@ -5091,7 +5091,7 @@ CTranslatorExprToDXL::PdxlnDML
 		ulCtid = pcrCtid->UlId();
 		ulSegmentId = pcrSegmentId->UlId();
 	}
-	
+
 	CColRef *pcrTupleOid = popDML->PcrTupleOid();
 	ULONG ulTupleOid = 0;
 	BOOL fPreserveOids = false;
@@ -5100,29 +5100,29 @@ CTranslatorExprToDXL::PdxlnDML
 		fPreserveOids = true;
 		ulTupleOid = pcrTupleOid->UlId();
 	}
-	
+
 	CDXLNode *pdxlnChild = Pdxln(pexprChild, pdrgpcrSource, pdrgpdsBaseTables, pulNonGatherMotions, pfDML, false /*fRemap*/, false /*fRoot*/);
 
 	CDXLTableDescr *pdxltabdesc = Pdxltabdesc(ptabdesc, NULL /*pdrgpcrOutput*/);
 	DrgPul *pdrgpul = CUtils::Pdrgpul(m_pmp, pdrgpcrSource);
-	
+
 	CDXLDirectDispatchInfo *pdxlddinfo = Pdxlddinfo(pexpr);
 	CDXLPhysicalDML *pdxlopDML = GPOS_NEW(m_pmp) CDXLPhysicalDML
 									(
-									m_pmp, 
-									edxldmltype, 
-									pdxltabdesc, 
-									pdrgpul, 
-									ulAction, 
-									ulOid, 
-									ulCtid, 
-									ulSegmentId, 
-									fPreserveOids, 
+									m_pmp,
+									edxldmltype,
+									pdxltabdesc,
+									pdrgpul,
+									ulAction,
+									ulOid,
+									ulCtid,
+									ulSegmentId,
+									fPreserveOids,
 									ulTupleOid,
 									pdxlddinfo,
 									popDML->FInputSorted()
 									);
-	
+
 	// project list
 	CColRefSet *pcrsOutput = pexpr->Prpp()->PcrsRequired();
 	CDXLNode *pdxlnPrL = PdxlnProjList(pcrsOutput, pdrgpcrSource);
@@ -5130,10 +5130,10 @@ CTranslatorExprToDXL::PdxlnDML
 	CDXLNode *pdxlnDML = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopDML);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexpr);
 	pdxlnDML->SetProperties(pdxlprop);
-	
+
 	pdxlnDML->AddChild(pdxlnPrL);
 	pdxlnDML->AddChild(pdxlnChild);
-	
+
 #ifdef GPOS_DEBUG
 	pdxlnDML->Pdxlop()->AssertValid(pdxlnDML, false /* fValidateChildren */);
 #endif
@@ -5154,28 +5154,28 @@ CDXLNode *
 CTranslatorExprToDXL::PdxlnCTAS
 	(
 	CExpression *pexpr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
 {
 	GPOS_ASSERT(NULL != pexpr);
 	GPOS_ASSERT(1 == pexpr->UlArity());
-	
+
 	CPhysicalDML *popDML = CPhysicalDML::PopConvert(pexpr->Pop());
 	GPOS_ASSERT(CLogicalDML::EdmlInsert == popDML->Edmlop());
-	
+
 	CExpression *pexprChild = (*pexpr)[0];
 	CTableDescriptor *ptabdesc = popDML->Ptabdesc();
 	DrgPcr *pdrgpcrSource = popDML->PdrgpcrSource();
 	CMDRelationCtasGPDB *pmdrel = (CMDRelationCtasGPDB *) m_pmda->Pmdrel(ptabdesc->Pmdid());
-	
+
 	CDXLNode *pdxlnChild = Pdxln(pexprChild, pdrgpcrSource, pdrgpdsBaseTables, pulNonGatherMotions, pfDML, true /*fRemap*/, true /*fRoot*/);
 
 	DrgPul *pdrgpul = CUtils::Pdrgpul(m_pmp, pdrgpcrSource);
-	
+
 	pmdrel->Pdxlctasopt()->AddRef();
-	
+
 	const ULONG ulColumns = ptabdesc->UlColumns();
 
 	DrgPi *pdrgpiVarTypeMod = pmdrel->PdrgpiVarTypeMod();
@@ -5186,7 +5186,7 @@ CTranslatorExprToDXL::PdxlnCTAS
 	for (ULONG ul = 0; ul < ulColumns; ul++)
 	{
 		const CColumnDescriptor *pcd = ptabdesc->Pcoldesc(ul);
-		
+
 		CMDName *pmdnameCol = GPOS_NEW(m_pmp) CMDName(m_pmp, pcd->Name().Pstr());
 		CColRef *pcr = m_pcf->PcrCreate(pcd->Pmdtype(), pcd->Name());
 
@@ -5194,7 +5194,7 @@ CTranslatorExprToDXL::PdxlnCTAS
 		// colid for the dxl column
 		CMDIdGPDB *pmdidColType = CMDIdGPDB::PmdidConvert(pcr->Pmdtype()->Pmdid());
 		pmdidColType->AddRef();
-		
+
 		CDXLColDescr *pdxlcd = GPOS_NEW(m_pmp) CDXLColDescr
 											(
 											m_pmp,
@@ -5205,10 +5205,10 @@ CTranslatorExprToDXL::PdxlnCTAS
 											false /* fdropped */,
 											pcd->UlWidth()
 											);
-		
-		pdrgpdxlcd->Append(pdxlcd);		
+
+		pdrgpdxlcd->Append(pdxlcd);
 	}
-	
+
 	DrgPul *pdrgpulDistr = NULL;
 	if (IMDRelation::EreldistrHash == pmdrel->Ereldistribution())
 	{
@@ -5222,7 +5222,7 @@ CTranslatorExprToDXL::PdxlnCTAS
 			pdrgpulDistr->Append(GPOS_NEW(m_pmp) ULONG(iAttno - 1));
 		}
 	}
-	
+
 	CMDName *pmdnameSchema = NULL;
 	if (NULL != pmdrel->PmdnameSchema())
 	{
@@ -5232,10 +5232,10 @@ CTranslatorExprToDXL::PdxlnCTAS
 	pdrgpiVarTypeMod->AddRef();
 	CDXLPhysicalCTAS *pdxlopCTAS = GPOS_NEW(m_pmp) CDXLPhysicalCTAS
 									(
-									m_pmp, 
+									m_pmp,
 									pmdnameSchema,
 									GPOS_NEW(m_pmp) CMDName(m_pmp, pmdrel->Mdname().Pstr()),
-									pdrgpdxlcd, 
+									pdrgpdxlcd,
 									pmdrel->Pdxlctasopt(),
 									pmdrel->Ereldistribution(),
 									pdrgpulDistr,
@@ -5245,17 +5245,17 @@ CTranslatorExprToDXL::PdxlnCTAS
 									pdrgpul,
 									pdrgpiVarTypeMod
 									);
-	
+
 	CDXLNode *pdxlnCTAS = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopCTAS);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexpr);
 	pdxlnCTAS->SetProperties(pdxlprop);
-	
+
 	CColRefSet *pcrsOutput = pexpr->Prpp()->PcrsRequired();
 	CDXLNode *pdxlnPrL = PdxlnProjList(pcrsOutput, pdrgpcrSource);
 
 	pdxlnCTAS->AddChild(pdxlnPrL);
 	pdxlnCTAS->AddChild(pdxlnChild);
-	
+
 #ifdef GPOS_DEBUG
 	pdxlnCTAS->Pdxlop()->AssertValid(pdxlnCTAS, false /* fValidateChildren */);
 #endif
@@ -5282,8 +5282,8 @@ CTranslatorExprToDXL::Pdxlddinfo
 	CPhysicalDML *popDML = CPhysicalDML::PopConvert(pexprDML->Pop());
 	CTableDescriptor *ptabdesc = popDML->Ptabdesc();
 	const DrgPcoldesc *pdrgpcoldescDist = ptabdesc->PdrgpcoldescDist();
-	
-	if (CLogicalDML::EdmlInsert != popDML->Edmlop() || 
+
+	if (CLogicalDML::EdmlInsert != popDML->Edmlop() ||
 		IMDRelation::EreldistrHash != ptabdesc->Ereldistribution() ||
 		1 < pdrgpcoldescDist->UlLength())
 	{
@@ -5291,13 +5291,13 @@ CTranslatorExprToDXL::Pdxlddinfo
 		// with a single distribution column
 		return NULL;
 	}
-	
-	
-	GPOS_ASSERT(1 == pdrgpcoldescDist->UlLength());	
+
+
+	GPOS_ASSERT(1 == pdrgpcoldescDist->UlLength());
 	CColumnDescriptor *pcoldesc = (*pdrgpcoldescDist)[0];
-	ULONG ulPos = ptabdesc->UlPos(pcoldesc, ptabdesc->Pdrgpcoldesc());	
+	ULONG ulPos = ptabdesc->UlPos(pcoldesc, ptabdesc->Pdrgpcoldesc());
 	GPOS_ASSERT(ulPos < ptabdesc->Pdrgpcoldesc()->UlLength() && "Column not found");
-		
+
 	CColRef *pcrDistrCol = (*popDML->PdrgpcrSource())[ulPos];
 	CPropConstraint *ppc = CDrvdPropRelational::Pdprel((*pexprDML)[0]->Pdp(CDrvdProp::EptRelational))->Ppc();
 
@@ -5312,15 +5312,15 @@ CTranslatorExprToDXL::Pdxlddinfo
 		CRefCount::SafeRelease(pcnstrDistrCol);
 		return NULL;
 	}
-	
+
 	GPOS_ASSERT(CConstraint::EctInterval == pcnstrDistrCol->Ect());
-	
+
 	CConstraintInterval *pci = dynamic_cast<CConstraintInterval *>(pcnstrDistrCol);
 	GPOS_ASSERT(1 >= pci->Pdrgprng()->UlLength());
-	
+
 	DrgPdxldatum *pdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdxldatum(m_pmp);
 	CDXLDatum *pdxldatum = NULL;
-	
+
 	if (1 == pci->Pdrgprng()->UlLength())
 	{
 		const CRange *prng = (*pci->Pdrgprng())[0];
@@ -5331,11 +5331,11 @@ CTranslatorExprToDXL::Pdxlddinfo
 		GPOS_ASSERT(pci->FIncludesNull());
 		pdxldatum = pcrDistrCol->Pmdtype()->PdxldatumNull(m_pmp);
 	}
-	
+
 	pdrgpdxldatum->Append(pdxldatum);
 
-	pcnstrDistrCol->Release(); 
-	
+	pcnstrDistrCol->Release();
+
 	DrgPdrgPdxldatum *pdrgpdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdrgPdxldatum(m_pmp);
 	pdrgpdrgpdxldatum->Append(pdrgpdxldatum);
 	return GPOS_NEW(m_pmp) CDXLDirectDispatchInfo(pdrgpdrgpdxldatum);
@@ -5354,7 +5354,7 @@ CTranslatorExprToDXL::PdxlnSplit
 	(
 	CExpression *pexpr,
 	DrgPcr *, // pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -5384,7 +5384,7 @@ CTranslatorExprToDXL::PdxlnSplit
 	CColRef *pcrSegmentId = popSplit->PcrSegmentId();
 	GPOS_ASSERT(NULL != pcrSegmentId);
 	ulSegmentId = pcrSegmentId->UlId();
-	
+
 	CColRef *pcrTupleOid = popSplit->PcrTupleOid();
 	BOOL fPreserveOids = false;
 	if (NULL != pcrTupleOid)
@@ -5419,15 +5419,15 @@ CTranslatorExprToDXL::PdxlnSplit
 													fPreserveOids,
 													ulTupleOid
 													);
-	
+
 	// project list
 	CColRefSet *pcrsOutput = pexpr->Prpp()->PcrsRequired();
 	CDXLNode *pdxlnPrL = PdxlnProjList(pexprProjList, pcrsOutput, pdrgpcrInsert);
-	
+
 	CDXLNode *pdxlnSplit = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopSplit);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexpr);
 	pdxlnSplit->SetProperties(pdxlprop);
-	
+
 	pdxlnSplit->AddChild(pdxlnPrL);
 	pdxlnSplit->AddChild(pdxlnChild);
 
@@ -5450,7 +5450,7 @@ CTranslatorExprToDXL::PdxlnRowTrigger
 	(
 	CExpression *pexpr,
 	DrgPcr *, // pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -5499,7 +5499,7 @@ CTranslatorExprToDXL::PdxlnRowTrigger
 													pdrgpulOld,
 													pdrgpulNew
 													);
-	
+
 	// project list
 	CColRefSet *pcrsOutput = pexpr->Prpp()->PcrsRequired();
 	CDXLNode *pdxlnPrL = NULL;
@@ -5515,7 +5515,7 @@ CTranslatorExprToDXL::PdxlnRowTrigger
 	CDXLNode *pdxlnRowTrigger = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopRowTrigger);
 	CDXLPhysicalProperties *pdxlprop = Pdxlprop(pexpr);
 	pdxlnRowTrigger->SetProperties(pdxlprop);
-	
+
 	pdxlnRowTrigger->AddChild(pdxlnPrL);
 	pdxlnRowTrigger->AddChild(pdxlnChild);
 
@@ -5573,7 +5573,7 @@ CTranslatorExprToDXL::PdxlnScCmp
 	)
 {
 	GPOS_ASSERT(NULL != pexprScCmp);
-	
+
 	// extract components
 	CExpression *pexprLeft = (*pexprScCmp)[0];
 	CExpression *pexprRight = (*pexprScCmp)[1];
@@ -5581,29 +5581,29 @@ CTranslatorExprToDXL::PdxlnScCmp
 	// translate children expression
 	CDXLNode *pdxlnLeft = PdxlnScalar(pexprLeft);
 	CDXLNode *pdxlnRight = PdxlnScalar(pexprRight);
-	
+
 	CScalarCmp *popScCmp = CScalarCmp::PopConvert(pexprScCmp->Pop());
-	
+
 	GPOS_ASSERT(NULL != popScCmp);
 	GPOS_ASSERT(NULL != popScCmp->Pstr());
 	GPOS_ASSERT(NULL != popScCmp->Pstr()->Wsz());
-	
+
 	// construct a scalar comparison node
 	IMDId *pmdid = popScCmp->PmdidOp();
 	pmdid->AddRef();
 
 	CWStringConst *pstrName = GPOS_NEW(m_pmp) CWStringConst(m_pmp, popScCmp->Pstr()->Wsz());
-	
+
 	CDXLNode *pdxlnCmp = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarComp(m_pmp, pmdid, pstrName));
-	
+
 	// add children
 	pdxlnCmp->AddChild(pdxlnLeft);
 	pdxlnCmp->AddChild(pdxlnRight);
-	
+
 #ifdef GPOS_DEBUG
 	pdxlnCmp->Pdxlop()->AssertValid(pdxlnCmp, false /* fValidateChildren */);
 #endif
-	
+
 	return pdxlnCmp;
 }
 
@@ -5673,13 +5673,13 @@ CTranslatorExprToDXL::PdxlnScOp
 
 	IMDId *pmdidOp = pscop->PmdidOp();
 	pmdidOp->AddRef();
-	
+
 	IMDId *pmdidReturnType = pscop->PmdidReturnType();
 	if (NULL != pmdidReturnType)
 	{
 		pmdidReturnType->AddRef();
 	}
-	
+
 	CDXLNode *pdxlnOpExpr = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarOpExpr(m_pmp, pmdidOp, pmdidReturnType, pstrName));
 
 	TranslateScalarChildren(pexprOp, pdxlnOpExpr);
@@ -5779,7 +5779,7 @@ CTranslatorExprToDXL::PdxlnScId
 	)
 {
 	GPOS_ASSERT(NULL != pexprIdent);
-	
+
 	CScalarIdent *popScId = CScalarIdent::PopConvert(pexprIdent->Pop());
 	CColRef *pcr = const_cast<CColRef*>(popScId->Pcr());
 
@@ -5801,26 +5801,26 @@ CTranslatorExprToDXL::PdxlnScFuncExpr
 	)
 {
 	GPOS_ASSERT(NULL != pexprFunc);
-	
+
 	CScalarFunc *popScFunc = CScalarFunc::PopConvert(pexprFunc->Pop());
-	
+
 	IMDId *pmdidFunc = popScFunc->PmdidFunc();
 	pmdidFunc->AddRef();
-	
+
 	IMDId *pmdidRetType = popScFunc->PmdidType();
 	pmdidRetType->AddRef();
 
 	const IMDFunction *pmdfunc = m_pmda->Pmdfunc(pmdidFunc);
-		
+
 	CDXLNode *pdxlnFuncExpr = GPOS_NEW(m_pmp) CDXLNode
 											(
 											m_pmp,
 											GPOS_NEW(m_pmp) CDXLScalarFuncExpr(m_pmp, pmdidFunc, pmdidRetType, pmdfunc->FReturnsSet())
 											);
-	
+
 	// translate children
 	TranslateScalarChildren(pexprFunc, pdxlnFuncExpr);
-	
+
 	return pdxlnFuncExpr;
 }
 
@@ -5840,12 +5840,12 @@ CTranslatorExprToDXL::PdxlnScWindowFuncExpr
 	)
 {
 	GPOS_ASSERT(NULL != pexprWindowFunc);
-	
+
 	CScalarWindowFunc *popScWindowFunc = CScalarWindowFunc::PopConvert(pexprWindowFunc->Pop());
-	
+
 	IMDId *pmdidFunc = popScWindowFunc->PmdidFunc();
 	pmdidFunc->AddRef();
-	
+
 	IMDId *pmdidRetType = popScWindowFunc->PmdidType();
 	pmdidRetType->AddRef();
 
@@ -5859,12 +5859,12 @@ CTranslatorExprToDXL::PdxlnScWindowFuncExpr
 															edxlwinstage,
 															0 /* ulWinspecPosition */
 															);
-	
+
 	CDXLNode *pdxlnWindowRef = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopWindowref);
 
 	// translate children
 	TranslateScalarChildren(pexprWindowFunc, pdxlnWindowRef);
-	
+
 	return pdxlnWindowRef;
 }
 
@@ -5895,7 +5895,7 @@ CTranslatorExprToDXL::Ews
 #endif
 	ULONG *pulElem = rgrgulMapping[(ULONG) ews];
 	EdxlWinStage edxlws = (EdxlWinStage) pulElem[0];
-	
+
 	return edxlws;
 }
 
@@ -5914,11 +5914,11 @@ CTranslatorExprToDXL::PdxlnScAggref
 	)
 {
 	GPOS_ASSERT(NULL != pexprAggFunc);
-	
+
 	CScalarAggFunc *popScAggFunc = CScalarAggFunc::PopConvert(pexprAggFunc->Pop());
 	IMDId *pmdidAggFunc = popScAggFunc->Pmdid();
 	pmdidAggFunc->AddRef();
-	
+
 	IMDId *pmdidResolvedRetType = NULL;
 	if (popScAggFunc->FHasAmbiguousReturnType())
 	{
@@ -5953,7 +5953,7 @@ CTranslatorExprToDXL::PdxlnScAggref
 
 	CDXLNode *pdxlnAggref = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopAggRef);
 	TranslateScalarChildren(pexprAggFunc, pdxlnAggref);
-	
+
 	return pdxlnAggref;
 }
 
@@ -5979,7 +5979,7 @@ CTranslatorExprToDXL::PdxlnScIfStmt
 
 	IMDId *pmdidType = popScIf->PmdidType();
 	pmdidType->AddRef();
-	
+
 	CDXLNode *pdxlnIfStmt = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarIfStmt(m_pmp, pmdidType));
 	TranslateScalarChildren(pexprIfStmt, pdxlnIfStmt);
 
@@ -6109,19 +6109,19 @@ CTranslatorExprToDXL::PdxlnScNullTest
 	)
 {
 	GPOS_ASSERT(NULL != pexprNullTest);
-	
+
 	CDXLNode *pdxlnNullTest = GPOS_NEW(m_pmp) CDXLNode
 											(
-											m_pmp, 
+											m_pmp,
 											GPOS_NEW(m_pmp) CDXLScalarNullTest(m_pmp, true /* fIsNull */));
-	
+
 	// translate child
 	GPOS_ASSERT(1 == pexprNullTest->UlArity());
-	
+
 	CExpression *pexprChild = (*pexprNullTest)[0];
 	CDXLNode *pdxlnChild = PdxlnScalar(pexprChild);
 	pdxlnNullTest->AddChild(pdxlnChild);
-	
+
 	return pdxlnNullTest;
 }
 
@@ -6403,7 +6403,7 @@ CTranslatorExprToDXL::Pdxlwf
 		// an empty frame is translated as 'no frame'
 		return NULL;
 	}
-		
+
 	// mappings for frame info in expression and dxl worlds
 	const ULONG rgulSpecMapping[][2] =
 	{
@@ -6466,7 +6466,7 @@ CTranslatorExprToDXL::PdxlnWindow
 	(
 	CExpression *pexprSeqPrj,
 	DrgPcr *pdrgpcr,
-	DrgPds *pdrgpdsBaseTables, 
+	DrgPds *pdrgpdsBaseTables,
 	ULONG *pulNonGatherMotions,
 	BOOL *pfDML
 	)
@@ -6539,7 +6539,7 @@ CTranslatorExprToDXL::PdxlnWindow
 			pcrsOutput->Include(pcr);
 		}
 	}
-	
+
 	// translate project list expression
 	CDXLNode *pdxlnPrL = PdxlnProjList((*pexprSeqPrj)[1], pcrsOutput, pdrgpcr);
 
@@ -6550,7 +6550,7 @@ CTranslatorExprToDXL::PdxlnWindow
 	CDXLPhysicalWindow *pdxlopWindow = GPOS_NEW(m_pmp) CDXLPhysicalWindow(m_pmp, pdrgpulColIds, pdrgpdxlwk);
 	CDXLNode *pdxlnWindow = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopWindow);
 	pdxlnWindow->SetProperties(pdxlprop);
-	
+
 	// add children
 	pdxlnWindow->AddChild(pdxlnPrL);
 	pdxlnWindow->AddChild(pdxlnFilter);
@@ -6585,17 +6585,17 @@ CTranslatorExprToDXL::PdxlnArray
 
 	IMDId *pmdidElem = pop->PmdidElem();
 	pmdidElem->AddRef();
-	
+
 	IMDId *pmdidArray = pop->PmdidArray();
 	pmdidArray->AddRef();
 
-	CDXLNode *pdxlnArray = 
+	CDXLNode *pdxlnArray =
 			GPOS_NEW(m_pmp) CDXLNode
 						(
 						m_pmp,
 						GPOS_NEW(m_pmp) CDXLScalarArray
 									(
-									m_pmp, 
+									m_pmp,
 									pmdidElem,
 									pmdidArray,
 									pop->FMultiDimensional()
@@ -6603,7 +6603,7 @@ CTranslatorExprToDXL::PdxlnArray
 						);
 
 	TranslateScalarChildren(pexpr, pdxlnArray);
-	
+
 	return pdxlnArray;
 }
 
@@ -6722,7 +6722,7 @@ CTranslatorExprToDXL::PdxlnAssertConstraint
 	GPOS_ASSERT(NULL != pexpr);
 	CScalarAssertConstraint *popAssertConstraint = CScalarAssertConstraint::PopConvert(pexpr->Pop());
 	CWStringDynamic *pstrErrorMsg = GPOS_NEW(m_pmp) CWStringDynamic(m_pmp, popAssertConstraint->PstrErrorMsg()->Wsz());
-	
+
 	CDXLNode *pdxlnAssertConstraint  = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarAssertConstraint(m_pmp, pstrErrorMsg));
 	TranslateScalarChildren(pexpr, pdxlnAssertConstraint);
 	return pdxlnAssertConstraint;
@@ -6777,22 +6777,22 @@ CTranslatorExprToDXL::PdxlnArrayCmp
 	pmdidOp->AddRef();
 
 	const CWStringConst *pstrOpName = pop->Pstr();
-	
+
 	CScalarArrayCmp::EArrCmpType earrcmpt = pop->Earrcmpt();
 	GPOS_ASSERT(CScalarArrayCmp::EarrcmpSentinel > earrcmpt);
 	EdxlArrayCompType edxlarrcmpt = Edxlarraycomptypeall;
 	if (CScalarArrayCmp::EarrcmpAny == earrcmpt)
 	{
-		edxlarrcmpt = Edxlarraycomptypeany; 
+		edxlarrcmpt = Edxlarraycomptypeany;
 	}
-	
-	CDXLNode *pdxlnArrayCmp = 
+
+	CDXLNode *pdxlnArrayCmp =
 			GPOS_NEW(m_pmp) CDXLNode
 						(
 						m_pmp,
 						GPOS_NEW(m_pmp) CDXLScalarArrayComp
 									(
-									m_pmp, 
+									m_pmp,
 									pmdidOp,
 									GPOS_NEW(m_pmp) CWStringConst(m_pmp, pstrOpName->Wsz()),
 									edxlarrcmpt
@@ -6800,7 +6800,7 @@ CTranslatorExprToDXL::PdxlnArrayCmp
 						);
 
 	TranslateScalarChildren(pexpr, pdxlnArrayCmp);
-	
+
 	return pdxlnArrayCmp;
 }
 
@@ -6847,7 +6847,7 @@ CTranslatorExprToDXL::PdxlnScConst
 	)
 {
 	GPOS_ASSERT(NULL != pexprScConst);
-	
+
 	CScalarConst *popScConst = CScalarConst::PopConvert(pexprScConst->Pop());
 
 	IDatum *pdatum = popScConst->Pdatum();
@@ -6855,7 +6855,7 @@ CTranslatorExprToDXL::PdxlnScConst
 	const IMDType *pmdtype = pmda->Pmdtype(pdatum->Pmdid());
 
 	CDXLNode *pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pmdtype->PdxlopScConst(m_pmp, pdatum));
-	
+
 	return pdxln;
 }
 
@@ -6873,13 +6873,13 @@ CTranslatorExprToDXL::PdxlnFilter
 	(
 	CDXLNode *pdxlnCond
 	)
-{	
+{
 	CDXLNode *pdxlnFilter = GPOS_NEW(m_pmp) CDXLNode(m_pmp, GPOS_NEW(m_pmp) CDXLScalarFilter(m_pmp));
 	if (NULL != pdxlnCond)
 	{
 		pdxlnFilter->AddChild(pdxlnCond);
 	}
-	
+
 	return pdxlnFilter;
 }
 
@@ -6901,13 +6901,13 @@ CTranslatorExprToDXL::Pdxltabdesc
 {
 	GPOS_ASSERT(NULL != ptabdesc);
 	GPOS_ASSERT_IMP(NULL != pdrgpcrOutput, ptabdesc->UlColumns() == pdrgpcrOutput->UlLength());
-	
+
 	// get tbl name
 	CMDName *pmdnameTbl = GPOS_NEW(m_pmp) CMDName(m_pmp, ptabdesc->Name().Pstr());
-	
+
 	CMDIdGPDB *pmdid = CMDIdGPDB::PmdidConvert(ptabdesc->Pmdid());
 	pmdid->AddRef();
-	
+
 	CDXLTableDescr *pdxltabdesc = GPOS_NEW(m_pmp) CDXLTableDescr(m_pmp, pmdid, pmdnameTbl, ptabdesc->UlExecuteAsUser());
 
 	const ULONG ulColumns = ptabdesc->UlColumns();
@@ -6915,11 +6915,11 @@ CTranslatorExprToDXL::Pdxltabdesc
 	for (ULONG ul = 0; ul < ulColumns; ul++)
 	{
 		const CColumnDescriptor *pcd = ptabdesc->Pcoldesc(ul);
-		
+
 		GPOS_ASSERT(NULL != pcd);
-		
+
 		CMDName *pmdnameCol = GPOS_NEW(m_pmp) CMDName(m_pmp, pcd->Name().Pstr());
-		 
+
 		// output col ref for the current col descrs
 		CColRef *pcr = NULL;
 		if (NULL != pdrgpcrOutput)
@@ -6935,7 +6935,7 @@ CTranslatorExprToDXL::Pdxltabdesc
 		// colid for the dxl column
 		CMDIdGPDB *pmdidColType = CMDIdGPDB::PmdidConvert(pcr->Pmdtype()->Pmdid());
 		pmdidColType->AddRef();
-		
+
 		CDXLColDescr *pdxlcd = GPOS_NEW(m_pmp) CDXLColDescr
 											(
 											m_pmp,
@@ -6946,10 +6946,10 @@ CTranslatorExprToDXL::Pdxltabdesc
 											false /* fdropped */,
 											pcd->UlWidth()
 											);
-		
-		pdxltabdesc->AddColumnDescr(pdxlcd);		
+
+		pdxltabdesc->AddColumnDescr(pdxlcd);
 	}
-	
+
 	return pdxltabdesc;
 }
 
@@ -7037,14 +7037,14 @@ CTranslatorExprToDXL::PdxlnProjList
 	)
 {
 	GPOS_ASSERT(NULL != pcrsOutput);
-	
+
 	CDXLScalarProjList *pdxlopPrL = GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp);
 	CDXLNode *pdxlnPrL = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopPrL);
 
 	if (NULL != pdrgpcr)
 	{
 		CColRefSet *pcrs= GPOS_NEW(m_pmp) CColRefSet(m_pmp);
-		
+
 		for (ULONG ul = 0; ul < pdrgpcr->UlLength(); ul++)
 		{
 			CColRef *pcr = (*pdrgpcr)[ul];
@@ -7080,7 +7080,7 @@ CTranslatorExprToDXL::PdxlnProjList
 			pdxlnPrL->AddChild(pdxlnPrEl);
 		}
 	}
-	
+
 	return pdxlnPrL;
 }
 
@@ -7109,23 +7109,23 @@ CTranslatorExprToDXL::PdxlnProjList
 	// translate computed column expressions into DXL and index them on their col ids
 	CHashMap<ULONG, CDXLNode, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>, CleanupDelete<ULONG>, CleanupRelease<CDXLNode> >
 		*phmComputedColumns = GPOS_NEW(m_pmp) CHashMap<ULONG, CDXLNode, gpos::UlHash<ULONG>, gpos::FEqual<ULONG>, CleanupDelete<ULONG>, CleanupRelease<CDXLNode> >(m_pmp);
-	
+
 	for (ULONG ul = 0; NULL != pexprProjList && ul < pexprProjList->UlArity(); ul++)
 	{
 		CExpression *pexprProjElem = (*pexprProjList)[ul];
 
 		// translate proj elem
 		CDXLNode *pdxlnProjElem = PdxlnProjElem(pexprProjElem);
-		
+
 		const CScalarProjectElement *popScPrEl =
 				CScalarProjectElement::PopConvert(pexprProjElem->Pop());
-		
+
 		ULONG *pulKey = GPOS_NEW(m_pmp) ULONG(popScPrEl->Pcr()->UlId());
 #ifdef GPOS_DEBUG
 		BOOL fInserted =
 #endif // GPOS_DEBUG
 		phmComputedColumns->FInsert(pulKey, pdxlnProjElem);
-		
+
 		GPOS_ASSERT(fInserted);
 	}
 
@@ -7143,7 +7143,7 @@ CTranslatorExprToDXL::PdxlnProjList
 			pdrgpcrCopy->Append(pcr);
 		}
 	}
-	
+
 	// translate project list according to the specified order
 	CDXLScalarProjList *pdxlopPrL = GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp);
 	CDXLNode *pdxlnProjList = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopPrL);
@@ -7154,7 +7154,7 @@ CTranslatorExprToDXL::PdxlnProjList
 		CColRef *pcr = (*pdrgpcrCopy)[ul];
 		ULONG ulKey = pcr->UlId();
 		CDXLNode *pdxlnProjElem = phmComputedColumns->PtLookup(&ulKey);
-		
+
 		if (NULL == pdxlnProjElem)
 		{
 			// not a computed column
@@ -7164,7 +7164,7 @@ CTranslatorExprToDXL::PdxlnProjList
 		{
 			pdxlnProjElem->AddRef();
 		}
-		
+
 		pdxlnProjList->AddChild(pdxlnProjElem);
 	}
 
@@ -7172,7 +7172,7 @@ CTranslatorExprToDXL::PdxlnProjList
 	pdrgpcrCopy->Release();
 	pcrsOutput->Release();
 	phmComputedColumns->Release();
-	
+
 	return pdxlnProjList;
 }
 
@@ -7193,10 +7193,10 @@ CTranslatorExprToDXL::PdxlnProjList
 {
 	CDXLScalarProjList *pdxlopPrL = GPOS_NEW(m_pmp) CDXLScalarProjList(m_pmp);
 	CDXLNode *pdxlnProjList = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopPrL);
-	
+
 	// create a copy of the required output columns
 	CColRefSet *pcrsOutput = GPOS_NEW(m_pmp) CColRefSet(m_pmp, *pcrsRequired);
-	
+
 	if (NULL != pexprProjList)
 	{
 		// translate defined columns from project list

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalAbstractBitmapScan.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalAbstractBitmapScan.h
@@ -21,6 +21,15 @@ namespace gpdxl
 {
 	using namespace gpos;
 
+	enum Edxlbs
+	{
+		EdxlbsIndexProjList = 0,
+		EdxlbsIndexFilter,
+		EdxlbsIndexRecheckCond,
+		EdxlbsIndexBitmap,
+		EdxlbsSentinel
+	};
+
 	// fwd declarations
 	class CDXLTableDescr;
 	class CXMLSerializer;

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDynamicTableScan.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDynamicTableScan.h
@@ -25,6 +25,7 @@ namespace gpdxl
 	enum Edxldts
 	{
 		EdxldtsIndexProjList = 0,
+		EdxldtsIndexFilter,
 		EdxldtsSentinel
 	};
 	

--- a/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
@@ -28,6 +28,7 @@ ULONG CPartTblTest::m_ulPartTblTestCounter = 0;  // start from first test
 // minidump files
 const CHAR *rgszPartTblFileNames[] =
 	{
+	"../data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp",
 	"../data/dxl/minidump/Select-Over-PartTbl.mdp",
 	"../data/dxl/minidump/PartTbl-DPE.mdp",
 	"../data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp",


### PR DESCRIPTION
When the outer child of correlated nest loop join is a partition table,
and it has predicate on the partition key, Orca generated plan with
dynamic partition selector and scan for the outer child, however while
translating plan expression to DXL ORCA always assumed that the outer child
is a relation instead of physical sequence, which caused Orca to replace
the partition selector with filter.

Here is an example to reproduce the issue:
```sql
create table t2(c int, d int);
create table h(j int, i int) DISTRIBUTED BY (i) PARTITION by RANGE(j) (START (1) END (3) EVERY (1));
select (select h.i from t2) from h where h.j = 1;
```
This issue has been fixed in this patch and relevant tests are added.