### PR TITLE
Insert random motion for randomly distributed children for parallel append [#133978027]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 684)
+set(GPORCA_VERSION_MINOR 685)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.684
+LIB_VERSION = 1.685
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/RandomDistributedChildrenUnhashableColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/RandomDistributedChildrenUnhashableColumns.mdp
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CREATE TABLE foo (a int, b int) DISTRIBUTED RANDOMLY;
+CREATE TABLE bar (c int, d int) DISTRIBUTED RANDOMLY;
+
+EXPLAIN SELECT xmin FROM foo UNION ALL SELECT xmin FROM bar;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
+      <dxl:TraceFlags Value="101001,101013,102120,103001,103014,103015,103022,103025,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16385.1.1" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16385.1.1" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16388.1.1" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.16388.1.1" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="4" ColName="xmin" TypeMdid="0.28.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:UnionAll InputColumns="4;13" CastAcrossInputs="false">
+        <dxl:Columns>
+          <dxl:Column ColId="4" Attno="1" ColName="xmin" TypeMdid="0.28.1.0"/>
+        </dxl:Columns>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16385.1.1" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16388.1.1" TableName="bar">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:UnionAll>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="3" Alias="xmin">
+            <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Append IsTarget="false" IsZapped="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="3" Alias="xmin">
+              <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="3" Alias="xmin">
+                <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="3" Alias="xmin">
+                  <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.16385.1.1" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RandomMotion>
+          <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000014" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="12" Alias="xmin">
+                <dxl:Ident ColId="12" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="12" Alias="xmin">
+                  <dxl:Ident ColId="12" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.16388.1.1" TableName="bar">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RandomMotion>
+        </dxl:Append>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -895,6 +895,8 @@ add_library(gpopt
             src/base/CDatumSortedSet.cpp
             include/gpopt/base/CDistributionSpecHashedNoOp.h
             src/base/CDistributionSpecHashedNoOp.cpp
+            include/gpopt/base/CDistributionSpecStrictRandom.h
+            src/base/CDistributionSpecStrictRandom.cpp
             )
 
 target_link_libraries(gpopt

--- a/libgpopt/include/gpopt/base/CDistributionSpec.h
+++ b/libgpopt/include/gpopt/base/CDistributionSpec.h
@@ -45,6 +45,7 @@ namespace gpopt
 				EdtSingleton,		// data is on a single segment or the master
 				EdtStrictSingleton,	// data is on a single segment or the master (derived only, only compatible with other singleton distributions)
 				EdtRandom,			// data is randomly distributed across all segments
+				EdtStrictRandom,    // same as random, used to force multiple slices for parallel union all.
 				EdtRouted,			// data is routed to a segment explicitly specified in the tuple,
 				EdtUniversal,		// data is available everywhere (derived only)
 				EdtNonSingleton,	// data can have any distribution except singleton (required only)

--- a/libgpopt/include/gpopt/base/CDistributionSpecStrictRandom.h
+++ b/libgpopt/include/gpopt/base/CDistributionSpecStrictRandom.h
@@ -1,0 +1,51 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#ifndef GPOPT_CDistributionSpecStrictRandom_H
+#define GPOPT_CDistributionSpecStrictRandom_H
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CDistributionSpec.h"
+#include "gpopt/base/CDistributionSpecRandom.h"
+
+namespace gpopt
+{
+    using namespace gpos;
+    
+    //---------------------------------------------------------------------------
+    //	@class:
+    //		CDistributionSpecStrictRandom
+    //
+    //	@doc:
+    //		Class for representing forced random distribution.
+    //
+    //---------------------------------------------------------------------------
+    class CDistributionSpecStrictRandom : public CDistributionSpecRandom
+    {
+    public:
+        
+        //ctor
+        CDistributionSpecStrictRandom();
+        
+        // accessor
+        virtual
+        EDistributionType Edt() const
+        {
+            return CDistributionSpec::EdtStrictRandom;
+        }
+        
+        // does this distribution match the given one
+        virtual
+        BOOL FMatch(const CDistributionSpec *pds) const;
+        
+        // does this distribution satisfy the given one
+        virtual
+        BOOL FSatisfies(const CDistributionSpec *pds) const;
+    }; // class CDistributionSpecStrictRandom
+    
+}
+
+#endif // !GPOPT_CDistributionSpecStrictRandom_H
+
+// EOF

--- a/libgpopt/src/base/CDistributionSpecRandom.cpp
+++ b/libgpopt/src/base/CDistributionSpecRandom.cpp
@@ -81,7 +81,7 @@ CDistributionSpecRandom::FSatisfies
 	const CDistributionSpec *pds
 	)
 	const
-{	
+{
 	if (FMatch(pds))
 	{
 		return true;

--- a/libgpopt/src/base/CDistributionSpecStrictRandom.cpp
+++ b/libgpopt/src/base/CDistributionSpecStrictRandom.cpp
@@ -1,0 +1,20 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#include "gpopt/base/CDistributionSpecStrictRandom.h"
+
+using namespace gpopt;
+
+CDistributionSpecStrictRandom::CDistributionSpecStrictRandom()
+{
+}
+
+BOOL CDistributionSpecStrictRandom::FMatch(const CDistributionSpec *pds) const
+{
+    return pds->Edt() == Edt();
+}
+
+BOOL CDistributionSpecStrictRandom::FSatisfies(const CDistributionSpec *pds) const
+{
+    return FMatch(pds);
+}

--- a/libgpopt/src/operators/CStrictHashedDistributions.cpp
+++ b/libgpopt/src/operators/CStrictHashedDistributions.cpp
@@ -2,7 +2,7 @@
 //	Copyright (C) 2016 Pivotal Software, Inc.
 
 #include "gpopt/operators/CStrictHashedDistributions.h"
-#include "gpopt/base/CDistributionSpecRandom.h"
+#include "gpopt/base/CDistributionSpecStrictRandom.h"
 
 using namespace gpopt;
 
@@ -48,7 +48,7 @@ DrgPds(pmp)
 			// Some databases actually execute it as if it's a random redistribution.
 			// We should not generate such a plan, for clarity and our own sanity
 
-			pdshashed = GPOS_NEW(pmp) CDistributionSpecRandom();
+			pdshashed = GPOS_NEW(pmp) CDistributionSpecStrictRandom();
 			pdrgpexpr->Release();
 		}
 		Append(pdshashed);

--- a/server/src/unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.cpp
@@ -22,6 +22,7 @@ static const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnion-ConstTable.mdp",
 		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNotEqualNumOfDistrColumns.mdp",
 		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialUnion.mdp",
+		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/RandomDistributedChildrenUnhashableColumns.mdp",
 	};
 
 namespace gpopt


### PR DESCRIPTION
Parallel Union currently has 2 optimization request. The second request is not satisfied
when the children of the parallel union are randomly distributed.

For the first request, if the output columns are not hashable columns the
`CPhysicalParallelUnion` requires random distribution. Since the children are randomly
distributed the `CPhysicalTableScan` already satisfied the optimization request and no
motion is created on top of `CPhysicalTableScan`.

To overcome this issue and enforce a `CPhysicalMotionRandom`, we introduce a new distribution
spec called `CDistributionSpecRandomStrict`. This distribution spec is requested replaces
regular `CDistributionSpecRandom` in the first optimization request where no output column is
redistributable.

Below is the output after this commit:
```
explain select xmin from foo union all select xmin from bar;

Physical plan:
+--CPhysicalMotionGather(master)   rows:1   width:4  rebinds:1   cost:431.000029   origin: [Grp:2, GrpExpr:3]
   +--CPhysicalParallelUnionAll   rows:1   width:4  rebinds:1   cost:431.000014   origin: [Grp:2, GrpExpr:1]
      |--CPhysicalMotionRandom   rows:1   width:38  rebinds:1   cost:431.000014   origin: [Grp:0, GrpExpr:2]
      |  +--CPhysicalTableScan "foo" ("foo")   rows:1   width:38  rebinds:1   cost:431.000007   origin: [Grp:0, GrpExpr:1]
      +--CPhysicalMotionRandom   rows:1   width:38  rebinds:1   cost:431.000014   origin: [Grp:1, GrpExpr:2]
         +--CPhysicalTableScan "bar" ("bar")   rows:1   width:38  rebinds:1   cost:431.000007   origin: [Grp:1, GrpExpr:1]

                                           QUERY PLAN
------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
   ->  Append  (cost=0.00..431.00 rows=1 width=4)
         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
               ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=4)
         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
               ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=4)

```