### PR TITLE
Remove broadcast motion for physical sequence project [#131569023]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 674)
+set(GPORCA_VERSION_MINOR 675)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.674
+LIB_VERSION = 1.675
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/CastOnSubquery.mdp
+++ b/data/dxl/minidump/CastOnSubquery.mdp
@@ -455,148 +455,178 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="21">
-	  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-	    <dxl:Properties>
-	      <dxl:Cost StartupCost="0" TotalCost="325.121094" Rows="4.000000" Width="8"/>
-	    </dxl:Properties>
-	    <dxl:ProjList>
-	      <dxl:ProjElem ColId="0" Alias="a">
-	        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	      </dxl:ProjElem>
-	      <dxl:ProjElem ColId="1" Alias="b">
-	        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-	      </dxl:ProjElem>
-	    </dxl:ProjList>
-	    <dxl:Filter/>
-	    <dxl:SortingColumnList/>
-	    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
-	      <dxl:Properties>
-	        <dxl:Cost StartupCost="0" TotalCost="324.105469" Rows="4.000000" Width="8"/>
-	      </dxl:Properties>
-	      <dxl:ProjList>
-	        <dxl:ProjElem ColId="0" Alias="a">
-	          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	        </dxl:ProjElem>
-	        <dxl:ProjElem ColId="1" Alias="b">
-	          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-	        </dxl:ProjElem>
-	      </dxl:ProjList>
-	      <dxl:Filter/>
-	      <dxl:JoinFilter>
-	        <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1209.1.0">
-	          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
-	            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	          </dxl:Cast>
-	          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
-	            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-	          </dxl:Cast>
-	        </dxl:Comparison>
-	      </dxl:JoinFilter>
-	      <dxl:Assert ErrorCode="P0003">
-	        <dxl:Properties>
-	          <dxl:Cost StartupCost="0" TotalCost="3.066406" Rows="2.000000" Width="4"/>
-	        </dxl:Properties>
-	        <dxl:ProjList>
-	          <dxl:ProjElem ColId="9" Alias="c">
-	            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-	          </dxl:ProjElem>
-	        </dxl:ProjList>
-	        <dxl:AssertConstraintList>
-	          <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-	              <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
-	              <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-	              </dxl:Cast>
-	            </dxl:Comparison>
-	          </dxl:AssertConstraint>
-	        </dxl:AssertConstraintList>
-	        <dxl:Window PartitionColumns="">
-	          <dxl:Properties>
-	            <dxl:Cost StartupCost="0" TotalCost="2.058594" Rows="20.000000" Width="12"/>
-	          </dxl:Properties>
-	          <dxl:ProjList>
-	            <dxl:ProjElem ColId="18" Alias="row_number">
-	              <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-	            </dxl:ProjElem>
-	            <dxl:ProjElem ColId="9" Alias="c">
-	              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-	            </dxl:ProjElem>
-	          </dxl:ProjList>
-	          <dxl:Filter/>
-	          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-	            <dxl:Properties>
-	              <dxl:Cost StartupCost="0" TotalCost="1.058594" Rows="20.000000" Width="4"/>
-	            </dxl:Properties>
-	            <dxl:ProjList>
-	              <dxl:ProjElem ColId="9" Alias="c">
-	                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-	              </dxl:ProjElem>
-	            </dxl:ProjList>
-	            <dxl:Filter/>
-	            <dxl:SortingColumnList/>
-	            <dxl:TableScan>
-	              <dxl:Properties>
-	                <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
-	              </dxl:Properties>
-	              <dxl:ProjList>
-	                <dxl:ProjElem ColId="9" Alias="c">
-	                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-	                </dxl:ProjElem>
-	              </dxl:ProjList>
-	              <dxl:Filter/>
-	              <dxl:TableDescriptor Mdid="0.217327.1.1" TableName="bar">
-	                <dxl:Columns>
-	                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-	                  <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-	                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-	                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-	                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-	                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-	                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-	                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	                </dxl:Columns>
-	              </dxl:TableDescriptor>
-	            </dxl:TableScan>
-	          </dxl:BroadcastMotion>
-	          <dxl:WindowKeyList>
-	            <dxl:WindowKey>
-	              <dxl:SortingColumnList/>
-	            </dxl:WindowKey>
-	          </dxl:WindowKeyList>
-	        </dxl:Window>
-	      </dxl:Assert>
-	      <dxl:TableScan>
-	        <dxl:Properties>
-	          <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
-	        </dxl:Properties>
-	        <dxl:ProjList>
-	          <dxl:ProjElem ColId="0" Alias="a">
-	            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-	          </dxl:ProjElem>
-	          <dxl:ProjElem ColId="1" Alias="b">
-	            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-	          </dxl:ProjElem>
-	        </dxl:ProjList>
-	        <dxl:Filter/>
-	        <dxl:TableDescriptor Mdid="0.217301.1.1" TableName="foo">
-	          <dxl:Columns>
-	            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-	            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-	            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-	            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-	            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-	            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-	            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-	            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-	            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-	          </dxl:Columns>
-	        </dxl:TableDescriptor>
-	      </dxl:TableScan>
-	    </dxl:NestedLoopJoin>
-	  </dxl:GatherMotion>
-	</dxl:Plan>
+<dxl:Plan Id="0" SpaceSize="9">
+  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="326.335938" Rows="4.000000" Width="8"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="0" Alias="a">
+        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="1" Alias="b">
+        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="325.320312" Rows="4.000000" Width="8"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="0" Alias="a">
+          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="1" Alias="b">
+          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:JoinFilter>
+        <dxl:Comparison ComparisonOperator="~~" OperatorMdid="0.1209.1.0">
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:Cast>
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
+            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:Cast>
+        </dxl:Comparison>
+      </dxl:JoinFilter>
+      <dxl:Assert ErrorCode="P0003">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="4.281250" Rows="2.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="9" Alias="c">
+            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:AssertConstraintList>
+          <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+              <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+              <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:Cast>
+            </dxl:Comparison>
+          </dxl:AssertConstraint>
+        </dxl:AssertConstraintList>
+        <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="3.273438" Rows="20.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="c">
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="row_number">
+              <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="10.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="c">
+                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="row_number">
+                <dxl:Ident ColId="18" ColName="row_number" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:Window PartitionColumns="">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="2.039062" Rows="10.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="18" Alias="row_number">
+                  <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="c">
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1.039062" Rows="10.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="c">
+                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.019531" Rows="10.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="c">
+                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.217327.1.1" TableName="bar">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:GatherMotion>
+              <dxl:WindowKeyList>
+                <dxl:WindowKey>
+                  <dxl:SortingColumnList/>
+                </dxl:WindowKey>
+              </dxl:WindowKeyList>
+            </dxl:Window>
+          </dxl:Result>
+        </dxl:BroadcastMotion>
+      </dxl:Assert>
+      <dxl:TableScan>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="0.039062" Rows="10.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:TableDescriptor Mdid="0.217301.1.1" TableName="foo">
+          <dxl:Columns>
+            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:TableScan>
+    </dxl:NestedLoopJoin>
+  </dxl:GatherMotion>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -852,7 +852,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="6392">
+	<dxl:Plan Id="0" SpaceSize="2816">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="282440.388516" Rows="4.000000" Width="269"/>

--- a/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -333,16 +333,73 @@ WHERE  sach_vsnr = 465132477;
         </dxl:LogicalProject>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
-      <dxl:DMLInsert Columns="0,1,10" ActionCol="11" OidCol="12" CtidCol="0" SegmentIdCol="0" InputSorted="false">
+    <dxl:Plan Id="0" SpaceSize="2">
+  <dxl:DMLInsert Columns="0,1,10" ActionCol="11" OidCol="12" CtidCol="0" SegmentIdCol="0" InputSorted="false">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="431.001443" Rows="1.000000" Width="10"/>
+    </dxl:Properties>
+    <dxl:DirectDispatchInfo>
+      <dxl:KeyValue>
+        <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="465132477"/>
+      </dxl:KeyValue>
+    </dxl:DirectDispatchInfo>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="0" Alias="ag">
+        <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="1" Alias="sach_vsnr">
+        <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
+        <dxl:Ident ColId="10" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:TableDescriptor Mdid="0.42167058.1.1" TableName="test_row_number_step2">
+      <dxl:Columns>
+        <dxl:Column ColId="13" Attno="1" ColName="ag" TypeMdid="0.21.1.0"/>
+        <dxl:Column ColId="14" Attno="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+        <dxl:Column ColId="15" Attno="3" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
+        <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+        <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+        <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+        <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+        <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+        <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+        <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+      </dxl:Columns>
+    </dxl:TableDescriptor>
+    <dxl:RedistributeMotion InputSegments="-1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53">
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="18"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="0" Alias="ag">
+          <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="1" Alias="sach_vsnr">
+          <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
+          <dxl:Ident ColId="10" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+          <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+          <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.26.1.0"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter/>
+      <dxl:SortingColumnList/>
+      <dxl:HashExprList>
+        <dxl:HashExpr TypeMdid="0.23.1.0">
+          <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+        </dxl:HashExpr>
+      </dxl:HashExprList>
+      <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.001443" Rows="1.000000" Width="10"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="1.000000" Width="18"/>
         </dxl:Properties>
-        <dxl:DirectDispatchInfo>
-          <dxl:KeyValue>
-            <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="465132477"/>
-          </dxl:KeyValue>
-        </dxl:DirectDispatchInfo>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ag">
             <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
@@ -351,54 +408,38 @@ WHERE  sach_vsnr = 465132477;
             <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
-            <dxl:Ident ColId="10" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
+            <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
+              <dxl:Ident ColId="9" ColName="idx_lfd_053" TypeMdid="0.20.1.0"/>
+            </dxl:FuncExpr>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="12" Alias="ColRef_0012">
+            <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="false" IsByValue="true" Value="42167058"/>
           </dxl:ProjElem>
         </dxl:ProjList>
-        <dxl:TableDescriptor Mdid="0.42167058.1.1" TableName="test_row_number_step2">
-          <dxl:Columns>
-            <dxl:Column ColId="13" Attno="1" ColName="ag" TypeMdid="0.21.1.0"/>
-            <dxl:Column ColId="14" Attno="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="15" Attno="3" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
-            <dxl:Column ColId="16" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-            <dxl:Column ColId="17" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="18" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="19" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-            <dxl:Column ColId="20" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-            <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-            <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-          </dxl:Columns>
-        </dxl:TableDescriptor>
-        <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" DuplicateSensitive="true">
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Window PartitionColumns="">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000141" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="1.000000" Width="14"/>
           </dxl:Properties>
           <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="idx_lfd_053">
+              <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+            </dxl:ProjElem>
             <dxl:ProjElem ColId="0" Alias="ag">
               <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="1" Alias="sach_vsnr">
               <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
-              <dxl:Ident ColId="10" ColName="idx_lfd_053" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-              <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-              <dxl:Ident ColId="12" ColName="ColRef_0012" TypeMdid="0.26.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
-              <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-            </dxl:HashExpr>
-          </dxl:HashExprList>
-          <dxl:Result>
+          <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000099" Rows="54.000000" Width="18"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="1.000000" Width="6"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ag">
@@ -407,28 +448,14 @@ WHERE  sach_vsnr = 465132477;
               <dxl:ProjElem ColId="1" Alias="sach_vsnr">
                 <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="idx_lfd_053">
-                <dxl:FuncExpr FuncId="0.480.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
-                  <dxl:Ident ColId="9" ColName="idx_lfd_053" TypeMdid="0.20.1.0"/>
-                </dxl:FuncExpr>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="ColRef_0012">
-                <dxl:ConstValue TypeMdid="0.26.1.0" IsNull="false" IsByValue="true" Value="42167058"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Window PartitionColumns="">
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="54.000000" Width="14"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="6"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="idx_lfd_053">
-                  <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="ag">
                   <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
                 </dxl:ProjElem>
@@ -436,63 +463,36 @@ WHERE  sach_vsnr = 465132477;
                   <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000081" Rows="54.000000" Width="6"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="ag">
-                    <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="sach_vsnr">
-                    <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList/>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="6"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="ag">
-                      <dxl:Ident ColId="0" ColName="ag" TypeMdid="0.21.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="sach_vsnr">
-                      <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="465132477"/>
-                    </dxl:Comparison>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.42167032.1.1" TableName="test_row_number_step1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="ag" TypeMdid="0.21.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:BroadcastMotion>
-              <dxl:WindowKeyList>
-                <dxl:WindowKey>
-                  <dxl:SortingColumnList/>
-                </dxl:WindowKey>
-              </dxl:WindowKeyList>
-            </dxl:Window>
-          </dxl:Result>
-        </dxl:RedistributeMotion>
-      </dxl:DMLInsert>
-    </dxl:Plan>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="465132477"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.42167032.1.1" TableName="test_row_number_step1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="ag" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+          <dxl:WindowKeyList>
+            <dxl:WindowKey>
+              <dxl:SortingColumnList/>
+            </dxl:WindowKey>
+          </dxl:WindowKeyList>
+        </dxl:Window>
+      </dxl:Result>
+    </dxl:RedistributeMotion>
+  </dxl:DMLInsert>
+</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/data/dxl/minidump/DMLCollapseProject.mdp
+++ b/data/dxl/minidump/DMLCollapseProject.mdp
@@ -358,7 +358,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="4">
       <dxl:DMLInsert Columns="1,2,3,13" ActionCol="15" OidCol="16" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.070655" Rows="1.000000" Width="28"/>

--- a/data/dxl/minidump/Lead-Lag-WinFuncs.mdp
+++ b/data/dxl/minidump/Lead-Lag-WinFuncs.mdp
@@ -228,7 +228,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalWindow>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="2">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5.919955" Rows="10.000000" Width="8"/>

--- a/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
+++ b/data/dxl/minidump/PartTbl-DPE-WindowFunction.mdp
@@ -692,7 +692,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="45">
+<dxl:Plan Id="0" SpaceSize="32">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="10323.538987" Rows="10000.000000" Width="20"/>

--- a/data/dxl/minidump/PartTbl-WindowFunction.mdp
+++ b/data/dxl/minidump/PartTbl-WindowFunction.mdp
@@ -692,7 +692,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="10">
+<dxl:Plan Id="0" SpaceSize="9">
   <dxl:HashJoin JoinType="Inner">
     <dxl:Properties>
       <dxl:Cost StartupCost="0" TotalCost="116561.907440" Rows="10000.000000" Width="20"/>
@@ -793,9 +793,9 @@
         <dxl:SortingColumnList>
           <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
         </dxl:SortingColumnList>
-        <dxl:Sequence>
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="97961.505097" Rows="100009.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="98743.825409" Rows="100009.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -805,34 +805,15 @@
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:PartitionSelector RelationMdid="0.71316.1.1" PartitionLevels="1" ScanId="1">
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
-                <dxl:PartOid Level="0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-            </dxl:PrintableFilter>
-          </dxl:PartitionSelector>
-          <dxl:Sort SortDiscardDuplicates="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="97961.505097" Rows="100009.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="390.660156" Rows="100009.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -842,12 +823,31 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1082.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
+            <dxl:PartitionSelector RelationMdid="0.71316.1.1" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                  <dxl:PartOid Level="0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
             <dxl:DynamicTableScan PartIndexId="1">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="390.660156" Rows="100009.000000" Width="8"/>
@@ -875,8 +875,8 @@
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:DynamicTableScan>
-          </dxl:Sort>
-        </dxl:Sequence>
+          </dxl:Sequence>
+        </dxl:Sort>
       </dxl:GatherMotion>
       <dxl:WindowKeyList>
         <dxl:WindowKey>

--- a/data/dxl/minidump/Preds-Over-WinFunc2.mdp
+++ b/data/dxl/minidump/Preds-Over-WinFunc2.mdp
@@ -254,7 +254,7 @@
         </dxl:LogicalWindow>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="1">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.187500" Rows="1.000000" Width="40"/>

--- a/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -888,7 +888,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="23072">
+	<dxl:Plan Id="0" SpaceSize="12492">
 	  <dxl:Sort SortDiscardDuplicates="false">
 	    <dxl:Properties>
 	      <dxl:Cost StartupCost="0" TotalCost="281618.935587" Rows="3009.000000" Width="64"/>

--- a/data/dxl/minidump/Subq-NoParams.mdp
+++ b/data/dxl/minidump/Subq-NoParams.mdp
@@ -383,7 +383,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-	<dxl:Plan Id="0" SpaceSize="21">
+	<dxl:Plan Id="0" SpaceSize="9">
 	  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
 	    <dxl:Properties>
 	      <dxl:Cost StartupCost="0" TotalCost="325.106771" Rows="3.333333" Width="8"/>


### PR DESCRIPTION
When Window operator has row_number as the window function GPORCA does not generate the
correct distribution request from its child (asking Broadcast motion).

We have had other issues with Window operator requesting Broadcast motion from its child.
To avoid generating the incorrect plan we are disabling such a request till we fully
understand when such a request is guaranteed to be correct.