### PR TITLE
Fixed outer references in groupby columns [#134091245]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 686)
+set(GPORCA_VERSION_MINOR 687)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.686
+LIB_VERSION = 1.687
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/DQA-KeepOuterReference.mdp
+++ b/data/dxl/minidump/DQA-KeepOuterReference.mdp
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+drop table if exists tint;
+CREATE TABLE tint (
+    c int
+);
+
+set optimizer=on;
+
+
+== expect to see tint.c still in groupby grouping columns
+select (select distinct tint.c from tint as tt)  x from tint;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="16"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.32778.1.1" Name="tint" Rows="7.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.32778.1.1" Name="tint" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.5" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.4" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.3" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.2" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="7.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.166667" DistinctValues="1.166667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.166667" DistinctValues="1.166667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.166667" DistinctValues="1.166667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.166667" DistinctValues="1.166667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.166667" DistinctValues="1.166667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.166667" DistinctValues="1.166667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="17" ColName="x" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="17" Alias="x">
+            <dxl:ScalarSubquery ColId="1">
+              <dxl:LogicalGroupBy>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="1"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList/>
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.32778.1.1" TableName="tint">
+                    <dxl:Columns>
+                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+              </dxl:LogicalGroupBy>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.32778.1.1" TableName="tint">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15" OutputSegments="-1">
+	<dxl:Properties>
+	  <dxl:Cost StartupCost="0" TotalCost="1293.002375" Rows="7.000000" Width="4"/>
+	</dxl:Properties>
+	<dxl:ProjList>
+	  <dxl:ProjElem ColId="16" Alias="x">
+	    <dxl:Ident ColId="16" ColName="x" TypeMdid="0.23.1.0"/>
+	  </dxl:ProjElem>
+	</dxl:ProjList>
+	<dxl:Filter/>
+	<dxl:SortingColumnList/>
+	<dxl:Result>
+	  <dxl:Properties>
+	    <dxl:Cost StartupCost="0" TotalCost="1293.002306" Rows="7.000000" Width="4"/>
+	  </dxl:Properties>
+	  <dxl:ProjList>
+	    <dxl:ProjElem ColId="16" Alias="x">
+	      <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+		<dxl:TestExpr/>
+		<dxl:ParamList>
+		  <dxl:Param ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+		</dxl:ParamList>
+		<dxl:Result>
+		  <dxl:Properties>
+		    <dxl:Cost StartupCost="0" TotalCost="431.000920" Rows="112.000000" Width="4"/>
+		  </dxl:Properties>
+		  <dxl:ProjList>
+		    <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+		      <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+		    </dxl:ProjElem>
+		  </dxl:ProjList>
+		  <dxl:Filter/>
+		  <dxl:OneTimeFilter/>
+		  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+		    <dxl:Properties>
+		      <dxl:Cost StartupCost="0" TotalCost="431.000892" Rows="112.000000" Width="1"/>
+		    </dxl:Properties>
+		    <dxl:GroupingColumns>
+		      <dxl:GroupingColumn ColId="0"/>
+		    </dxl:GroupingColumns>
+		    <dxl:ProjList>
+		      <dxl:ProjElem ColId="0" Alias="c">
+			<dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+		      </dxl:ProjElem>
+		    </dxl:ProjList>
+		    <dxl:Filter/>
+		    <dxl:Materialize Eager="true">
+		      <dxl:Properties>
+			<dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="112.000000" Width="1"/>
+		      </dxl:Properties>
+		      <dxl:ProjList/>
+		      <dxl:Filter/>
+		      <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+			<dxl:Properties>
+			  <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="112.000000" Width="1"/>
+			</dxl:Properties>
+			<dxl:ProjList/>
+			<dxl:Filter/>
+			<dxl:SortingColumnList/>
+			<dxl:TableScan>
+			  <dxl:Properties>
+			    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="7.000000" Width="1"/>
+			  </dxl:Properties>
+			  <dxl:ProjList/>
+			  <dxl:Filter/>
+			  <dxl:TableDescriptor Mdid="0.32778.1.1" TableName="tint">
+			    <dxl:Columns>
+			      <dxl:Column ColId="8" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+			      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+			      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+			      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+			      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+			      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+			      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+			      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+			    </dxl:Columns>
+			  </dxl:TableDescriptor>
+			</dxl:TableScan>
+		      </dxl:BroadcastMotion>
+		    </dxl:Materialize>
+		  </dxl:Aggregate>
+		</dxl:Result>
+	      </dxl:SubPlan>
+	    </dxl:ProjElem>
+	  </dxl:ProjList>
+	  <dxl:Filter/>
+	  <dxl:OneTimeFilter/>
+	  <dxl:TableScan>
+	    <dxl:Properties>
+	      <dxl:Cost StartupCost="0" TotalCost="1293.002304" Rows="1000.000000" Width="4"/>
+	    </dxl:Properties>
+	    <dxl:ProjList>
+	      <dxl:ProjElem ColId="0" Alias="c">
+		<dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+	      </dxl:ProjElem>
+	    </dxl:ProjList>
+	    <dxl:Filter/>
+	    <dxl:TableDescriptor Mdid="0.32778.1.1" TableName="tint">
+	      <dxl:Columns>
+		<dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+		<dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+		<dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+		<dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+		<dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+		<dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+		<dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+		<dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+	      </dxl:Columns>
+	    </dxl:TableDescriptor>
+	  </dxl:TableScan>
+	</dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/GroupByOuterRef.mdp
+++ b/data/dxl/minidump/GroupByOuterRef.mdp
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table t (a int, b int);
+create table s (i int, j int);
+
+select a, b
+from t
+where t.a in (select count(s.i) from s group by t.b)
+
+== expected to see group by outer referenced column t.b removed ==
+
+select a, b
+from t
+where t.a in (select count(s.i) from s);
+
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/server/src/unittest/gpopt/minidump/CAggTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CAggTest.cpp
@@ -28,6 +28,7 @@ ULONG CAggTest::m_ulAggTestCounter = 0;  // start from first test
 // minidump files
 const CHAR *rgszAggFileNames[] =
 {
+	"../data/dxl/minidump/DQA-KeepOuterReference.mdp",
 	"../data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp",
 	"../data/dxl/minidump/ScalarCorrelatedSubqueryCountStar.mdp",
 	"../data/dxl/minidump/ScalarSubqueryCountStar.mdp",


### PR DESCRIPTION
In general, it's beneficial to remove outer references from groupby,
because this value is always a constant for subquery. For example:

```
select a from t where c in (select count(s.j) from s group by s.i, t.b)
```

The `t.b` can be removed safely from above SQL statement, because for
every execution of IN subquery, the `t.b` is constant.

However, this is an issue if the outer reference is the only groupby
column and there is NO additional aggregate functions used. For example:

```
select a from t where c in (select distinct t.b from s)
```

The above statement cannot be further simplified because the rewritten
query below after removing outer reference is invalid:

```
select a from t where c in (select distinct ??? from s)
```

Hence, we add additional validation in pre-processing to ensure correct
rewritten is done.

Signed-off-by: Xin Zhang <xzhang@pivotal.io>