### PR TITLE
Push down Equivclasses predicates under limit in subquery [#129871531]

### DIFF
--- a/data/dxl/minidump/EquivClassesLimit.mdp
+++ b/data/dxl/minidump/EquivClassesLimit.mdp
@@ -458,17 +458,17 @@
             </dxl:ProjList>
             <dxl:Filter>
 	          <dxl:And>
+	            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+	              <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
+	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="30"/>
+	            </dxl:Comparison>
+	            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+	              <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
+	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="30"/>
+	            </dxl:Comparison>
 	            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
 	              <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
 	              <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
-	            </dxl:Comparison>
-	            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	              <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
-	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="30"/>
-	            </dxl:Comparison>
-	            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-	              <dxl:Ident ColId="1" ColName="y" TypeMdid="0.23.1.0"/>
-	              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="30"/>
 	            </dxl:Comparison>
 	          </dxl:And>
             </dxl:Filter>

--- a/data/dxl/minidump/PartTbl-EquivClassLimitFilter.mdp
+++ b/data/dxl/minidump/PartTbl-EquivClassLimitFilter.mdp
@@ -1,0 +1,725 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    create table t1(a int, b int) DISTRIBUTED BY (a) PARTITION by RANGE(b) (START (1) END (3) EVERY (1));
+    create table t2(c int, d int);
+    create table h(j int, i int) DISTRIBUTED BY (i) PARTITION by RANGE(j) (START (1) END (3) EVERY (1));
+    explain select (select h.i from t2) from ( select h.* from h, t1 where h.i=t1.a and t1.a=2 order by t1.b limit 10) h where h.j = 1;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.41479.1.1" Name="t2" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.41479.1.1" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.41374.1.1" Name="t1" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.41374.1.1" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.41505.1.1" Name="h" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.41505.1.1" Name="h" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" Keys="7,8,2" PartitionColumns="0" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="i" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.1" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41505.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41479.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.41374.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="28" ColName="?column?" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="28" Alias="?column?">
+            <dxl:ScalarSubquery ColId="2">
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.41479.1.1" TableName="t2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="19" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="20" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalSelect>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          </dxl:Comparison>
+          <dxl:LogicalLimit>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset/>
+            <dxl:LogicalJoin JoinType="Inner">
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.41505.1.1" TableName="h">
+                  <dxl:Columns>
+                    <dxl:Column ColId="1" Attno="1" ColName="j" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.41374.1.1" TableName="t1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+              <dxl:And>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="2" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+                </dxl:Comparison>
+              </dxl:And>
+            </dxl:LogicalJoin>
+          </dxl:LogicalLimit>
+        </dxl:LogicalSelect>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="132">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="10775.111991" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="27" Alias="?column?">
+            <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+              <dxl:TestExpr/>
+              <dxl:ParamList>
+                <dxl:Param ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ParamList>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000016" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="28" Alias="ColRef_0028">
+                    <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Materialize Eager="true">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000011" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:TableScan>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList/>
+                      <dxl:Filter/>
+                      <dxl:TableDescriptor Mdid="0.41479.1.1" TableName="t2">
+                        <dxl:Columns>
+                          <dxl:Column ColId="18" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="19" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:GatherMotion>
+                </dxl:Materialize>
+              </dxl:Result>
+            </dxl:SubPlan>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1293.000936" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="i">
+              <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:And>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:Comparison>
+              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+            </dxl:And>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Limit>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000904" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="j">
+                <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="i">
+                <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000896" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="j">
+                  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="i">
+                  <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000851" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="j">
+                    <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="i">
+                    <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="b">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.000851" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="j">
+                      <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="i">
+                      <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="b">
+                      <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:JoinFilter>
+                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000506" Rows="3.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="j">
+                        <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="i">
+                        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Sequence>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="j">
+                          <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="i">
+                          <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:PartitionSelector RelationMdid="0.41505.1.1" PartitionLevels="1" ScanId="1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                            <dxl:PartOid Level="0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:PartEqFilters>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                        </dxl:PartEqFilters>
+                        <dxl:PartFilters>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                        </dxl:PartFilters>
+                        <dxl:ResidualFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                        </dxl:ResidualFilter>
+                        <dxl:PropagationExpression>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                        </dxl:PropagationExpression>
+                        <dxl:PrintableFilter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                          </dxl:Comparison>
+                        </dxl:PrintableFilter>
+                      </dxl:PartitionSelector>
+                      <dxl:DynamicTableScan PartIndexId="1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="j">
+                            <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="i">
+                            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+                          </dxl:Comparison>
+                        </dxl:Filter>
+                        <dxl:TableDescriptor Mdid="0.41505.1.1" TableName="h">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="j" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:DynamicTableScan>
+                    </dxl:Sequence>
+                  </dxl:BroadcastMotion>
+                  <dxl:Sequence>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="a">
+                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="b">
+                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:PartitionSelector RelationMdid="0.41374.1.1" PartitionLevels="1" ScanId="2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                          <dxl:PartOid Level="0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:PartEqFilters>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                      </dxl:PartEqFilters>
+                      <dxl:PartFilters>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                      </dxl:PartFilters>
+                      <dxl:ResidualFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                      </dxl:ResidualFilter>
+                      <dxl:PropagationExpression>
+                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+                      </dxl:PropagationExpression>
+                      <dxl:PrintableFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                      </dxl:PrintableFilter>
+                    </dxl:PartitionSelector>
+                    <dxl:DynamicTableScan PartIndexId="2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000077" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="a">
+                          <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="b">
+                          <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:TableDescriptor Mdid="0.41374.1.1" TableName="t1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:DynamicTableScan>
+                  </dxl:Sequence>
+                </dxl:NestedLoopJoin>
+              </dxl:Sort>
+            </dxl:GatherMotion>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
+        </dxl:Result>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -377,408 +377,293 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="110000">
-  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-    <dxl:Properties>
-      <dxl:Cost StartupCost="0" TotalCost="66.414062" Rows="1.000000" Width="4"/>
-    </dxl:Properties>
-    <dxl:ProjList>
-      <dxl:ProjElem ColId="20" Alias="c9596">
-        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-      </dxl:ProjElem>
-    </dxl:ProjList>
-    <dxl:Filter/>
-    <dxl:SortingColumnList/>
-    <dxl:Result>
-      <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="65.412109" Rows="1.000000" Width="4"/>
-      </dxl:Properties>
-      <dxl:ProjList>
-        <dxl:ProjElem ColId="20" Alias="?column?">
-          <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-        </dxl:ProjElem>
-      </dxl:ProjList>
-      <dxl:Filter/>
-      <dxl:OneTimeFilter/>
-      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="65.412109" Rows="1.000000" Width="4"/>
-        </dxl:Properties>
-        <dxl:GroupingColumns>
-          <dxl:GroupingColumn ColId="20"/>
-          <dxl:GroupingColumn ColId="17"/>
-        </dxl:GroupingColumns>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="20" Alias="?column?">
-            <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="17" Alias="max">
-            <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="64.376953" Rows="1.000000" Width="8"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="17" Alias="max">
-              <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="20" Alias="?column?">
-              <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
-              <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-            </dxl:HashExpr>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
-              <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-            </dxl:HashExpr>
-          </dxl:HashExprList>
-          <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="63.373047" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="17" Alias="max">
-                <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="?column?">
-                <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
-                <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0">
-                  <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
-                </dxl:FuncExpr>
-              </dxl:Comparison>
-            </dxl:JoinFilter>
-            <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="11.365234" Rows="2.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="16" Alias="avg">
-                  <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="17" Alias="max">
-                  <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="10.341797" Rows="1.000000" Width="12"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="16" Alias="avg">
-                    <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="17" Alias="max">
-                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:JoinFilter>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="4.136719" Rows="1.000000" Width="20"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="8" Alias="c504">
-                      <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="16" Alias="avg">
-                      <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="17" Alias="max">
-                      <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3.117188" Rows="1.000000" Width="20"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="8" Alias="c504">
-                        <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="16" Alias="avg">
-                        <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="17" Alias="max">
-                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="20"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="8"/>
-                      </dxl:GroupingColumns>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="16" Alias="avg">
-                          <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal">
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="17" Alias="max">
-                          <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="c504">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="8" Alias="c504">
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
-                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="8" Alias="c504">
-                              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.131046.1.1" TableName="t39">
-                            <dxl:Columns>
-                              <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="5" Attno="3" ColName="c501" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:GatherMotion>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="5.087891" Rows="1.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="1" Alias="?column?">
-                      <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="min">
-                      <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:And>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                      </dxl:Comparison>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:And>
-                  </dxl:Filter>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Limit>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="4.072266" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="1" Alias="?column?">
-                        <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="min">
-                        <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="3.056641" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="?column?">
-                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="min">
-                          <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2.041016" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="1"/>
-                        </dxl:GroupingColumns>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="2" Alias="min">
-                            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal">
-                              <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="?column?">
-                            <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="1" Alias="?column?">
-                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Result>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="">
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                          </dxl:Result>
-                        </dxl:Result>
-                      </dxl:Aggregate>
-                    </dxl:Result>
-                    <dxl:LimitCount>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="3613"/>
-                    </dxl:LimitCount>
-                    <dxl:LimitOffset>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                    </dxl:LimitOffset>
-                  </dxl:Limit>
-                </dxl:Result>
-              </dxl:HashJoin>
-            </dxl:BroadcastMotion>
-            <dxl:Result>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.007812" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="20" Alias="?column?">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Materialize Eager="true">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.003906" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.002930" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList/>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                  </dxl:Result>
-                </dxl:RandomMotion>
-              </dxl:Materialize>
-            </dxl:Result>
-          </dxl:NestedLoopJoin>
-        </dxl:RedistributeMotion>
-      </dxl:Aggregate>
-    </dxl:Result>
-  </dxl:GatherMotion>
-</dxl:Plan>
+	<dxl:Plan Id="0" SpaceSize="13000">
+	  <dxl:Result>
+	    <dxl:Properties>
+	      <dxl:Cost StartupCost="0" TotalCost="43.320312" Rows="1.000000" Width="4"/>
+	    </dxl:Properties>
+	    <dxl:ProjList>
+	      <dxl:ProjElem ColId="20" Alias="c9596">
+	        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+	      </dxl:ProjElem>
+	    </dxl:ProjList>
+	    <dxl:Filter/>
+	    <dxl:OneTimeFilter/>
+	    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+	      <dxl:Properties>
+	        <dxl:Cost StartupCost="0" TotalCost="43.320312" Rows="1.000000" Width="4"/>
+	      </dxl:Properties>
+	      <dxl:GroupingColumns>
+	        <dxl:GroupingColumn ColId="20"/>
+	        <dxl:GroupingColumn ColId="17"/>
+	      </dxl:GroupingColumns>
+	      <dxl:ProjList>
+	        <dxl:ProjElem ColId="20" Alias="?column?">
+	          <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+	        </dxl:ProjElem>
+	        <dxl:ProjElem ColId="17" Alias="max">
+	          <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+	        </dxl:ProjElem>
+	      </dxl:ProjList>
+	      <dxl:Filter/>
+	      <dxl:HashJoin JoinType="Inner">
+	        <dxl:Properties>
+	          <dxl:Cost StartupCost="0" TotalCost="42.281250" Rows="1.000000" Width="8"/>
+	        </dxl:Properties>
+	        <dxl:ProjList>
+	          <dxl:ProjElem ColId="17" Alias="max">
+	            <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+	          </dxl:ProjElem>
+	          <dxl:ProjElem ColId="20" Alias="?column?">
+	            <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+	          </dxl:ProjElem>
+	        </dxl:ProjList>
+	        <dxl:Filter/>
+	        <dxl:JoinFilter>
+	          <dxl:And>
+	            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1756.1.0">
+	              <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+	              <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0">
+	                <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+	              </dxl:FuncExpr>
+	            </dxl:Comparison>
+	            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+	              <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+	              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	            </dxl:Comparison>
+	          </dxl:And>
+	        </dxl:JoinFilter>
+	        <dxl:HashCondList>
+	          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+	            <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+	            <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+	          </dxl:Comparison>
+	        </dxl:HashCondList>
+	        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+	          <dxl:Properties>
+	            <dxl:Cost StartupCost="0" TotalCost="3.097656" Rows="1.000000" Width="20"/>
+	          </dxl:Properties>
+	          <dxl:ProjList>
+	            <dxl:ProjElem ColId="8" Alias="c504">
+	              <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	            </dxl:ProjElem>
+	            <dxl:ProjElem ColId="16" Alias="avg">
+	              <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+	            </dxl:ProjElem>
+	            <dxl:ProjElem ColId="17" Alias="max">
+	              <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+	            </dxl:ProjElem>
+	          </dxl:ProjList>
+	          <dxl:Filter/>
+	          <dxl:SortingColumnList/>
+	          <dxl:Result>
+	            <dxl:Properties>
+	              <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="20"/>
+	            </dxl:Properties>
+	            <dxl:ProjList>
+	              <dxl:ProjElem ColId="8" Alias="c504">
+	                <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	              </dxl:ProjElem>
+	              <dxl:ProjElem ColId="16" Alias="avg">
+	                <dxl:Ident ColId="16" ColName="avg" TypeMdid="0.1700.1.0"/>
+	              </dxl:ProjElem>
+	              <dxl:ProjElem ColId="17" Alias="max">
+	                <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
+	              </dxl:ProjElem>
+	            </dxl:ProjList>
+	            <dxl:Filter/>
+	            <dxl:OneTimeFilter/>
+	            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+	              <dxl:Properties>
+	                <dxl:Cost StartupCost="0" TotalCost="2.078125" Rows="1.000000" Width="20"/>
+	              </dxl:Properties>
+	              <dxl:GroupingColumns>
+	                <dxl:GroupingColumn ColId="8"/>
+	              </dxl:GroupingColumns>
+	              <dxl:ProjList>
+	                <dxl:ProjElem ColId="16" Alias="avg">
+	                  <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal">
+	                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	                  </dxl:AggFunc>
+	                </dxl:ProjElem>
+	                <dxl:ProjElem ColId="17" Alias="max">
+	                  <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal">
+	                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	                  </dxl:AggFunc>
+	                </dxl:ProjElem>
+	                <dxl:ProjElem ColId="8" Alias="c504">
+	                  <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	                </dxl:ProjElem>
+	              </dxl:ProjList>
+	              <dxl:Filter/>
+	              <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+	                <dxl:Properties>
+	                  <dxl:Cost StartupCost="0" TotalCost="1.007812" Rows="1.000000" Width="8"/>
+	                </dxl:Properties>
+	                <dxl:ProjList>
+	                  <dxl:ProjElem ColId="8" Alias="c504">
+	                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	                  </dxl:ProjElem>
+	                </dxl:ProjList>
+	                <dxl:Filter/>
+	                <dxl:SortingColumnList/>
+	                <dxl:HashExprList>
+	                  <dxl:HashExpr TypeMdid="0.23.1.0">
+	                    <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	                  </dxl:HashExpr>
+	                </dxl:HashExprList>
+	                <dxl:TableScan>
+	                  <dxl:Properties>
+	                    <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
+	                  </dxl:Properties>
+	                  <dxl:ProjList>
+	                    <dxl:ProjElem ColId="8" Alias="c504">
+	                      <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+	                    </dxl:ProjElem>
+	                  </dxl:ProjList>
+	                  <dxl:Filter/>
+	                  <dxl:TableDescriptor Mdid="0.131046.1.1" TableName="t39">
+	                    <dxl:Columns>
+	                      <dxl:Column ColId="3" Attno="1" ColName="c499" TypeMdid="0.23.1.0"/>
+	                      <dxl:Column ColId="4" Attno="2" ColName="c500" TypeMdid="0.23.1.0"/>
+	                      <dxl:Column ColId="5" Attno="3" ColName="c501" TypeMdid="0.23.1.0"/>
+	                      <dxl:Column ColId="6" Attno="4" ColName="c502" TypeMdid="0.23.1.0"/>
+	                      <dxl:Column ColId="7" Attno="5" ColName="c503" TypeMdid="0.23.1.0"/>
+	                      <dxl:Column ColId="8" Attno="6" ColName="c504" TypeMdid="0.23.1.0"/>
+	                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+	                      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+	                      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+	                      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+	                      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+	                      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+	                      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+	                    </dxl:Columns>
+	                  </dxl:TableDescriptor>
+	                </dxl:TableScan>
+	              </dxl:RedistributeMotion>
+	            </dxl:Aggregate>
+	          </dxl:Result>
+	        </dxl:GatherMotion>
+	        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+	          <dxl:Properties>
+	            <dxl:Cost StartupCost="0" TotalCost="38.066406" Rows="1.000000" Width="8"/>
+	          </dxl:Properties>
+	          <dxl:ProjList>
+	            <dxl:ProjElem ColId="2" Alias="min">
+	              <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+	            </dxl:ProjElem>
+	            <dxl:ProjElem ColId="20" Alias="?column?">
+	              <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+	            </dxl:ProjElem>
+	          </dxl:ProjList>
+	          <dxl:Filter/>
+	          <dxl:JoinFilter>
+	            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+	          </dxl:JoinFilter>
+	          <dxl:Result>
+	            <dxl:Properties>
+	              <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+	            </dxl:Properties>
+	            <dxl:ProjList>
+	              <dxl:ProjElem ColId="20" Alias="?column?">
+	                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	              </dxl:ProjElem>
+	            </dxl:ProjList>
+	            <dxl:Filter/>
+	            <dxl:OneTimeFilter/>
+	            <dxl:Result>
+	              <dxl:Properties>
+	                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+	              </dxl:Properties>
+	              <dxl:ProjList>
+	                <dxl:ProjElem ColId="19" Alias="">
+	                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+	                </dxl:ProjElem>
+	              </dxl:ProjList>
+	              <dxl:Filter/>
+	              <dxl:OneTimeFilter/>
+	            </dxl:Result>
+	          </dxl:Result>
+	          <dxl:Limit>
+	            <dxl:Properties>
+	              <dxl:Cost StartupCost="0" TotalCost="4.056641" Rows="1.000000" Width="4"/>
+	            </dxl:Properties>
+	            <dxl:ProjList>
+	              <dxl:ProjElem ColId="2" Alias="min">
+	                <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+	              </dxl:ProjElem>
+	            </dxl:ProjList>
+	            <dxl:Result>
+	              <dxl:Properties>
+	                <dxl:Cost StartupCost="0" TotalCost="3.048828" Rows="1.000000" Width="4"/>
+	              </dxl:Properties>
+	              <dxl:ProjList>
+	                <dxl:ProjElem ColId="2" Alias="min">
+	                  <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+	                </dxl:ProjElem>
+	              </dxl:ProjList>
+	              <dxl:Filter>
+	                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+	                  <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+	                  <dxl:Ident ColId="2" ColName="min" TypeMdid="0.23.1.0"/>
+	                </dxl:Comparison>
+	              </dxl:Filter>
+	              <dxl:OneTimeFilter/>
+	              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+	                <dxl:Properties>
+	                  <dxl:Cost StartupCost="0" TotalCost="2.041016" Rows="1.000000" Width="8"/>
+	                </dxl:Properties>
+	                <dxl:GroupingColumns>
+	                  <dxl:GroupingColumn ColId="1"/>
+	                </dxl:GroupingColumns>
+	                <dxl:ProjList>
+	                  <dxl:ProjElem ColId="2" Alias="min">
+	                    <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal">
+	                      <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+	                    </dxl:AggFunc>
+	                  </dxl:ProjElem>
+	                  <dxl:ProjElem ColId="1" Alias="?column?">
+	                    <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+	                  </dxl:ProjElem>
+	                </dxl:ProjList>
+	                <dxl:Filter/>
+	                <dxl:Result>
+	                  <dxl:Properties>
+	                    <dxl:Cost StartupCost="0" TotalCost="1.009766" Rows="1.000000" Width="4"/>
+	                  </dxl:Properties>
+	                  <dxl:ProjList>
+	                    <dxl:ProjElem ColId="1" Alias="?column?">
+	                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+	                    </dxl:ProjElem>
+	                  </dxl:ProjList>
+	                  <dxl:Filter/>
+	                  <dxl:OneTimeFilter/>
+	                  <dxl:Result>
+	                    <dxl:Properties>
+	                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+	                    </dxl:Properties>
+	                    <dxl:ProjList>
+	                      <dxl:ProjElem ColId="0" Alias="">
+	                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+	                      </dxl:ProjElem>
+	                    </dxl:ProjList>
+	                    <dxl:Filter/>
+	                    <dxl:OneTimeFilter/>
+	                  </dxl:Result>
+	                </dxl:Result>
+	              </dxl:Aggregate>
+	            </dxl:Result>
+	            <dxl:LimitCount>
+	              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="3613"/>
+	            </dxl:LimitCount>
+	            <dxl:LimitOffset>
+	              <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+	            </dxl:LimitOffset>
+	          </dxl:Limit>
+	        </dxl:NestedLoopJoin>
+	      </dxl:HashJoin>
+	    </dxl:Aggregate>
+	  </dxl:Result>
+	</dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/libgpopt/include/gpopt/operators/CLogicalLimit.h
+++ b/libgpopt/include/gpopt/operators/CLogicalLimit.h
@@ -165,10 +165,7 @@ namespace gpopt
 				IMemoryPool *, //pmp,
 				CExpressionHandle &exprhdl
 				)
