### PR TITLE
Fix bug that system id counter is never incremented during serialization [#131856005]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 676)
+set(GPORCA_VERSION_MINOR 677)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.676
+LIB_VERSION = 1.677
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -1515,6 +1515,7 @@ CMDAccessor::UlpSerializeSysid
 		
 		wszBuffer += str.UlLength();
 		ulpAllocSize -= str.UlLength();
+		ul++;
 	}
 	
 	return ulpRequiredSpace;


### PR DESCRIPTION
This causes the incomplete minidump file when the query contains CTAS such as:
```sql
create table foo as
select row_number() over() as row_num, id_col
from bar
distributed by (id_col);
```