### PR TITLE
Fix statistics computation for bug when nulls are present

### DIFF
--- a/data/dxl/minidump/notequal-predicate-over-data-with-nulls.mdp
+++ b/data/dxl/minidump/notequal-predicate-over-data-with-nulls.mdp
@@ -1,0 +1,656 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table test_stat
+(a bigint
+,b integer
+,c varchar(1)
+)
+distributed by (a);
+
+insert into test_stat
+select id, mod(id,100),'J'
+from generate_series(1,1000000) id;
+
+insert into test_stat
+select id, mod(id,100),null
+from generate_series(1,1000000) id;
+
+analyze test_stat;
+
+set optimizer=on; 
+explain select c from test_stat
+where c <> 'J';
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.58894.1.1" Name="test_stat" Rows="2001360.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.58894.1.1" Name="test_stat" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.20.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.531.1.0" Name="&lt;&gt;" ComparisonType="NEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.157.1.0"/>
+        <dxl:Commutator Mdid="0.531.1.0"/>
+        <dxl:InverseOp Mdid="0.98.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.8" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="3.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013067" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015571" DistinctValues="1.200000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013733" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="81"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023357" DistinctValues="1.800000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038928" DistinctValues="4.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="353"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="40093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012675" DistinctValues="11910.704856">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="40093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="52322"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="52322"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="52322"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027154" DistinctValues="25517.095144">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="52322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="78521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="78521"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="120615"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020437" DistinctValues="19204.337963">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="120615"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="139900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="139900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="139900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009179" DistinctValues="8625.770051">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="139900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="148562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="148562"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="148562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010213" DistinctValues="9596.691986">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="148562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="158199"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="158199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="200488"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="200488"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="238438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="238438"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="276085"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="276085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="319085"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="319085"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="357499"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030969" DistinctValues="29101.447210">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="357499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="388179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="388179"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="388179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008861" DistinctValues="8326.352790">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="388179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="396957"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006447" DistinctValues="6057.793599">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="396957"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="403183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="403183"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="403183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012766" DistinctValues="11995.910261">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="403183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="415512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="415512"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="415512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014285" DistinctValues="13423.276662">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="415512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="429308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="429308"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="429308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006331" DistinctValues="5948.819477">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="429308"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="435422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="435422"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="470602"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="470602"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="507259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016154" DistinctValues="15179.561978">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="507259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="524795"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="524795"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="524795"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023676" DistinctValues="22248.238022">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="524795"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="550497"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020492" DistinctValues="19256.357138">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="550497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="570145"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="570145"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="570145"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002211" DistinctValues="2077.742118">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="570145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="572265"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="572265"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="572265"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017126" DistinctValues="16092.700744">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="572265"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="588685"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="588685"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="629780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009516" DistinctValues="8941.540411">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="629780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="639375"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="639375"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="639375"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011263" DistinctValues="10583.540850">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="639375"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="650732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="650732"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="650732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019051" DistinctValues="17901.718739">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="650732"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="669942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="669942"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="712346"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="712346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="754345"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000740" DistinctValues="695.093933">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="754345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="755032"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="755032"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="755032"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011284" DistinctValues="10603.470776">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="755032"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="765512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="765512"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="765512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009070" DistinctValues="8522.236102">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="765512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="773935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="773935"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="773935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018736" DistinctValues="17604.999189">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="773935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="791335"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037492" DistinctValues="35231.599995">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="791335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="827558"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000267" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="827558"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="827558"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002337" DistinctValues="2196.200005">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="827558"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="829816"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="829816"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="869192"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="869192"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="915509"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="915509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="955375"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039829" DistinctValues="37428.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="955375"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="999676"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.3" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="2001360.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.58894.1.1.2" Name="c" Width="2.000000" NullFreq="0.502933" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.497067" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUo=" LintValue="160776748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUo=" LintValue="160776748"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.20.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+            <dxl:Ident ColId="3" ColName="c" TypeMdid="0.1043.1.0"/>
+          </dxl:Cast>
+          <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABUo=" LintValue="160776748"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.58894.1.1" TableName="test_stat">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.20.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="477.842827" Rows="1006549.988880" Width="2"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="470.340674" Rows="1006549.988880" Width="2"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.531.1.0">
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1043.1.0"/>
+              </dxl:Cast>
+              <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAABUo=" LintValue="160776748"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.58894.1.1" TableName="test_stat">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.20.1.0"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libnaucrates/src/statistics/CHistogram.cpp
+++ b/libnaucrates/src/statistics/CHistogram.cpp
@@ -329,6 +329,12 @@ CHistogram::PhistNEqual
 	DrgPbucket *pdrgppbucket = PdrgppbucketNEqual(pmp, ppoint);
 	CDouble dNullFreq(0.0);
 
+	if (!ppoint->Pdatum()->FNull())
+	{
+		// (col = NOT-NULL-CONSTANT) means that null values will also be returned
+		dNullFreq = m_dNullFreq;
+	}
+
 	return GPOS_NEW(pmp) CHistogram(pdrgppbucket, true /*fWellDefined*/, dNullFreq, m_dDistinctRemain, m_dFreqRemain);
 }
 

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -233,6 +233,7 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/retail_28.mdp",
 		"../data/dxl/minidump/JoinNDVRemain.mdp",
 		"../data/dxl/minidump/Least-Greatest.mdp",
+		"../data/dxl/minidump/notequal-predicate-over-data-with-nulls.mdp",
 #endif
 	};
 


### PR DESCRIPTION
ORCA computes wrong statistics for the following filter contains when NULLs are present in the histogram: 
* <> 
* NOT IN

The issue happens when NULLS are present.

Both <>, and NOT IN predicates will trigger a CHistogram::PhistNEqual histogram calculation.

Example predicates:

* Predicate is c <> 'J'. If the column has NULL values then those need to be returned.
* Predicate is c <> 'null'. If the column has NULL values then those tuples should not be returned.

@d @oarap @hsyuan please take a look.