### PR TITLE
[#129977107] Performance enhancement for pruning unused computed columns

### DIFF
--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -157,9 +157,18 @@ namespace gpopt
 			static
 			CExpression *PexprInferPredicates(IMemoryPool *pmp, CExpression *pexpr);
 
-			// driver for pruning unused computed columns
+			// entry for pruning unused computed columns
 			static CExpression *
 			PexprPruneUnusedComputedCols
+				(
+				IMemoryPool *pmp,
+				CExpression *pexpr,
+				CColRefSet *pcrsReqd
+				);
+
+			// driver for pruning unused computed columns
+			static CExpression *
+			PexprPruneUnusedComputedColsRecursive
 				(
 				IMemoryPool *pmp,
 				CExpression *pexpr,


### PR DESCRIPTION
Pruning unused computed columns is a preprocessing step for orca which
is performed on the initial query.

The required columns passed by the query is fed to this preprocessing
stage and the list of columns are copied to a new list in every
recursive call. The generated new list is deleted in the end the
original required columns is unchanged after the preprocessing stage.

Therefore to avoid the extra copy oparation which causes orca to spend
significant optimization time, we remove the copy operation and pass the
required columns set by reference.

For the initial copy we introduced PexprPruneUnusedComputedColsTop
function which is called once and responsible for copying initial set
to a set that will be processed and deleted when the preprocessing
stage is over.

The functional behaviour of the PruneUnusedComputedCols changed a little
because we do not delete the required column set at the end of every
call but pass it to the next and consecutive recursive calls. However,
it is safe to the that because non of the required columns from other
child of a tree will appear on the project list of the other children.
Therefore, the added columns to the required columns which is caused by
the recursive call and passing by reference will not have a bad affect
on the overall result.

No extra test case is provided since the code does not change or fix any
query that produces wrong results. There is a test suite that tests this
preprocessing stage allready.