### PR TITLE
Change ExmiWarningAsError to ExmiOptimizerError.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 680)
+set(GPORCA_VERSION_MINOR 681)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.680
+LIB_VERSION = 1.681
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/libnaucrates/include/naucrates/exception.h
+++ b/libnaucrates/include/naucrates/exception.h
@@ -73,7 +73,7 @@ namespace gpdxl
 		ExmiConstExprEvalNonConst,
 
 		// ORCA Exceptions that need to be reported as ERROR to GPDB
-		ExmiWarningAsError,
+		ExmiOptimizerError,
 		ExmiNoAvailableMemory,
 		ExmiInvalidComparisonTypeCode,
 

--- a/libnaucrates/src/exception.cpp
+++ b/libnaucrates/src/exception.cpp
@@ -225,7 +225,7 @@ gpdxl::EresExceptionInit
 					1, // attno
 					GPOS_WSZ_WSZLEN("DXL-to-Expr Translation: Attribute number not found in project list")),
 
-			CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiWarningAsError),
+			CMessage(CException(gpdxl::ExmaDXL, gpdxl::ExmiOptimizerError),
 					CException::ExsevError,
 					GPOS_WSZ_WSZLEN("%s"),
 					1, // attno


### PR DESCRIPTION
We changed `ExmiWarningAsError to ExmiOptimizerError`. This is based on the comments from PR : https://github.com/greenplum-db/gpdb/pull/1247

@oarap @xinzweb Please take a look when you get the chance.