-				const
-			{
-				return PpcDeriveConstraintPassThru(exprhdl, 0 /*ulChild*/);
-			}
+				const;
 
 			//-------------------------------------------------------------------------------------
 			// Required Relational Properties

--- a/libgpopt/src/operators/CLogicalLimit.cpp
+++ b/libgpopt/src/operators/CLogicalLimit.cpp
@@ -364,4 +364,22 @@ CLogicalLimit::PstatsDerive
 	return pstatsChild->PstatsLimit(pmp, dRowsMax);
 }
 
+CPropConstraint *
+CLogicalLimit::PpcDeriveConstraint
+       (
+       IMemoryPool *pmp,
+       CExpressionHandle &exprhdl
+       )
+       const
+{
+       GPOS_ASSERT(Esp(exprhdl) > EspNone);
+
+       if (Esp(exprhdl) == EspNone)
+               return NULL;
+
+       DrgPcrs *pdrgpcrs = GPOS_NEW(pmp) DrgPcrs(pmp);
+
+       return GPOS_NEW(pmp) CPropConstraint(pmp, pdrgpcrs, NULL);
+}
+
 // EOF

--- a/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
@@ -89,7 +89,7 @@ const CHAR *rgszPartTblFileNames[] =
 	"../data/dxl/minidump/PartTbl-CSQ-NonPartKey.mdp",
 	"../data/dxl/minidump/PartTbl-LeftOuterHashJoin-DPE-IsNull.mdp",
 	"../data/dxl/minidump/PartTbl-LeftOuterNLJoin-DPE-IsNull.mdp",
-
+	"../data/dxl/minidump/PartTbl-EquivClassLimitFilter.mdp"
 	};
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Equivclass predicate were not being pushed down under the limit node for
the following case:
```sql
create table t1(a int, b int) DISTRIBUTED BY (a) PARTITION by RANGE(b)
(START (1) END (3) EVERY (1));
create table t2(c int, d int);
create table h(j int, i int) DISTRIBUTED BY (i) PARTITION by RANGE(j)
(START (1) END (3) EVERY (1));
explain select (select h.i from t2) from (
select h.* from h, t1
where h.i=t1.a and t1.a=2
order by t1.b limit 10
) h
where h.j = 1;
```
This patch fixes the issue for such cases.