### PR TITLE
Filters above limit should not pushed down into a partition selector in subquery with limit clause [#133827909]

### DIFF
--- a/data/dxl/minidump/DonotPushPartConstThruLimit.mdp
+++ b/data/dxl/minidump/DonotPushPartConstThruLimit.mdp
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table h(j int, i int) DISTRIBUTED BY (i) PARTITION by RANGE(j) (START (1) END (3) EVERY (1));
+insert into h values (1,1);
+insert into h values (2,2);
+insert into h values (2,2);
+analyze h;
+
+select * from (select * from h order by j limit 2) x where j = 2;
+-->
+
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="2.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.16527.1.1" Name="h" Rows="3.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16527.1.1" Name="h" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" Keys="7,8,2" PartitionColumns="0" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="j" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="i" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="" Unbounded="false">
+          <dxl:And>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.525.1.0" Name="&gt;=" ComparisonType="GEq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.150.1.0"/>
+        <dxl:Commutator Mdid="0.523.1.0"/>
+        <dxl:InverseOp Mdid="0.97.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.1" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="2.000000" FreqRemain="0.333333" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.666667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.16527.1.1.0" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="2.000000" FreqRemain="0.333333" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.666667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="i" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+        </dxl:Comparison>
+        <dxl:LogicalLimit>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset/>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.16527.1.1" TableName="h">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalLimit>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="1.333334" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="j">
+            <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="i">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          </dxl:Comparison>
+        </dxl:Filter>
+        <dxl:OneTimeFilter/>
+        <dxl:Limit>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="2.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="j">
+              <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="i">
+              <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000109" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="j">
+                <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="i">
+                <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="2.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="j">
+                  <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="i">
+                  <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Sequence>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="3.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="j">
+                    <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="i">
+                    <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:PartitionSelector RelationMdid="0.16527.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                      <dxl:PartOid Level="0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="3.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="j">
+                      <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="i">
+                      <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:DynamicTableScan PartIndexId="1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="3.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="j">
+                        <dxl:Ident ColId="0" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="i">
+                        <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.16527.1.1" TableName="h">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="j" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:DynamicTableScan>
+                </dxl:Sort>
+              </dxl:Sequence>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:GatherMotion>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          </dxl:LimitOffset>
+        </dxl:Limit>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/libgpopt/include/gpopt/operators/CPhysical.h
@@ -64,6 +64,14 @@ namespace gpopt
 				EceoSentinel
 			};
 
+			enum EPropogatePartConstraint
+			{
+				EppcAllowed,
+				EppcProhibited,
+
+				EppcSentinel
+			};
+
 		private:
 
 			//---------------------------------------------------------------------------
@@ -321,7 +329,8 @@ namespace gpopt
 				(
 				IMemoryPool *pmp,
 				CExpressionHandle &exprhdl,
-				CPartitionPropagationSpec *pppsRequired
+				CPartitionPropagationSpec *pppsRequired,
+				EPropogatePartConstraint eppcPropogate
 				);
 			
 			// pass cte requirement to the child

--- a/libgpopt/src/operators/CPhysical.cpp
+++ b/libgpopt/src/operators/CPhysical.cpp
@@ -934,7 +934,8 @@ CPhysical::PppsRequiredPushThruUnresolvedUnary
 	(
 	IMemoryPool *pmp,
 	CExpressionHandle &exprhdl,
-	CPartitionPropagationSpec *pppsRequired
+	CPartitionPropagationSpec *pppsRequired,
+	EPropogatePartConstraint eppcPropogate
 	)
 {
 	GPOS_ASSERT(NULL != pppsRequired);
@@ -962,7 +963,13 @@ CPhysical::PppsRequiredPushThruUnresolvedUnary
 		{
 			// push requirements to child node
 			ppimResult->AddRequiredPartPropagation(ppimReqd, ulPartIndexId, CPartIndexMap::EppraPreservePropagators);
-			(void) ppfmResult->FCopyPartFilter(pmp, ulPartIndexId, ppfmReqd);
+			if (CPhysical::EppcAllowed == eppcPropogate)
+			{
+				// for some logical operators such as limit while we push the part index map, we cannot push the constraints
+				// since they are NOT semantically equivalent. So only push the constraints when the operator asks this
+				// utility function to do so
+				(void) ppfmResult->FCopyPartFilter(pmp, ulPartIndexId, ppfmReqd);
+			}
 		}
 	}
 	

--- a/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -430,7 +430,7 @@ CPhysicalAgg::PppsRequired
 	GPOS_ASSERT(0 == ulChildIndex);
 	GPOS_ASSERT(NULL != pppsRequired);
 
-	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired);
+	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired, CPhysical::EppcAllowed);
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/operators/CPhysicalLimit.cpp
+++ b/libgpopt/src/operators/CPhysicalLimit.cpp
@@ -282,7 +282,12 @@ CPhysicalLimit::PppsRequired
 	GPOS_ASSERT(0 == ulChildIndex);
 	GPOS_ASSERT(NULL != pppsRequired);
 	
