### PR TITLE
Increase uniformity of metric prettyprinting

### DIFF
--- a/libgpopt/src/engine/CEngine.cpp
+++ b/libgpopt/src/engine/CEngine.cpp
@@ -435,7 +435,7 @@ CEngine::DeriveStats
 {
 	CWStringDynamic str(m_pmp);
 	COstreamString oss (&str);
-	oss << "\n[OPT]: Statistics Derivation Time (stage " << m_ulCurrSearchStage <<"): ";
+	oss << "\n[OPT]: Statistics Derivation Time (stage " << m_ulCurrSearchStage <<") ";
 	CHAR *sz = CUtils::SzFromWsz(m_pmp, const_cast<WCHAR *>(str.Wsz()));
 
 	{
@@ -1567,7 +1567,7 @@ CEngine::PrintActivatedXforms
 			os
 				<< pxform->SzId() << ": "
 				<< ulCalls << " calls, "
-				<< ulTime << " ms"<< std::endl;
+				<< ulTime << "ms"<< std::endl;
 		}
 		os << "[OPT]: <End Xforms - stage " << m_ulCurrSearchStage << ">" << std::endl;
 	}


### PR DESCRIPTION
Noticed two nitpick-level irregularities in the metric printing when reading the [ORCA profiling](http://engineering.pivotal.io/post/orca-profiling/) blogpost; not sure if it's of any interest but I figured I'd submit and leave that decision to you (also not sure if there is test output which this would conflict with but nothing obvious stood out). The trailing colon which preceds the timing info is added elsewhere so remove from the OPT string; also remove space between time and unit on Xforms to make it uniform with other metric printings in order to make parsing the output via scripts easier.
