### PR TITLE
Remove whole banning mechanism from gporca [#133570595]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 683)
+set(GPORCA_VERSION_MINOR 684)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.
@@ -135,7 +135,7 @@ find_package(Xerces REQUIRED)
 include_directories(${XERCES_INCLUDE_DIRS})
 
 # GPOS.
-find_package(GPOS 1.144 REQUIRED)
+find_package(GPOS 1.146 REQUIRED)
 include_directories(${GPOS_INCLUDE_DIRS})
 
 # Extra system libs needed on Solaris.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.683
+LIB_VERSION = 1.684
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/libgpopt/src/xforms/CXformUtils.cpp
+++ b/libgpopt/src/xforms/CXformUtils.cpp
@@ -10,10 +10,6 @@
 //---------------------------------------------------------------------------
 
 
-#define ALLOW_va_start
-#define ALLOW_va_end
-#define ALLOW_va_arg
-
 #include "gpos/base.h"
 #include "gpos/error/CMessage.h"
 #include "gpos/error/CMessageRepository.h"

--- a/libnaucrates/src/CDXLUtils.cpp
+++ b/libnaucrates/src/CDXLUtils.cpp
@@ -9,11 +9,6 @@
 //		Implementation of the utility methods for parsing and searializing DXL.
 //---------------------------------------------------------------------------
 
-#define ALLOW_strlen
-#define ALLOW_wcslen
-#define ALLOW_wcsncmp
-#define ALLOW_wcstombs
-
 #include "gpos/base.h"
 #include "gpos/common/CAutoTimer.h"
 #include "gpos/common/CAutoRef.h"

--- a/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -9,9 +9,6 @@
 //		Implementation of the factory methods for creation of DXL elements.
 //---------------------------------------------------------------------------
 
-#define ALLOW_strncasecmp
-#define ALLOW_sscanf
-
 #include "gpos/string/CWStringConst.h"
 #include "gpos/string/CWStringDynamic.h"
 #include "gpos/common/clibwrapper.h"

--- a/server/src/unittest/dxl/CParseHandlerTest.cpp
+++ b/server/src/unittest/dxl/CParseHandlerTest.cpp
@@ -8,8 +8,6 @@
 //	@doc:
 //		Tests parsing DXL documents into DXL trees.
 //---------------------------------------------------------------------------
-#define ALLOW_printf
-
 #include "gpos/error/CException.h"
 #include "gpos/error/CAutoTrace.h"
 #include "gpos/error/CMessage.h"

--- a/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
+++ b/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
@@ -8,8 +8,6 @@
 //	@doc:
 //		Test for expression preprocessing
 //---------------------------------------------------------------------------
-#define ALLOW_strstr
-
 #include <string.h>
 
 #include "gpos/io/COstreamString.h"


### PR DESCRIPTION
gporca has a set of banned API calls which needs to be allowed with the
ALLOW_xxx macro in order for gpopt to compile. But it should be the
library caller(GPDB/Orca)'s resposibility to take care of the function call.

see discussions on greenplum-db/gpdb#1136
and https://groups.google.com/a/greenplum.org/forum/#!topic/gpdb-dev/Mcw6JPav6h4