-	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired);
+	// limit should not push predicate below it as it will generate wrong results
+	// for example, the following two queries are not equivalent.
+	// Q1: select * from (select * from foo order by a limit 1) x where x.a = 10
+	// Q2: select * from (select * from foo where a = 10 order by a limit 1) x
+
+	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired, CPhysical::EppcProhibited);
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/operators/CPhysicalSequenceProject.cpp
+++ b/libgpopt/src/operators/CPhysicalSequenceProject.cpp
@@ -413,7 +413,7 @@ CPhysicalSequenceProject::PppsRequired
 	GPOS_ASSERT(0 == ulChildIndex);
 	GPOS_ASSERT(NULL != pppsRequired);
 
-	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired);
+	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired, CPhysical::EppcAllowed);
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/operators/CPhysicalSort.cpp
+++ b/libgpopt/src/operators/CPhysicalSort.cpp
@@ -228,7 +228,7 @@ CPhysicalSort::PppsRequired
 	GPOS_ASSERT(0 == ulChildIndex);
 	GPOS_ASSERT(NULL != pppsRequired);
 	
-	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired);
+	return CPhysical::PppsRequiredPushThruUnresolvedUnary(pmp, exprhdl, pppsRequired, CPhysical::EppcAllowed);
 }
 
 //---------------------------------------------------------------------------

--- a/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
@@ -28,6 +28,7 @@ ULONG CPartTblTest::m_ulPartTblTestCounter = 0;  // start from first test
 // minidump files
 const CHAR *rgszPartTblFileNames[] =
 	{
+	"../data/dxl/minidump/DonotPushPartConstThruLimit.mdp",
 	"../data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp",
 	"../data/dxl/minidump/Select-Over-PartTbl.mdp",
 	"../data/dxl/minidump/PartTbl-DPE.mdp",


### PR DESCRIPTION
The bug is in derivation of required partition propagation specification from the child. Before this fix, we were pushing the partition constraints below Limit which will return wrong results.

To illustrate consider the following table schema and data:
```sql
create table h(j int, i int) DISTRIBUTED BY (i) PARTITION by RANGE(j) (START (1) END (3) EVERY (1));
insert into h values (1,1);
insert into h values (2,2);
insert into h values (2,2);
```

SQL in question is:

```
select * from (select * from h order by j limit 2) x where j = 2;
```

With Planner:
** As you can see from the explain the condition `j = 2` is not pushed below the limit
```sql
vraghavan=# set optimizer = off;
SET
vraghavan=# select * from (select * from h order by j limit 2) x where j = 2;
 j | i
---+---
 2 | 2
(1 row)

vraghavan=# explain select * from (select * from h order by j limit 2) x where j = 2;
                                             QUERY PLAN
-----------------------------------------------------------------------------------------------------
 Subquery Scan x  (cost=3644.00..3644.07 rows=1 width=8)
   Filter: x.j = 2
   ->  Limit  (cost=3644.00..3644.05 rows=2 width=8)
         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=3644.00..3644.05 rows=2 width=8)
               Merge Key: public.h.j
               ->  Limit  (cost=3644.00..3644.01 rows=1 width=8)
                     ->  Sort  (cost=3644.00..4074.50 rows=57400 width=8)
                           Sort Key (Limit): public.h.j
                           ->  Append  (cost=0.00..1922.00 rows=57400 width=8)
                                 ->  Seq Scan on h_1_prt_1 h  (cost=0.00..961.00 rows=28700 width=8)
                                 ->  Seq Scan on h_1_prt_2 h  (cost=0.00..961.00 rows=28700 width=8)
 Settings:  optimizer=off
 Optimizer status: legacy query optimizer
(13 rows)
```

Orca before the fix:
* PROBLEM: We push the `j=2` below the limit.

```
vraghavan=# select * from (select * from h order by j limit 2) x where j = 2;
 j | i
---+---
 2 | 2
 2 | 2
(2 rows)

vraghavan=# explain select * from (select * from h order by j limit 2) x where j = 2;                                                                                                                                                                       QUERY PLAN
----------------------------------------------------------------------------------------------------------------
 Result  (cost=0.00..431.00 rows=1 width=8)
   Filter: j = 2
   ->  Limit  (cost=0.00..431.00 rows=1 width=8)
         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
               Merge Key: j
               ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
                     ->  Partition Selector for h (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                           Filter: j = 2
                           Partitions selected: 1 (out of 2)
                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                           Sort Key: j
                           ->  Dynamic Table Scan on h (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
 Settings:  optimizer=on
 Optimizer status: PQO version 1.684
(14 rows)
```

Orca after the fix:

```
vraghavan=# select * from (select * from h order by j limit 2) x where j = 2;
 j | i
---+---
 2 | 2
(1 row)
vraghavan=# explain select * from (select * from h order by j limit 2) x where j = 2;
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Result  (cost=0.00..431.00 rows=1 width=8)
   Filter: j = 2
   ->  Limit  (cost=0.00..431.00 rows=1 width=8)
         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
               Merge Key: j
               ->  Limit  (cost=0.00..431.00 rows=1 width=8)
                     ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
                           ->  Partition Selector for h (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                 Partitions selected: 2 (out of 2)
                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                                 Sort Key: j
                                 ->  Dynamic Table Scan on h (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
 Settings:  optimizer=on
 Optimizer status: PQO version 1.684
```
@d @oarap @hsyuan @bhuvnesh2703 @xinzweb please take a look