### PR TITLE
Hint to disable CXformExpandNAryJoinDP when join has large number of children [#121181555]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 671)
+set(GPORCA_VERSION_MINOR 672)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.671
+LIB_VERSION = 1.672
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/CJoinOrderDPTest/DisableDPJoinOrderForLargeArity.mdp
+++ b/data/dxl/minidump/CJoinOrderDPTest/DisableDPJoinOrderForLargeArity.mdp
@@ -1,0 +1,2932 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CREATE TABLE foo1 (
+    a1 integer NOT NULL,
+    a2 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo2 (
+    b1 integer NOT NULL,
+    b2 integer
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+
+CREATE TABLE foo3 (
+    c1 integer NOT NULL,
+    c2 integer NOT NULL,
+    c3 integer NOT NULL,
+    c4 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+
+CREATE TABLE foo4 (
+    d1 integer NOT NULL,
+    d2 integer NOT NULL,
+    d3 integer NOT NULL,
+    d4 integer NOT NULL,
+    d5 numeric(19,2)
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo5 (
+    e1 integer NOT NULL,
+    e2 smallint NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo6 (
+    f1 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo7 (
+    m1 integer NOT NULL,
+    m2 integer NOT NULL,
+    m3 integer NOT NULL,
+    m4 integer NOT NULL,
+    m5 integer NOT NULL,
+    m6 integer,
+    m7 integer,
+    m8 integer,
+    m9 integer
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo8 (
+    h1 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo9 (
+    g1 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo10 (
+    i1 integer NOT NULL,
+    i2 character varying(60) NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo11 (
+    j1 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo12 (
+    k1 integer NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+CREATE TABLE foo13 (
+    l1 integer NOT NULL,
+    l2 integer NOT NULL,
+    l3 character varying(90) NOT NULL,
+    l4 character varying(18) NOT NULL,
+    l5 character varying(12) NOT NULL,
+    l6 character varying(18) NOT NULL,
+    l7 integer NOT NULL,
+    l8 integer NOT NULL,
+    l9 character varying(180) NOT NULL,
+    l10 character varying(180) NOT NULL
+)
+WITH (appendonly=true) DISTRIBUTED RANDOMLY;
+
+SELECT R4.M8 AS column0, SUM(FOO4.d5) AS column1 
+FROM foo2 FOO2 
+INNER JOIN foo1 FOO1 ON FOO2.b2 = FOO1.a2 
+INNER JOIN foo4 FOO4 ON FOO4.d2 = FOO2.b1 
+INNER JOIN foo5 FOO5 ON FOO4.d1 = FOO5.e1 
+INNER JOIN 	( SELECT FOO7.m8 AS M8, FOO7.m1 AS M1 
+		FROM foo6 FOO6 
+		INNER JOIN foo7 FOO7 ON FOO6.f1 = FOO7.m9 
+		INNER JOIN foo8 FOO8 ON FOO7.m6 = FOO8.h1 
+		INNER JOIN foo9 FOO9 ON FOO7.m2 = FOO9.g1 
+		INNER JOIN 	( SELECT FOO10.i1 AS i1 
+				FROM foo10 FOO10 
+				WHERE FOO10.i2 = 'EN' ) FOO10 ON FOO7.m5 = FOO10.i1 
+		INNER JOIN foo11 FOO11 ON FOO7.m7 = FOO11.j1 
+		INNER JOIN foo12 FOO12 ON FOO7.m4 = FOO12.k1 ) R4 ON R4.M1 = FOO4.d4 
+INNER JOIN	( SELECT FOO7.m3 AS M3, FOO7.m1 AS M1 
+		FROM foo6 FOO6 
+		INNER JOIN foo7 FOO7 ON FOO6.f1 = FOO7.m9 
+		INNER JOIN foo8 FOO8 ON FOO7.m6 = FOO8.h1 
+		INNER JOIN foo9 FOO9 ON FOO7.m2 = FOO9.g1 
+		INNER JOIN 	( SELECT FOO10.i1 AS i1 FROM foo10 FOO10 
+				WHERE FOO10.i2 = 'EN' ) FOO10 ON FOO7.m5 = FOO10.i1 
+		INNER JOIN foo11 FOO11 ON FOO7.m7 = FOO11.j1 
+		INNER JOIN foo12 FOO12 ON FOO7.m4 = FOO12.k1 ) R5 ON R5.M1 = FOO4.d4 
+INNER JOIN 	( SELECT R2.L8 AS L8, FOO3.c2 AS C2, FOO3.c1 AS C1
+		FROM 	( SELECT FOO13.l8 AS L8, FOO13.l1 AS L1, FOO13.l2 AS L2, FOO13.l4 AS L4, FOO13.l5 AS L5, FOO13.l6 AS L6,FOO13.l7 AS L7, FOO13.l9 AS L9, FOO13.l10 AS L10, '../samples/images/' || FOO13.l3 AS L3 
+			FROM foo13 FOO13 ) R2 
+		INNER JOIN foo3 FOO3 ON R2.L8 = FOO3.c3 ) R3 ON R3.C1 = FOO4.d3 
+
+INNER JOIN 	( SELECT FOO3.c4 AS C4, FOO3.c2 AS C2 
+		FROM foo3 FOO3
+		GROUP BY FOO3.c4, FOO3.c2 ) R1 ON R1.C2 = R3.C2 
+WHERE FOO1.a1 IN ( 9929 ) AND CAST(FOO5.e2 AS CHAR(4)) = '2011' 
+AND R5.M3 IN ( 961 ) 
+AND R3.L8 = 740 
+AND R1.C4 = 7 
+GROUP BY R4.M8;
+
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.29187.1.1" Name="foo13" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.29187.1.1" Name="foo13" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="12,10" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="l1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l2" Attno="2" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l3" Attno="3" Mdid="0.1043.1.0" Nullable="false" ColWidth="90">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l4" Attno="4" Mdid="0.1043.1.0" Nullable="false" ColWidth="18">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l5" Attno="5" Mdid="0.1043.1.0" Nullable="false" ColWidth="12">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l6" Attno="6" Mdid="0.1043.1.0" Nullable="false" ColWidth="18">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l7" Attno="7" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l8" Attno="8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l9" Attno="9" Mdid="0.1043.1.0" Nullable="false" ColWidth="180">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l10" Attno="10" Mdid="0.1043.1.0" Nullable="false" ColWidth="180">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.29063.1.1" Name="foo9" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.29063.1.1" Name="foo9" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="3,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="g1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.28939.1.1" Name="foo5" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.28939.1.1" Name="foo5" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="4,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="e1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e2" Attno="2" Mdid="0.21.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.9" Name="l10" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.8" Name="l9" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.1" Name="l2" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.0" Name="l1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29094.1.1.1" Name="i2" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29094.1.1.0" Name="i1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29063.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29063.1.1.0" Name="g1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.28815.1.1" Name="foo1" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.28815.1.1" Name="foo1" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="4,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="a2" Attno="2" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.654.1.0" Name="||" ComparisonType="Other" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.25.1.0"/>
+        <dxl:OpFunc Mdid="0.1258.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1042.1.0" Name="bpchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.1054.1.0"/>
+        <dxl:InequalityOp Mdid="0.1057.1.0"/>
+        <dxl:LessThanOp Mdid="0.1058.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1059.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1060.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1061.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1078.1.0"/>
+        <dxl:ArrayType Mdid="0.1014.1.0"/>
+        <dxl:MinAgg Mdid="0.2245.1.0"/>
+        <dxl:MaxAgg Mdid="0.2244.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.21.1.0" Name="int2" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="2" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.94.1.0"/>
+        <dxl:InequalityOp Mdid="0.519.1.0"/>
+        <dxl:LessThanOp Mdid="0.95.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.522.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.520.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.524.1.0"/>
+        <dxl:ComparisonOp Mdid="0.350.1.0"/>
+        <dxl:ArrayType Mdid="0.1005.1.0"/>
+        <dxl:MinAgg Mdid="0.2133.1.0"/>
+        <dxl:MaxAgg Mdid="0.2117.1.0"/>
+        <dxl:AvgAgg Mdid="0.2102.1.0"/>
+        <dxl:SumAgg Mdid="0.2109.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.6" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29156.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29156.1.1.0" Name="k1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29125.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29125.1.1.0" Name="j1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.7" Name="m8" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.6" Name="m7" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.668.1.0" Name="bpchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
+        <dxl:ResultType Mdid="0.1042.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:GPDBScalarOp Mdid="0.1054.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.1042.1.0"/>
+        <dxl:RightType Mdid="0.1042.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1048.1.0"/>
+        <dxl:Commutator Mdid="0.1054.1.0"/>
+        <dxl:InverseOp Mdid="0.1057.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.426.1.0"/>
+          <dxl:OpClass Mdid="0.427.1.0"/>
+          <dxl:OpClass Mdid="0.3018.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.29094.1.1" Name="foo10" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.29094.1.1" Name="foo10" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="4,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="i2" Attno="2" Mdid="0.1043.1.0" Nullable="false" ColWidth="60">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.28970.1.1" Name="foo6" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.28970.1.1" Name="foo6" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="3,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="f1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.11" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.10" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.3" Name="l4" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.2" Name="l3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29094.1.1.3" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29094.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29063.1.1.3" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29063.1.1.2" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28939.1.1.4" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28815.1.1.4" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28846.1.1.4" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.28846.1.1" Name="foo2" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.28846.1.1" Name="foo2" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="4,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b2" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.5" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29156.1.1.3" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29156.1.1.2" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29125.1.1.3" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29125.1.1.2" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.5" Name="m6" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.4" Name="m5" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.5" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.4" Name="d5" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
+      <dxl:GPDBAgg Mdid="0.2114.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationStatistics Mdid="2.29125.1.1" Name="foo11" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.29125.1.1" Name="foo11" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="3,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="j1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.12" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.5" Name="l6" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.4" Name="l5" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29094.1.1.4" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.29001.1.1" Name="foo7" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:ColumnStatistics Mdid="1.28970.1.1.3" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28970.1.1.2" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28939.1.1.3" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28939.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28815.1.1.3" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28815.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28846.1.1.3" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28846.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Relation Mdid="0.29001.1.1" Name="foo7" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="11,9" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="m1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m2" Attno="2" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m3" Attno="3" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m4" Attno="4" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m5" Attno="5" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m6" Attno="6" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m7" Attno="7" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m8" Attno="8" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m9" Attno="9" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.28877.1.1" Name="foo3" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.28877.1.1" Name="foo3" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="6,4" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c2" Attno="2" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c3" Attno="3" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c4" Attno="4" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.3" Name="c4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.2" Name="c3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29032.1.1.3" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29032.1.1.2" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.11" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.10" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.2" Name="m3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.3" Name="m4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.3" Name="d4" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.2" Name="d3" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1994.1.0"/>
+          <dxl:OpClass Mdid="0.1995.1.0"/>
+          <dxl:OpClass Mdid="0.3035.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.29156.1.1" Name="foo12" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.29156.1.1" Name="foo12" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="3,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="k1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.6" Name="l7" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29187.1.1.7" Name="l8" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.29032.1.1" Name="foo8" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:ColumnStatistics Mdid="1.28970.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28970.1.1.0" Name="f1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28939.1.1.1" Name="e2" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28939.1.1.0" Name="e1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28815.1.1.1" Name="a2" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28815.1.1.0" Name="a1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28846.1.1.1" Name="b2" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28846.1.1.0" Name="b1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Relation Mdid="0.29032.1.1" Name="foo8" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="3,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="h1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.28908.1.1" Name="foo4" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.28908.1.1" Name="foo4" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Random" Keys="7,5" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="d1" Attno="1" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d2" Attno="2" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d3" Attno="3" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d4" Attno="4" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d5" Attno="5" Mdid="0.1700.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.1" Name="c2" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28877.1.1.0" Name="c1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29032.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29032.1.1.0" Name="h1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.9" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.8" Name="m9" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.1" Name="m2" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.29001.1.1.0" Name="m1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.1" Name="d2" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.28908.1.1.0" Name="d1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="35" ColName="column0" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="126" ColName="column1" TypeMdid="0.1700.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="35"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="126" Alias="column1">
+            <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Normal">
+              <dxl:Ident ColId="15" ColName="d5" TypeMdid="0.1700.1.0"/>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalSelect>
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="6" ColName="a1" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9929"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+              <dxl:FuncExpr FuncId="0.668.1.0" FuncRetSet="false" TypeMdid="0.1042.1.0">
+                <dxl:CoerceViaIO TypeMdid="0.1042.1.0" TypeModification="-1" CoercionForm="2" Location="0">
+                  <dxl:Ident ColId="20" ColName="e2" TypeMdid="0.21.1.0"/>
+                </dxl:CoerceViaIO>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="8"/>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:FuncExpr>
+              <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACDIwMTE=" LintValue="91628332"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="67" ColName="m3" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="961"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="105" ColName="l8" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="740"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="122" ColName="c4" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7"/>
+            </dxl:Comparison>
+          </dxl:And>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalJoin JoinType="Inner">
+              <dxl:LogicalJoin JoinType="Inner">
+                <dxl:LogicalJoin JoinType="Inner">
+                  <dxl:LogicalJoin JoinType="Inner">
+                    <dxl:LogicalJoin JoinType="Inner">
+                      <dxl:LogicalJoin JoinType="Inner">
+                        <dxl:LogicalGet>
+                          <dxl:TableDescriptor Mdid="0.28846.1.1" TableName="foo2">
+                            <dxl:Columns>
+                              <dxl:Column ColId="1" Attno="1" ColName="b1" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="2" Attno="2" ColName="b2" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="4" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="5" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:LogicalGet>
+                        <dxl:LogicalGet>
+                          <dxl:TableDescriptor Mdid="0.28815.1.1" TableName="foo1">
+                            <dxl:Columns>
+                              <dxl:Column ColId="6" Attno="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="7" Attno="2" ColName="a2" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="8" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:LogicalGet>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="2" ColName="b2" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="7" ColName="a2" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:LogicalJoin>
+                      <dxl:LogicalGet>
+                        <dxl:TableDescriptor Mdid="0.28908.1.1" TableName="foo4">
+                          <dxl:Columns>
+                            <dxl:Column ColId="11" Attno="1" ColName="d1" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="12" Attno="2" ColName="d2" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="13" Attno="3" ColName="d3" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="14" Attno="4" ColName="d4" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="15" Attno="5" ColName="d5" TypeMdid="0.1700.1.0"/>
+                            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:LogicalGet>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="12" ColName="d2" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="1" ColName="b1" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:LogicalJoin>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.28939.1.1" TableName="foo5">
+                        <dxl:Columns>
+                          <dxl:Column ColId="19" Attno="1" ColName="e1" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="20" Attno="2" ColName="e2" TypeMdid="0.21.1.0"/>
+                          <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="11" ColName="d1" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="19" ColName="e1" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:LogicalJoin>
+                  <dxl:LogicalJoin JoinType="Inner">
+                    <dxl:LogicalJoin JoinType="Inner">
+                      <dxl:LogicalJoin JoinType="Inner">
+                        <dxl:LogicalJoin JoinType="Inner">
+                          <dxl:LogicalJoin JoinType="Inner">
+                            <dxl:LogicalJoin JoinType="Inner">
+                              <dxl:LogicalGet>
+                                <dxl:TableDescriptor Mdid="0.28970.1.1" TableName="foo6">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="24" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:LogicalGet>
+                              <dxl:LogicalGet>
+                                <dxl:TableDescriptor Mdid="0.29001.1.1" TableName="foo7">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="28" Attno="1" ColName="m1" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="29" Attno="2" ColName="m2" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="30" Attno="3" ColName="m3" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="31" Attno="4" ColName="m4" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="32" Attno="5" ColName="m5" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="33" Attno="6" ColName="m6" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="34" Attno="7" ColName="m7" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="35" Attno="8" ColName="m8" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="36" Attno="9" ColName="m9" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="37" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="38" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="39" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:LogicalGet>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="24" ColName="f1" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="36" ColName="m9" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:LogicalJoin>
+                            <dxl:LogicalGet>
+                              <dxl:TableDescriptor Mdid="0.29032.1.1" TableName="foo8">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="40" Attno="1" ColName="h1" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="41" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="42" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="43" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:LogicalGet>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="33" ColName="m6" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="40" ColName="h1" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:LogicalJoin>
+                          <dxl:LogicalGet>
+                            <dxl:TableDescriptor Mdid="0.29063.1.1" TableName="foo9">
+                              <dxl:Columns>
+                                <dxl:Column ColId="44" Attno="1" ColName="g1" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="45" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="46" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="47" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:LogicalGet>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="29" ColName="m2" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="44" ColName="g1" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:LogicalJoin>
+                        <dxl:LogicalSelect>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                            <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                              <dxl:Ident ColId="49" ColName="i2" TypeMdid="0.1043.1.0"/>
+                            </dxl:Cast>
+                            <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABkVO" LintValue="698204972"/>
+                          </dxl:Comparison>
+                          <dxl:LogicalGet>
+                            <dxl:TableDescriptor Mdid="0.29094.1.1" TableName="foo10">
+                              <dxl:Columns>
+                                <dxl:Column ColId="48" Attno="1" ColName="i1" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="49" Attno="2" ColName="i2" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                <dxl:Column ColId="50" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="51" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="52" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:LogicalGet>
+                        </dxl:LogicalSelect>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="32" ColName="m5" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="48" ColName="i1" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:LogicalJoin>
+                      <dxl:LogicalGet>
+                        <dxl:TableDescriptor Mdid="0.29125.1.1" TableName="foo11">
+                          <dxl:Columns>
+                            <dxl:Column ColId="53" Attno="1" ColName="j1" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="54" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="55" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="56" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:LogicalGet>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="34" ColName="m7" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="53" ColName="j1" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:LogicalJoin>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.29156.1.1" TableName="foo12">
+                        <dxl:Columns>
+                          <dxl:Column ColId="57" Attno="1" ColName="k1" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="58" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="59" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="60" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="31" ColName="m4" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="57" ColName="k1" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:LogicalJoin>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="28" ColName="m1" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="14" ColName="d4" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:LogicalJoin>
+                <dxl:LogicalJoin JoinType="Inner">
+                  <dxl:LogicalJoin JoinType="Inner">
+                    <dxl:LogicalJoin JoinType="Inner">
+                      <dxl:LogicalJoin JoinType="Inner">
+                        <dxl:LogicalJoin JoinType="Inner">
+                          <dxl:LogicalJoin JoinType="Inner">
+                            <dxl:LogicalGet>
+                              <dxl:TableDescriptor Mdid="0.28970.1.1" TableName="foo6">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="61" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="62" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="63" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="64" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:LogicalGet>
+                            <dxl:LogicalGet>
+                              <dxl:TableDescriptor Mdid="0.29001.1.1" TableName="foo7">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="65" Attno="1" ColName="m1" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="66" Attno="2" ColName="m2" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="67" Attno="3" ColName="m3" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="68" Attno="4" ColName="m4" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="69" Attno="5" ColName="m5" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="70" Attno="6" ColName="m6" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="71" Attno="7" ColName="m7" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="72" Attno="8" ColName="m8" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="73" Attno="9" ColName="m9" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="74" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="75" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="76" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:LogicalGet>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="61" ColName="f1" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="73" ColName="m9" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:LogicalJoin>
+                          <dxl:LogicalGet>
+                            <dxl:TableDescriptor Mdid="0.29032.1.1" TableName="foo8">
+                              <dxl:Columns>
+                                <dxl:Column ColId="77" Attno="1" ColName="h1" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="78" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="79" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="80" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:LogicalGet>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="70" ColName="m6" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="77" ColName="h1" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:LogicalJoin>
+                        <dxl:LogicalGet>
+                          <dxl:TableDescriptor Mdid="0.29063.1.1" TableName="foo9">
+                            <dxl:Columns>
+                              <dxl:Column ColId="81" Attno="1" ColName="g1" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="82" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="83" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="84" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:LogicalGet>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="66" ColName="m2" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="81" ColName="g1" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:LogicalJoin>
+                      <dxl:LogicalSelect>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                            <dxl:Ident ColId="86" ColName="i2" TypeMdid="0.1043.1.0"/>
+                          </dxl:Cast>
+                          <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABkVO" LintValue="698204972"/>
+                        </dxl:Comparison>
+                        <dxl:LogicalGet>
+                          <dxl:TableDescriptor Mdid="0.29094.1.1" TableName="foo10">
+                            <dxl:Columns>
+                              <dxl:Column ColId="85" Attno="1" ColName="i1" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="86" Attno="2" ColName="i2" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                              <dxl:Column ColId="87" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="88" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="89" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:LogicalGet>
+                      </dxl:LogicalSelect>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="69" ColName="m5" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="85" ColName="i1" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:LogicalJoin>
+                    <dxl:LogicalGet>
+                      <dxl:TableDescriptor Mdid="0.29125.1.1" TableName="foo11">
+                        <dxl:Columns>
+                          <dxl:Column ColId="90" Attno="1" ColName="j1" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="92" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="93" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="71" ColName="m7" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="90" ColName="j1" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:LogicalJoin>
+                  <dxl:LogicalGet>
+                    <dxl:TableDescriptor Mdid="0.29156.1.1" TableName="foo12">
+                      <dxl:Columns>
+                        <dxl:Column ColId="94" Attno="1" ColName="k1" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="95" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="96" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="97" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:LogicalGet>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="68" ColName="m4" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="94" ColName="k1" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:LogicalJoin>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="65" ColName="m1" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="14" ColName="d4" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:LogicalJoin>
+              <dxl:LogicalJoin JoinType="Inner">
+                <dxl:LogicalProject>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="111" Alias="l3">
+                      <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                        <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAAFi4uL3NhbXBsZXMvaW1hZ2VzLw==" LintValue="361882476"/>
+                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                          <dxl:Ident ColId="100" ColName="l3" TypeMdid="0.1043.1.0"/>
+                        </dxl:Cast>
+                      </dxl:OpExpr>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:LogicalGet>
+                    <dxl:TableDescriptor Mdid="0.29187.1.1" TableName="foo13">
+                      <dxl:Columns>
+                        <dxl:Column ColId="98" Attno="1" ColName="l1" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="99" Attno="2" ColName="l2" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="100" Attno="3" ColName="l3" TypeMdid="0.1043.1.0" ColWidth="90"/>
+                        <dxl:Column ColId="101" Attno="4" ColName="l4" TypeMdid="0.1043.1.0" ColWidth="18"/>
+                        <dxl:Column ColId="102" Attno="5" ColName="l5" TypeMdid="0.1043.1.0" ColWidth="12"/>
+                        <dxl:Column ColId="103" Attno="6" ColName="l6" TypeMdid="0.1043.1.0" ColWidth="18"/>
+                        <dxl:Column ColId="104" Attno="7" ColName="l7" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="105" Attno="8" ColName="l8" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="106" Attno="9" ColName="l9" TypeMdid="0.1043.1.0" ColWidth="180"/>
+                        <dxl:Column ColId="107" Attno="10" ColName="l10" TypeMdid="0.1043.1.0" ColWidth="180"/>
+                        <dxl:Column ColId="108" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="109" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="110" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:LogicalGet>
+                </dxl:LogicalProject>
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.28877.1.1" TableName="foo3">
+                    <dxl:Columns>
+                      <dxl:Column ColId="112" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="113" Attno="2" ColName="c2" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="114" Attno="3" ColName="c3" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="115" Attno="4" ColName="c4" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="116" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="117" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="118" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="105" ColName="l8" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="114" ColName="c3" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:LogicalJoin>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="112" ColName="c1" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="13" ColName="d3" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:LogicalJoin>
+            <dxl:LogicalGroupBy>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="122"/>
+                <dxl:GroupingColumn ColId="120"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList/>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.28877.1.1" TableName="foo3">
+                  <dxl:Columns>
+                    <dxl:Column ColId="119" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="120" Attno="2" ColName="c2" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="121" Attno="3" ColName="c3" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="122" Attno="4" ColName="c4" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="123" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="124" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="125" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:LogicalGroupBy>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="120" ColName="c2" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="113" ColName="c2" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+        </dxl:LogicalSelect>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="0">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="9051.008544" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="34" Alias="column0">
+            <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="125" Alias="column1">
+            <dxl:Ident ColId="125" ColName="column1" TypeMdid="0.1700.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="9051.008500" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="34"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="34" Alias="m8">
+              <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="125" Alias="column1">
+              <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Final">
+                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.1700.1.0"/>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="9051.008485" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="34" Alias="m8">
+                <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="34" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="9051.008485" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="34" Alias="m8">
+                  <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                  <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="9051.008466" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="34" Alias="m8">
+                    <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                    <dxl:Ident ColId="126" ColName="ColRef_0126" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="9051.008466" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="34"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="126" Alias="ColRef_0126">
+                      <dxl:AggFunc AggMdid="0.2114.1.0" AggDistinct="false" AggStage="Partial">
+                        <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="34" Alias="m8">
+                      <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="9051.008460" Rows="1.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="14" Alias="d5">
+                        <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="34" Alias="m8">
+                        <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="34" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:HashJoin JoinType="Inner">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="9051.008460" Rows="1.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="14" Alias="d5">
+                          <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="34" Alias="m8">
+                          <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:JoinFilter/>
+                      <dxl:HashCondList>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="43" ColName="g1" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:HashCondList>
+                      <dxl:HashJoin JoinType="Inner">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="8620.008117" Rows="1.000000" Width="16"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="14" Alias="d5">
+                            <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="m2">
+                            <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="m8">
+                            <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:JoinFilter/>
+                        <dxl:HashCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="52" ColName="j1" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:HashCondList>
+                        <dxl:HashJoin JoinType="Inner">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="8189.007768" Rows="1.000000" Width="20"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="14" Alias="d5">
+                              <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="28" Alias="m2">
+                              <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="33" Alias="m7">
+                              <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="34" Alias="m8">
+                              <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:JoinFilter/>
+                          <dxl:HashCondList>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="23" ColName="f1" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:HashCondList>
+                          <dxl:HashJoin JoinType="Inner">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="7758.007414" Rows="1.000000" Width="24"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="14" Alias="d5">
+                                <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="28" Alias="m2">
+                                <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="33" Alias="m7">
+                                <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="34" Alias="m8">
+                                <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="35" Alias="m9">
+                                <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:JoinFilter/>
+                            <dxl:HashCondList>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:HashCondList>
+                            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="1724.001157" Rows="1.000000" Width="20"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="27" Alias="m1">
+                                  <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="28" Alias="m2">
+                                  <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="33" Alias="m7">
+                                  <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="34" Alias="m8">
+                                  <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="35" Alias="m9">
+                                  <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:HashExprList>
+                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                              </dxl:HashExprList>
+                              <dxl:HashJoin JoinType="Inner">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="1724.001126" Rows="1.000000" Width="20"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="27" Alias="m1">
+                                    <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="28" Alias="m2">
+                                    <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="33" Alias="m7">
+                                    <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="34" Alias="m8">
+                                    <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="35" Alias="m9">
+                                    <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:JoinFilter/>
+                                <dxl:HashCondList>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="30" ColName="m4" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="56" ColName="k1" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:HashCondList>
+                                <dxl:HashJoin JoinType="Inner">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="1293.000771" Rows="1.000000" Width="24"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="27" Alias="m1">
+                                      <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="28" Alias="m2">
+                                      <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="30" Alias="m4">
+                                      <dxl:Ident ColId="30" ColName="m4" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="33" Alias="m7">
+                                      <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="34" Alias="m8">
+                                      <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="35" Alias="m9">
+                                      <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:JoinFilter/>
+                                  <dxl:HashCondList>
+                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                      <dxl:Ident ColId="31" ColName="m5" TypeMdid="0.23.1.0"/>
+                                      <dxl:Ident ColId="47" ColName="i1" TypeMdid="0.23.1.0"/>
+                                    </dxl:Comparison>
+                                  </dxl:HashCondList>
+                                  <dxl:HashJoin JoinType="Inner">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="862.000394" Rows="1.000000" Width="28"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="27" Alias="m1">
+                                        <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="28" Alias="m2">
+                                        <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="30" Alias="m4">
+                                        <dxl:Ident ColId="30" ColName="m4" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="31" Alias="m5">
+                                        <dxl:Ident ColId="31" ColName="m5" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="33" Alias="m7">
+                                        <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="34" Alias="m8">
+                                        <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="35" Alias="m9">
+                                        <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:JoinFilter/>
+                                    <dxl:HashCondList>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="32" ColName="m6" TypeMdid="0.23.1.0"/>
+                                        <dxl:Ident ColId="39" ColName="h1" TypeMdid="0.23.1.0"/>
+                                      </dxl:Comparison>
+                                    </dxl:HashCondList>
+                                    <dxl:TableScan>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="32"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="27" Alias="m1">
+                                          <dxl:Ident ColId="27" ColName="m1" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="28" Alias="m2">
+                                          <dxl:Ident ColId="28" ColName="m2" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="30" Alias="m4">
+                                          <dxl:Ident ColId="30" ColName="m4" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="31" Alias="m5">
+                                          <dxl:Ident ColId="31" ColName="m5" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="32" Alias="m6">
+                                          <dxl:Ident ColId="32" ColName="m6" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="33" Alias="m7">
+                                          <dxl:Ident ColId="33" ColName="m7" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="34" Alias="m8">
+                                          <dxl:Ident ColId="34" ColName="m8" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="35" Alias="m9">
+                                          <dxl:Ident ColId="35" ColName="m9" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:TableDescriptor Mdid="0.29001.1.1" TableName="foo7">
+                                        <dxl:Columns>
+                                          <dxl:Column ColId="27" Attno="1" ColName="m1" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="28" Attno="2" ColName="m2" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="29" Attno="3" ColName="m3" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="30" Attno="4" ColName="m4" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="31" Attno="5" ColName="m5" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="32" Attno="6" ColName="m6" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="33" Attno="7" ColName="m7" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="34" Attno="8" ColName="m8" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="35" Attno="9" ColName="m9" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                          <dxl:Column ColId="37" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                          <dxl:Column ColId="38" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                        </dxl:Columns>
+                                      </dxl:TableDescriptor>
+                                    </dxl:TableScan>
+                                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="39" Alias="h1">
+                                          <dxl:Ident ColId="39" ColName="h1" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:TableScan>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="39" Alias="h1">
+                                            <dxl:Ident ColId="39" ColName="h1" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="0.29032.1.1" TableName="foo8">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="39" Attno="1" ColName="h1" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="40" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                            <dxl:Column ColId="41" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                            <dxl:Column ColId="42" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                    </dxl:BroadcastMotion>
+                                  </dxl:HashJoin>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="3.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="47" Alias="i1">
+                                        <dxl:Ident ColId="47" ColName="i1" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:TableScan>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="47" Alias="i1">
+                                          <dxl:Ident ColId="47" ColName="i1" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter>
+                                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                                          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                            <dxl:Ident ColId="48" ColName="i2" TypeMdid="0.1043.1.0"/>
+                                          </dxl:Cast>
+                                          <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABkVO" LintValue="698204972"/>
+                                        </dxl:Comparison>
+                                      </dxl:Filter>
+                                      <dxl:TableDescriptor Mdid="0.29094.1.1" TableName="foo10">
+                                        <dxl:Columns>
+                                          <dxl:Column ColId="47" Attno="1" ColName="i1" TypeMdid="0.23.1.0"/>
+                                          <dxl:Column ColId="48" Attno="2" ColName="i2" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                          <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                          <dxl:Column ColId="50" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                          <dxl:Column ColId="51" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                        </dxl:Columns>
+                                      </dxl:TableDescriptor>
+                                    </dxl:TableScan>
+                                  </dxl:BroadcastMotion>
+                                </dxl:HashJoin>
+                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="56" Alias="k1">
+                                      <dxl:Ident ColId="56" ColName="k1" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="56" Alias="k1">
+                                        <dxl:Ident ColId="56" ColName="k1" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:TableDescriptor Mdid="0.29156.1.1" TableName="foo12">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="56" Attno="1" ColName="k1" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        <dxl:Column ColId="58" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                        <dxl:Column ColId="59" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:BroadcastMotion>
+                              </dxl:HashJoin>
+                            </dxl:RedistributeMotion>
+                            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="6034.005442" Rows="1.000000" Width="16"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="13" Alias="d4">
+                                  <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="14" Alias="d5">
+                                  <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="64" Alias="m1">
+                                  <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:SortingColumnList/>
+                              <dxl:HashExprList>
+                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                  <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                </dxl:HashExpr>
+                              </dxl:HashExprList>
+                              <dxl:HashJoin JoinType="Inner">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="6034.005417" Rows="1.000000" Width="16"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="13" Alias="d4">
+                                    <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="14" Alias="d5">
+                                    <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="64" Alias="m1">
+                                    <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:JoinFilter/>
+                                <dxl:HashCondList>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="113" ColName="c3" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="104" ColName="l8" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                </dxl:HashCondList>
+                                <dxl:HashJoin JoinType="Inner">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="5603.005046" Rows="1.000000" Width="20"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="13" Alias="d4">
+                                      <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="14" Alias="d5">
+                                      <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="64" Alias="m1">
+                                      <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="113" Alias="c3">
+                                      <dxl:Ident ColId="113" ColName="c3" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:JoinFilter/>
+                                  <dxl:HashCondList>
+                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                      <dxl:Ident ColId="112" ColName="c2" TypeMdid="0.23.1.0"/>
+                                      <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                    </dxl:Comparison>
+                                  </dxl:HashCondList>
+                                  <dxl:HashJoin JoinType="Inner">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="5172.004651" Rows="1.000000" Width="24"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="13" Alias="d4">
+                                        <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="14" Alias="d5">
+                                        <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="64" Alias="m1">
+                                        <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="112" Alias="c2">
+                                        <dxl:Ident ColId="112" ColName="c2" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="113" Alias="c3">
+                                        <dxl:Ident ColId="113" ColName="c3" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:JoinFilter/>
+                                    <dxl:HashCondList>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                        <dxl:Ident ColId="111" ColName="c1" TypeMdid="0.23.1.0"/>
+                                      </dxl:Comparison>
+                                    </dxl:HashCondList>
+                                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="4741.004022" Rows="1.000000" Width="20"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="12" Alias="d3">
+                                          <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="13" Alias="d4">
+                                          <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="14" Alias="d5">
+                                          <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="64" Alias="m1">
+                                          <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:HashExprList>
+                                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                                          <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                        </dxl:HashExpr>
+                                      </dxl:HashExprList>
+                                      <dxl:HashJoin JoinType="Inner">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="4741.003990" Rows="1.000000" Width="20"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="12" Alias="d3">
+                                            <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="13" Alias="d4">
+                                            <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="14" Alias="d5">
+                                            <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="64" Alias="m1">
+                                            <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:JoinFilter/>
+                                        <dxl:HashCondList>
+                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                            <dxl:Ident ColId="10" ColName="d1" TypeMdid="0.23.1.0"/>
+                                            <dxl:Ident ColId="18" ColName="e1" TypeMdid="0.23.1.0"/>
+                                          </dxl:Comparison>
+                                        </dxl:HashCondList>
+                                        <dxl:HashJoin JoinType="Inner">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="4310.003623" Rows="1.000000" Width="24"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="10" Alias="d1">
+                                              <dxl:Ident ColId="10" ColName="d1" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="12" Alias="d3">
+                                              <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="13" Alias="d4">
+                                              <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="14" Alias="d5">
+                                              <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="64" Alias="m1">
+                                              <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:JoinFilter/>
+                                          <dxl:HashCondList>
+                                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                              <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                              <dxl:Ident ColId="89" ColName="j1" TypeMdid="0.23.1.0"/>
+                                            </dxl:Comparison>
+                                          </dxl:HashCondList>
+                                          <dxl:HashJoin JoinType="Inner">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="3879.003263" Rows="1.000000" Width="28"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="10" Alias="d1">
+                                                <dxl:Ident ColId="10" ColName="d1" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="12" Alias="d3">
+                                                <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="13" Alias="d4">
+                                                <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="14" Alias="d5">
+                                                <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="64" Alias="m1">
+                                                <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="70" Alias="m7">
+                                                <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:JoinFilter/>
+                                            <dxl:HashCondList>
+                                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                <dxl:Ident ColId="11" ColName="d2" TypeMdid="0.23.1.0"/>
+                                                <dxl:Ident ColId="0" ColName="b1" TypeMdid="0.23.1.0"/>
+                                              </dxl:Comparison>
+                                            </dxl:HashCondList>
+                                            <dxl:HashJoin JoinType="Inner">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="3017.002548" Rows="1.000000" Width="32"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="10" Alias="d1">
+                                                  <dxl:Ident ColId="10" ColName="d1" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="11" Alias="d2">
+                                                  <dxl:Ident ColId="11" ColName="d2" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="12" Alias="d3">
+                                                  <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="13" Alias="d4">
+                                                  <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="14" Alias="d5">
+                                                  <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="64" Alias="m1">
+                                                  <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="70" Alias="m7">
+                                                  <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:JoinFilter/>
+                                              <dxl:HashCondList>
+                                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                  <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                  <dxl:Ident ColId="84" ColName="i1" TypeMdid="0.23.1.0"/>
+                                                </dxl:Comparison>
+                                              </dxl:HashCondList>
+                                              <dxl:HashJoin JoinType="Inner">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="2586.002160" Rows="1.000000" Width="36"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="10" Alias="d1">
+                                                    <dxl:Ident ColId="10" ColName="d1" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="11" Alias="d2">
+                                                    <dxl:Ident ColId="11" ColName="d2" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="12" Alias="d3">
+                                                    <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="13" Alias="d4">
+                                                    <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="14" Alias="d5">
+                                                    <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="64" Alias="m1">
+                                                    <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="68" Alias="m5">
+                                                    <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="70" Alias="m7">
+                                                    <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:JoinFilter/>
+                                                <dxl:HashCondList>
+                                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                    <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                                    <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                  </dxl:Comparison>
+                                                </dxl:HashCondList>
+                                                <dxl:TableScan>
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="24"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="10" Alias="d1">
+                                                      <dxl:Ident ColId="10" ColName="d1" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="11" Alias="d2">
+                                                      <dxl:Ident ColId="11" ColName="d2" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="12" Alias="d3">
+                                                      <dxl:Ident ColId="12" ColName="d3" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="13" Alias="d4">
+                                                      <dxl:Ident ColId="13" ColName="d4" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="14" Alias="d5">
+                                                      <dxl:Ident ColId="14" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:TableDescriptor Mdid="0.28908.1.1" TableName="foo4">
+                                                    <dxl:Columns>
+                                                      <dxl:Column ColId="10" Attno="1" ColName="d1" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="11" Attno="2" ColName="d2" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="12" Attno="3" ColName="d3" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="13" Attno="4" ColName="d4" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="14" Attno="5" ColName="d5" TypeMdid="0.1700.1.0"/>
+                                                      <dxl:Column ColId="15" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                    </dxl:Columns>
+                                                  </dxl:TableDescriptor>
+                                                </dxl:TableScan>
+                                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="2155.001661" Rows="3.000000" Width="12"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="64" Alias="m1">
+                                                      <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="68" Alias="m5">
+                                                      <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="70" Alias="m7">
+                                                      <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:SortingColumnList/>
+                                                  <dxl:HashJoin JoinType="Inner">
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="2155.001446" Rows="1.000000" Width="12"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="64" Alias="m1">
+                                                        <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="68" Alias="m5">
+                                                        <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                      <dxl:ProjElem ColId="70" Alias="m7">
+                                                        <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter/>
+                                                    <dxl:JoinFilter/>
+                                                    <dxl:HashCondList>
+                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                        <dxl:Ident ColId="65" ColName="m2" TypeMdid="0.23.1.0"/>
+                                                        <dxl:Ident ColId="80" ColName="g1" TypeMdid="0.23.1.0"/>
+                                                      </dxl:Comparison>
+                                                    </dxl:HashCondList>
+                                                    <dxl:HashJoin JoinType="Inner">
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="1724.001103" Rows="1.000000" Width="16"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="64" Alias="m1">
+                                                          <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="65" Alias="m2">
+                                                          <dxl:Ident ColId="65" ColName="m2" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="68" Alias="m5">
+                                                          <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                        <dxl:ProjElem ColId="70" Alias="m7">
+                                                          <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:JoinFilter/>
+                                                      <dxl:HashCondList>
+                                                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                          <dxl:Ident ColId="69" ColName="m6" TypeMdid="0.23.1.0"/>
+                                                          <dxl:Ident ColId="76" ColName="h1" TypeMdid="0.23.1.0"/>
+                                                        </dxl:Comparison>
+                                                      </dxl:HashCondList>
+                                                      <dxl:HashJoin JoinType="Inner">
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="1293.000754" Rows="1.000000" Width="20"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="64" Alias="m1">
+                                                            <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="65" Alias="m2">
+                                                            <dxl:Ident ColId="65" ColName="m2" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="68" Alias="m5">
+                                                            <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="69" Alias="m6">
+                                                            <dxl:Ident ColId="69" ColName="m6" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                          <dxl:ProjElem ColId="70" Alias="m7">
+                                                            <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:JoinFilter/>
+                                                        <dxl:HashCondList>
+                                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                            <dxl:Ident ColId="67" ColName="m4" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Ident ColId="93" ColName="k1" TypeMdid="0.23.1.0"/>
+                                                          </dxl:Comparison>
+                                                        </dxl:HashCondList>
+                                                        <dxl:HashJoin JoinType="Inner">
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="862.000400" Rows="1.000000" Width="24"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="64" Alias="m1">
+                                                            <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="65" Alias="m2">
+                                                            <dxl:Ident ColId="65" ColName="m2" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="67" Alias="m4">
+                                                            <dxl:Ident ColId="67" ColName="m4" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="68" Alias="m5">
+                                                            <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="69" Alias="m6">
+                                                            <dxl:Ident ColId="69" ColName="m6" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="70" Alias="m7">
+                                                            <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:JoinFilter/>
+                                                          <dxl:HashCondList>
+                                                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                            <dxl:Ident ColId="72" ColName="m9" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Ident ColId="60" ColName="f1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Comparison>
+                                                          </dxl:HashCondList>
+                                                          <dxl:TableScan>
+                                                            <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="28"/>
+                                                            </dxl:Properties>
+                                                            <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="64" Alias="m1">
+                                                            <dxl:Ident ColId="64" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="65" Alias="m2">
+                                                            <dxl:Ident ColId="65" ColName="m2" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="67" Alias="m4">
+                                                            <dxl:Ident ColId="67" ColName="m4" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="68" Alias="m5">
+                                                            <dxl:Ident ColId="68" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="69" Alias="m6">
+                                                            <dxl:Ident ColId="69" ColName="m6" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="70" Alias="m7">
+                                                            <dxl:Ident ColId="70" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            <dxl:ProjElem ColId="72" Alias="m9">
+                                                            <dxl:Ident ColId="72" ColName="m9" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            </dxl:ProjList>
+                                                            <dxl:Filter>
+                                                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                            <dxl:Ident ColId="66" ColName="m3" TypeMdid="0.23.1.0"/>
+                                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="961"/>
+                                                            </dxl:Comparison>
+                                                            </dxl:Filter>
+                                                            <dxl:TableDescriptor Mdid="0.29001.1.1" TableName="foo7">
+                                                            <dxl:Columns>
+                                                            <dxl:Column ColId="64" Attno="1" ColName="m1" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="65" Attno="2" ColName="m2" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="66" Attno="3" ColName="m3" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="67" Attno="4" ColName="m4" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="68" Attno="5" ColName="m5" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="69" Attno="6" ColName="m6" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="70" Attno="7" ColName="m7" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="71" Attno="8" ColName="m8" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="72" Attno="9" ColName="m9" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="73" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                            <dxl:Column ColId="74" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                            <dxl:Column ColId="75" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                            </dxl:TableDescriptor>
+                                                          </dxl:TableScan>
+                                                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                            <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                                            </dxl:Properties>
+                                                            <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="60" Alias="f1">
+                                                            <dxl:Ident ColId="60" ColName="f1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            </dxl:ProjList>
+                                                            <dxl:Filter/>
+                                                            <dxl:SortingColumnList/>
+                                                            <dxl:TableScan>
+                                                            <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                                            </dxl:Properties>
+                                                            <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="60" Alias="f1">
+                                                            <dxl:Ident ColId="60" ColName="f1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            </dxl:ProjList>
+                                                            <dxl:Filter/>
+                                                            <dxl:TableDescriptor Mdid="0.28970.1.1" TableName="foo6">
+                                                            <dxl:Columns>
+                                                            <dxl:Column ColId="60" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                            <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                            <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                            </dxl:TableDescriptor>
+                                                            </dxl:TableScan>
+                                                          </dxl:BroadcastMotion>
+                                                        </dxl:HashJoin>
+                                                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="93" Alias="k1">
+                                                            <dxl:Ident ColId="93" ColName="k1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:SortingColumnList/>
+                                                          <dxl:TableScan>
+                                                            <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                                            </dxl:Properties>
+                                                            <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="93" Alias="k1">
+                                                            <dxl:Ident ColId="93" ColName="k1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                            </dxl:ProjList>
+                                                            <dxl:Filter/>
+                                                            <dxl:TableDescriptor Mdid="0.29156.1.1" TableName="foo12">
+                                                            <dxl:Columns>
+                                                            <dxl:Column ColId="93" Attno="1" ColName="k1" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="94" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                            <dxl:Column ColId="95" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                            <dxl:Column ColId="96" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                            </dxl:TableDescriptor>
+                                                          </dxl:TableScan>
+                                                        </dxl:BroadcastMotion>
+                                                      </dxl:HashJoin>
+                                                      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="76" Alias="h1">
+                                                            <dxl:Ident ColId="76" ColName="h1" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:SortingColumnList/>
+                                                        <dxl:TableScan>
+                                                          <dxl:Properties>
+                                                            <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                                          </dxl:Properties>
+                                                          <dxl:ProjList>
+                                                            <dxl:ProjElem ColId="76" Alias="h1">
+                                                            <dxl:Ident ColId="76" ColName="h1" TypeMdid="0.23.1.0"/>
+                                                            </dxl:ProjElem>
+                                                          </dxl:ProjList>
+                                                          <dxl:Filter/>
+                                                          <dxl:TableDescriptor Mdid="0.29032.1.1" TableName="foo8">
+                                                            <dxl:Columns>
+                                                            <dxl:Column ColId="76" Attno="1" ColName="h1" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="77" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                            <dxl:Column ColId="78" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                            <dxl:Column ColId="79" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                            </dxl:Columns>
+                                                          </dxl:TableDescriptor>
+                                                        </dxl:TableScan>
+                                                      </dxl:BroadcastMotion>
+                                                    </dxl:HashJoin>
+                                                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                      <dxl:Properties>
+                                                        <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                                      </dxl:Properties>
+                                                      <dxl:ProjList>
+                                                        <dxl:ProjElem ColId="80" Alias="g1">
+                                                          <dxl:Ident ColId="80" ColName="g1" TypeMdid="0.23.1.0"/>
+                                                        </dxl:ProjElem>
+                                                      </dxl:ProjList>
+                                                      <dxl:Filter/>
+                                                      <dxl:SortingColumnList/>
+                                                      <dxl:TableScan>
+                                                        <dxl:Properties>
+                                                          <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                                        </dxl:Properties>
+                                                        <dxl:ProjList>
+                                                          <dxl:ProjElem ColId="80" Alias="g1">
+                                                            <dxl:Ident ColId="80" ColName="g1" TypeMdid="0.23.1.0"/>
+                                                          </dxl:ProjElem>
+                                                        </dxl:ProjList>
+                                                        <dxl:Filter/>
+                                                        <dxl:TableDescriptor Mdid="0.29063.1.1" TableName="foo9">
+                                                          <dxl:Columns>
+                                                            <dxl:Column ColId="80" Attno="1" ColName="g1" TypeMdid="0.23.1.0"/>
+                                                            <dxl:Column ColId="81" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                            <dxl:Column ColId="82" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                            <dxl:Column ColId="83" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                          </dxl:Columns>
+                                                        </dxl:TableDescriptor>
+                                                      </dxl:TableScan>
+                                                    </dxl:BroadcastMotion>
+                                                  </dxl:HashJoin>
+                                                </dxl:BroadcastMotion>
+                                              </dxl:HashJoin>
+                                              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000095" Rows="3.000000" Width="4"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="84" Alias="i1">
+                                                    <dxl:Ident ColId="84" ColName="i1" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:SortingColumnList/>
+                                                <dxl:TableScan>
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="84" Alias="i1">
+                                                      <dxl:Ident ColId="84" ColName="i1" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter>
+                                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                                                      <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                                                        <dxl:Ident ColId="85" ColName="i2" TypeMdid="0.1043.1.0"/>
+                                                      </dxl:Cast>
+                                                      <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABkVO" LintValue="698204972"/>
+                                                    </dxl:Comparison>
+                                                  </dxl:Filter>
+                                                  <dxl:TableDescriptor Mdid="0.29094.1.1" TableName="foo10">
+                                                    <dxl:Columns>
+                                                      <dxl:Column ColId="84" Attno="1" ColName="i1" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="85" Attno="2" ColName="i2" TypeMdid="0.1043.1.0" ColWidth="60"/>
+                                                      <dxl:Column ColId="86" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                      <dxl:Column ColId="87" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                      <dxl:Column ColId="88" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                    </dxl:Columns>
+                                                  </dxl:TableDescriptor>
+                                                </dxl:TableScan>
+                                              </dxl:BroadcastMotion>
+                                            </dxl:HashJoin>
+                                            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="862.000427" Rows="3.000000" Width="4"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="0" Alias="b1">
+                                                  <dxl:Ident ColId="0" ColName="b1" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:SortingColumnList/>
+                                              <dxl:HashJoin JoinType="Inner">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="862.000356" Rows="1.000000" Width="4"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="0" Alias="b1">
+                                                    <dxl:Ident ColId="0" ColName="b1" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:JoinFilter/>
+                                                <dxl:HashCondList>
+                                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                    <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
+                                                    <dxl:Ident ColId="6" ColName="a2" TypeMdid="0.23.1.0"/>
+                                                  </dxl:Comparison>
+                                                </dxl:HashCondList>
+                                                <dxl:TableScan>
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000004" Rows="1.000000" Width="8"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="0" Alias="b1">
+                                                      <dxl:Ident ColId="0" ColName="b1" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="1" Alias="b2">
+                                                      <dxl:Ident ColId="1" ColName="b2" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:TableDescriptor Mdid="0.28846.1.1" TableName="foo2">
+                                                    <dxl:Columns>
+                                                      <dxl:Column ColId="0" Attno="1" ColName="b1" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="1" Attno="2" ColName="b2" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                      <dxl:Column ColId="3" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                      <dxl:Column ColId="4" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                    </dxl:Columns>
+                                                  </dxl:TableDescriptor>
+                                                </dxl:TableScan>
+                                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="4"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="6" Alias="a2">
+                                                      <dxl:Ident ColId="6" ColName="a2" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter/>
+                                                  <dxl:SortingColumnList/>
+                                                  <dxl:TableScan>
+                                                    <dxl:Properties>
+                                                      <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
+                                                    </dxl:Properties>
+                                                    <dxl:ProjList>
+                                                      <dxl:ProjElem ColId="6" Alias="a2">
+                                                        <dxl:Ident ColId="6" ColName="a2" TypeMdid="0.23.1.0"/>
+                                                      </dxl:ProjElem>
+                                                    </dxl:ProjList>
+                                                    <dxl:Filter>
+                                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                        <dxl:Ident ColId="5" ColName="a1" TypeMdid="0.23.1.0"/>
+                                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9929"/>
+                                                      </dxl:Comparison>
+                                                    </dxl:Filter>
+                                                    <dxl:TableDescriptor Mdid="0.28815.1.1" TableName="foo1">
+                                                      <dxl:Columns>
+                                                        <dxl:Column ColId="5" Attno="1" ColName="a1" TypeMdid="0.23.1.0"/>
+                                                        <dxl:Column ColId="6" Attno="2" ColName="a2" TypeMdid="0.23.1.0"/>
+                                                        <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                      </dxl:Columns>
+                                                    </dxl:TableDescriptor>
+                                                  </dxl:TableScan>
+                                                </dxl:BroadcastMotion>
+                                              </dxl:HashJoin>
+                                            </dxl:BroadcastMotion>
+                                          </dxl:HashJoin>
+                                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="89" Alias="j1">
+                                                <dxl:Ident ColId="89" ColName="j1" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:SortingColumnList/>
+                                            <dxl:TableScan>
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="89" Alias="j1">
+                                                  <dxl:Ident ColId="89" ColName="j1" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:TableDescriptor Mdid="0.29125.1.1" TableName="foo11">
+                                                <dxl:Columns>
+                                                  <dxl:Column ColId="89" Attno="1" ColName="j1" TypeMdid="0.23.1.0"/>
+                                                  <dxl:Column ColId="90" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                  <dxl:Column ColId="91" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                  <dxl:Column ColId="92" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                </dxl:Columns>
+                                              </dxl:TableDescriptor>
+                                            </dxl:TableScan>
+                                          </dxl:BroadcastMotion>
+                                        </dxl:HashJoin>
+                                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000090" Rows="3.000000" Width="4"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="18" Alias="e1">
+                                              <dxl:Ident ColId="18" ColName="e1" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:SortingColumnList/>
+                                          <dxl:TableScan>
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="4"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="18" Alias="e1">
+                                                <dxl:Ident ColId="18" ColName="e1" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter>
+                                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                                                <dxl:FuncExpr FuncId="0.668.1.0" FuncRetSet="false" TypeMdid="0.1042.1.0">
+                                                  <dxl:CoerceViaIO TypeMdid="0.1042.1.0" TypeModification="-1" CoercionForm="2" Location="0">
+                                                    <dxl:Ident ColId="19" ColName="e2" TypeMdid="0.21.1.0"/>
+                                                  </dxl:CoerceViaIO>
+                                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="8"/>
+                                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                                                </dxl:FuncExpr>
+                                                <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACDIwMTE=" LintValue="91628332"/>
+                                              </dxl:Comparison>
+                                            </dxl:Filter>
+                                            <dxl:TableDescriptor Mdid="0.28939.1.1" TableName="foo5">
+                                              <dxl:Columns>
+                                                <dxl:Column ColId="18" Attno="1" ColName="e1" TypeMdid="0.23.1.0"/>
+                                                <dxl:Column ColId="19" Attno="2" ColName="e2" TypeMdid="0.21.1.0"/>
+                                                <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                              </dxl:Columns>
+                                            </dxl:TableDescriptor>
+                                          </dxl:TableScan>
+                                        </dxl:BroadcastMotion>
+                                      </dxl:HashJoin>
+                                    </dxl:RedistributeMotion>
+                                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000043" Rows="1.000000" Width="12"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="111" Alias="c1">
+                                          <dxl:Ident ColId="111" ColName="c1" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="112" Alias="c2">
+                                          <dxl:Ident ColId="112" ColName="c2" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="113" Alias="c3">
+                                          <dxl:Ident ColId="113" ColName="c3" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:SortingColumnList/>
+                                      <dxl:HashExprList>
+                                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                                          <dxl:Ident ColId="111" ColName="c1" TypeMdid="0.23.1.0"/>
+                                        </dxl:HashExpr>
+                                      </dxl:HashExprList>
+                                      <dxl:TableScan>
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="12"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="111" Alias="c1">
+                                            <dxl:Ident ColId="111" ColName="c1" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="112" Alias="c2">
+                                            <dxl:Ident ColId="112" ColName="c2" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="113" Alias="c3">
+                                            <dxl:Ident ColId="113" ColName="c3" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter>
+                                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                            <dxl:Ident ColId="113" ColName="c3" TypeMdid="0.23.1.0"/>
+                                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="740"/>
+                                          </dxl:Comparison>
+                                        </dxl:Filter>
+                                        <dxl:TableDescriptor Mdid="0.28877.1.1" TableName="foo3">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="111" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="112" Attno="2" ColName="c2" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="113" Attno="3" ColName="c3" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="114" Attno="4" ColName="c4" TypeMdid="0.23.1.0"/>
+                                            <dxl:Column ColId="115" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                            <dxl:Column ColId="116" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                            <dxl:Column ColId="117" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                    </dxl:RedistributeMotion>
+                                  </dxl:HashJoin>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="3.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="119" Alias="c2">
+                                        <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="4"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="119" Alias="c2">
+                                          <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="1.000000" Width="4"/>
+                                        </dxl:Properties>
+                                        <dxl:GroupingColumns>
+                                          <dxl:GroupingColumn ColId="121"/>
+                                          <dxl:GroupingColumn ColId="119"/>
+                                        </dxl:GroupingColumns>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="119" Alias="c2">
+                                            <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="121" Alias="c4">
+                                            <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:Sort SortDiscardDuplicates="false">
+                                          <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
+                                          </dxl:Properties>
+                                          <dxl:ProjList>
+                                            <dxl:ProjElem ColId="119" Alias="c2">
+                                              <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="121" Alias="c4">
+                                              <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                          </dxl:ProjList>
+                                          <dxl:Filter/>
+                                          <dxl:SortingColumnList>
+                                            <dxl:SortingColumn ColId="121" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                            <dxl:SortingColumn ColId="119" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                          </dxl:SortingColumnList>
+                                          <dxl:LimitCount/>
+                                          <dxl:LimitOffset/>
+                                          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                            <dxl:Properties>
+                                              <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
+                                            </dxl:Properties>
+                                            <dxl:ProjList>
+                                              <dxl:ProjElem ColId="119" Alias="c2">
+                                                <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                              <dxl:ProjElem ColId="121" Alias="c4">
+                                                <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                              </dxl:ProjElem>
+                                            </dxl:ProjList>
+                                            <dxl:Filter/>
+                                            <dxl:SortingColumnList/>
+                                            <dxl:HashExprList>
+                                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                                                <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                              </dxl:HashExpr>
+                                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                                                <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                              </dxl:HashExpr>
+                                            </dxl:HashExprList>
+                                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="8"/>
+                                              </dxl:Properties>
+                                              <dxl:GroupingColumns>
+                                                <dxl:GroupingColumn ColId="121"/>
+                                                <dxl:GroupingColumn ColId="119"/>
+                                              </dxl:GroupingColumns>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="119" Alias="c2">
+                                                  <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="121" Alias="c4">
+                                                  <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                                </dxl:ProjElem>
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:Sort SortDiscardDuplicates="false">
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="119" Alias="c2">
+                                                    <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="121" Alias="c4">
+                                                    <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter/>
+                                                <dxl:SortingColumnList>
+                                                  <dxl:SortingColumn ColId="121" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                  <dxl:SortingColumn ColId="119" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                                </dxl:SortingColumnList>
+                                                <dxl:LimitCount/>
+                                                <dxl:LimitOffset/>
+                                                <dxl:TableScan>
+                                                  <dxl:Properties>
+                                                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                                                  </dxl:Properties>
+                                                  <dxl:ProjList>
+                                                    <dxl:ProjElem ColId="119" Alias="c2">
+                                                      <dxl:Ident ColId="119" ColName="c2" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                    <dxl:ProjElem ColId="121" Alias="c4">
+                                                      <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                                    </dxl:ProjElem>
+                                                  </dxl:ProjList>
+                                                  <dxl:Filter>
+                                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                                      <dxl:Ident ColId="121" ColName="c4" TypeMdid="0.23.1.0"/>
+                                                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7"/>
+                                                    </dxl:Comparison>
+                                                  </dxl:Filter>
+                                                  <dxl:TableDescriptor Mdid="0.28877.1.1" TableName="foo3">
+                                                    <dxl:Columns>
+                                                      <dxl:Column ColId="118" Attno="1" ColName="c1" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="119" Attno="2" ColName="c2" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="120" Attno="3" ColName="c3" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="121" Attno="4" ColName="c4" TypeMdid="0.23.1.0"/>
+                                                      <dxl:Column ColId="122" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                      <dxl:Column ColId="123" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                      <dxl:Column ColId="124" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                                    </dxl:Columns>
+                                                  </dxl:TableDescriptor>
+                                                </dxl:TableScan>
+                                              </dxl:Sort>
+                                            </dxl:Aggregate>
+                                          </dxl:RedistributeMotion>
+                                        </dxl:Sort>
+                                      </dxl:Aggregate>
+                                    </dxl:Result>
+                                  </dxl:BroadcastMotion>
+                                </dxl:HashJoin>
+                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="3.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="104" Alias="l8">
+                                      <dxl:Ident ColId="104" ColName="l8" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="104" Alias="l8">
+                                        <dxl:Ident ColId="104" ColName="l8" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="104" ColName="l8" TypeMdid="0.23.1.0"/>
+                                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="740"/>
+                                      </dxl:Comparison>
+                                    </dxl:Filter>
+                                    <dxl:TableDescriptor Mdid="0.29187.1.1" TableName="foo13">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="97" Attno="1" ColName="l1" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="98" Attno="2" ColName="l2" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="99" Attno="3" ColName="l3" TypeMdid="0.1043.1.0" ColWidth="90"/>
+                                        <dxl:Column ColId="100" Attno="4" ColName="l4" TypeMdid="0.1043.1.0" ColWidth="18"/>
+                                        <dxl:Column ColId="101" Attno="5" ColName="l5" TypeMdid="0.1043.1.0" ColWidth="12"/>
+                                        <dxl:Column ColId="102" Attno="6" ColName="l6" TypeMdid="0.1043.1.0" ColWidth="18"/>
+                                        <dxl:Column ColId="103" Attno="7" ColName="l7" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="104" Attno="8" ColName="l8" TypeMdid="0.23.1.0"/>
+                                        <dxl:Column ColId="105" Attno="9" ColName="l9" TypeMdid="0.1043.1.0" ColWidth="180"/>
+                                        <dxl:Column ColId="106" Attno="10" ColName="l10" TypeMdid="0.1043.1.0" ColWidth="180"/>
+                                        <dxl:Column ColId="107" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                        <dxl:Column ColId="108" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                        <dxl:Column ColId="109" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:BroadcastMotion>
+                              </dxl:HashJoin>
+                            </dxl:RedistributeMotion>
+                          </dxl:HashJoin>
+                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="23" Alias="f1">
+                                <dxl:Ident ColId="23" ColName="f1" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="23" Alias="f1">
+                                  <dxl:Ident ColId="23" ColName="f1" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="0.28970.1.1" TableName="foo6">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="23" Attno="1" ColName="f1" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:BroadcastMotion>
+                        </dxl:HashJoin>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="52" Alias="j1">
+                              <dxl:Ident ColId="52" ColName="j1" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="52" Alias="j1">
+                                <dxl:Ident ColId="52" ColName="j1" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.29125.1.1" TableName="foo11">
+                              <dxl:Columns>
+                                <dxl:Column ColId="52" Attno="1" ColName="j1" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="54" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="55" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:HashJoin>
+                      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="3.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="43" Alias="g1">
+                            <dxl:Ident ColId="43" ColName="g1" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000003" Rows="1.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="43" Alias="g1">
+                              <dxl:Ident ColId="43" ColName="g1" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.29063.1.1" TableName="foo9">
+                            <dxl:Columns>
+                              <dxl:Column ColId="43" Attno="1" ColName="g1" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="45" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="46" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:BroadcastMotion>
+                    </dxl:HashJoin>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:Result>
+            </dxl:RedistributeMotion>
+          </dxl:Sort>
+        </dxl:Aggregate>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libgpopt/include/gpopt/engine/CHint.h
+++ b/libgpopt/include/gpopt/engine/CHint.h
@@ -15,6 +15,8 @@
 #include "gpos/memory/IMemoryPool.h"
 #include "gpos/common/CRefCount.h"
 
+#define JOIN_ORDER_DP_THRESHOLD ULONG(10)
+
 namespace gpopt
 {
 	using namespace gpos;
@@ -38,6 +40,7 @@ namespace gpopt
 
 			ULONG m_ulArrayExpansionThreshold;
 
+			ULONG m_ulJoinOrderDPLimit;
 
 			// private copy ctor
 			CHint(const CHint &);
@@ -49,12 +52,14 @@ namespace gpopt
 				(
 				ULONG ulMinNumOfPartsToRequireSortOnInsert,
 				ULONG ulJoinArityForAssociativityCommutativity,
-				ULONG ulArrayExpansionThreshold
+				ULONG ulArrayExpansionThreshold,
+				ULONG ulJoinOrderDPLimit
 				)
 				:
 				m_ulMinNumOfPartsToRequireSortOnInsert(ulMinNumOfPartsToRequireSortOnInsert),
 				m_ulJoinArityForAssociativityCommutativity(ulJoinArityForAssociativityCommutativity),
-				m_ulArrayExpansionThreshold(ulArrayExpansionThreshold)
+				m_ulArrayExpansionThreshold(ulArrayExpansionThreshold),
+				m_ulJoinOrderDPLimit(ulJoinOrderDPLimit)
 			{
 			}
 
@@ -84,14 +89,25 @@ namespace gpopt
 				return m_ulArrayExpansionThreshold;
 			}
 
+			// Maximum number of relations in an n-ary join operator where ORCA will
+			// explore join ordering via dynamic programming.
+			ULONG UlJoinOrderDPLimit() const
+			{
+				return m_ulJoinOrderDPLimit;
+			}
+
 			// generate default hint configurations, which disables sort during insert on
 			// append only row-oriented partitioned tables by default
 			static
 			CHint *PhintDefault(IMemoryPool *pmp)
 			{
-				return GPOS_NEW(pmp) CHint(INT_MAX /* ulMinNumOfPartsToRequireSortOnInsert */,
-										   INT_MAX /* ulJoinArityForAssociativityCommutativity */,
-										   INT_MAX /* ulArrayExpansionThreshold */);
+				return GPOS_NEW(pmp) CHint
+										(
+										INT_MAX /* ulMinNumOfPartsToRequireSortOnInsert */,
+										INT_MAX /* ulJoinArityForAssociativityCommutativity */,
+										INT_MAX /* ulArrayExpansionThreshold */,
+										JOIN_ORDER_DP_THRESHOLD /*ulJoinOrderDPLimit*/
+										);
 			}
 
 	}; // class CHint

--- a/libgpopt/src/xforms/CXformUtils.cpp
+++ b/libgpopt/src/xforms/CXformUtils.cpp
@@ -37,7 +37,9 @@
 #include "gpopt/xforms/CXformExploration.h"
 #include "gpopt/xforms/CDecorrelator.h"
 #include "gpopt/xforms/CXformUtils.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
 #include "gpopt/exception.h"
+#include "gpopt/engine/CHint.h"
 
 
 using namespace gpopt;
@@ -141,7 +143,20 @@ CXformUtils::ExfpExpandJoinOrder
 			return CXform::ExfpNone;
 		}
 
+		COptimizerConfig *poconf = COptCtxt::PoctxtFromTLS()->Poconf();
+		const CHint *phint = poconf->Phint();
+
 		const ULONG ulArity = exprhdl.UlArity();
+
+		// since the last child of the join operator is a scalar child
+		// defining the join predicate, ignore it.
+		const ULONG ulRelChild = ulArity - 1;
+
+		if (ulRelChild > phint->UlJoinOrderDPLimit())
+		{
+			return CXform::ExfpNone;
+		}
+
 		for (ULONG ul = 0; ul < ulArity; ul++)
 		{
 			CGroup *pgroupChild = (*exprhdl.Pgexpr())[ul];

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -59,6 +59,7 @@ namespace gpdxl
 		EdxltokenMinNumOfPartsToRequireSortOnInsert,
 		EdxltokenJoinArityForAssociativityCommutativity,
 		EdxltokenArrayExpansionThreshold,
+		EdxltokenJoinOrderDPThreshold,
 
 		EdxltokenPlanSamples,
 

--- a/libnaucrates/src/CDXLUtils.cpp
+++ b/libnaucrates/src/CDXLUtils.cpp
@@ -1236,6 +1236,7 @@ CDXLUtils::PstrSerializeOptimizerConfig
 	xmlser.AddAttribute(CDXLTokens::PstrToken(EdxltokenMinNumOfPartsToRequireSortOnInsert), phint->UlMinNumOfPartsToRequireSortOnInsert());
 	xmlser.AddAttribute(CDXLTokens::PstrToken(EdxltokenJoinArityForAssociativityCommutativity), phint->UlJoinArityForAssociativityCommutativity());
 	xmlser.AddAttribute(CDXLTokens::PstrToken(EdxltokenArrayExpansionThreshold), phint->UlArrayExpansionThreshold());
+	xmlser.AddAttribute(CDXLTokens::PstrToken(EdxltokenJoinOrderDPThreshold), phint->UlJoinOrderDPLimit());
 	xmlser.CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenHint));
 
 	return pstr;

--- a/libnaucrates/src/parser/CParseHandlerHint.cpp
+++ b/libnaucrates/src/parser/CParseHandlerHint.cpp
@@ -85,8 +85,15 @@ CParseHandlerHint::StartElement
 	ULONG ulMinNumOfPartsToRequireSortOnInsert = CDXLOperatorFactory::UlValueFromAttrs(m_pphm->Pmm(), attrs, EdxltokenMinNumOfPartsToRequireSortOnInsert, EdxltokenHint);
 	ULONG ulJoinArityForAssociativityCommutativity = CDXLOperatorFactory::UlValueFromAttrs(m_pphm->Pmm(), attrs, EdxltokenJoinArityForAssociativityCommutativity, EdxltokenHint, true, INT_MAX);
 	ULONG ulArrayExpansionThreshold = CDXLOperatorFactory::UlValueFromAttrs(m_pphm->Pmm(), attrs, EdxltokenArrayExpansionThreshold, EdxltokenHint, true, INT_MAX);
+	ULONG ulJoinOrderDPThreshold = CDXLOperatorFactory::UlValueFromAttrs(m_pphm->Pmm(), attrs, EdxltokenJoinOrderDPThreshold, EdxltokenHint, true, JOIN_ORDER_DP_THRESHOLD);
 
-	m_phint = GPOS_NEW(m_pmp) CHint(ulMinNumOfPartsToRequireSortOnInsert, ulJoinArityForAssociativityCommutativity, ulArrayExpansionThreshold);
+	m_phint = GPOS_NEW(m_pmp) CHint
+								(
+								ulMinNumOfPartsToRequireSortOnInsert,
+								ulJoinArityForAssociativityCommutativity,
+								ulArrayExpansionThreshold,
+								ulJoinOrderDPThreshold
+								);
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -82,6 +82,7 @@ CDXLTokens::Init
 			{EdxltokenMinNumOfPartsToRequireSortOnInsert, GPOS_WSZ_LIT("MinNumOfPartsToRequireSortOnInsert")},
 			{EdxltokenJoinArityForAssociativityCommutativity, GPOS_WSZ_LIT("JoinArityForAssociativityCommutativity")},
 			{EdxltokenArrayExpansionThreshold, GPOS_WSZ_LIT("ArrayExpansionThreshold")},
+			{EdxltokenJoinOrderDPThreshold, GPOS_WSZ_LIT("JoinOrderDynamicProgThreshold")},
 
 			{EdxltokenPlanSamples, GPOS_WSZ_LIT("PlanSamples")},
 			

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -64,6 +64,8 @@ add_executable(gporca_test
                src/unittest/gpopt/minidump/CAggTest.cpp
                include/unittest/gpopt/minidump/CArrayExpansionTest.h
                src/unittest/gpopt/minidump/CArrayExpansionTest.cpp
+               include/unittest/gpopt/minidump/CJoinOrderDPTest.h
+               src/unittest/gpopt/minidump/CJoinOrderDPTest.cpp
                include/unittest/gpopt/minidump/CPruneColumnsTest.h
                src/unittest/gpopt/minidump/CPruneColumnsTest.cpp
                include/unittest/gpopt/minidump/CMissingStatsTest.h
@@ -201,6 +203,7 @@ add_orca_test(CDXLUtilsTest)
 add_orca_test(CMDAccessorTest)
 add_orca_test(CMDProviderTest)
 add_orca_test(CArrayExpansionTest)
+add_orca_test(CJoinOrderDPTest)
 add_orca_test(CMiniDumperDXLTest)
 add_orca_test(CExpressionPreprocessorTest)
 add_orca_test(CWindowTest)

--- a/server/include/unittest/gpopt/minidump/CJoinOrderDPTest.h
+++ b/server/include/unittest/gpopt/minidump/CJoinOrderDPTest.h
@@ -1,0 +1,32 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software
+//
+//	@filename:
+//		CJoinOrderDPTest.h
+//
+//	@doc:
+//		Test for n-ary join order
+//
+//
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CJoinOrderDPTest_H
+#define GPOPT_CJoinOrderDPTest_H
+
+#include "gpos/base.h"
+
+namespace gpopt
+{
+	class CJoinOrderDPTest
+	{
+		public:
+
+			// unittests
+			static
+			gpos::GPOS_RESULT EresUnittest();
+	}; // class CJoinOrderDPTest
+}
+
+#endif // !GPOPT_CJoinOrderDPTest_H
+
+// EOF

--- a/server/src/startup/main.cpp
+++ b/server/src/startup/main.cpp
@@ -70,6 +70,7 @@
 #include "unittest/gpopt/mdcache/CMDProviderTest.h"
 
 #include "unittest/gpopt/minidump/CArrayExpansionTest.h"
+#include "unittest/gpopt/minidump/CJoinOrderDPTest.h"
 #include "unittest/gpopt/minidump/CPullUpProjectElementTest.h"
 #include "unittest/gpopt/minidump/CMiniDumperDXLTest.h"
 #include "unittest/gpopt/minidump/CMinidumpWithConstExprEvaluatorTest.h"
@@ -163,6 +164,7 @@ static gpos::CUnittest rgut[] =
 
 	// opt
 	GPOS_UNITTEST_STD(CArrayExpansionTest),
+	GPOS_UNITTEST_STD(CJoinOrderDPTest),
 	GPOS_UNITTEST_STD(CPullUpProjectElementTest),
 	GPOS_UNITTEST_STD(CCNFConverterTest),
 	GPOS_UNITTEST_STD(CColumnDescriptorTest),

--- a/server/src/unittest/gpopt/minidump/CJoinOrderDPTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CJoinOrderDPTest.cpp
@@ -1,0 +1,43 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software
+//
+//	@filename:
+//		CJoinOrderDPTest.cpp
+//
+//	@doc:
+//		Test for n-ary join order
+//---------------------------------------------------------------------------
+#include "unittest/gpopt/minidump/CJoinOrderDPTest.h"
+#include "unittest/gpopt/CTestUtils.h"
+
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CJoinOrderDPTest::EresUnittest
+//
+//	@doc:
+//		Unittest for array expansion in WHERE clause
+//
+//---------------------------------------------------------------------------
+gpos::GPOS_RESULT
+CJoinOrderDPTest::EresUnittest()
+{
+
+	ULONG ulTestCounter = 0;
+	const CHAR *rgszFileNames[] =
+	{
+			"../data/dxl/minidump/CJoinOrderDPTest/DisableDPJoinOrderForLargeArity.mdp",
+	};
+
+	return CTestUtils::EresUnittest_RunTestsWithoutAdditionalTraceFlags
+				(
+					rgszFileNames,
+					&ulTestCounter,
+					GPOS_ARRAY_SIZE(rgszFileNames),
+					true,
+					true
+				);
+}
+// EOF


### PR DESCRIPTION
CXformExpandNAryJoinDP uses dynamic programming (DP). It is an expensive transformation when the number of join children is more than 10 since computes all the subsets and join orders for
large number of tables.

In this commit we added a hint that sets a hard-limit on how many joins we want to consider in the `CXformExpandNAryJoinDP` rule.

-- Venky and Ivan