### PR TITLE
Use new paths from GPDB repo

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -414,13 +414,13 @@ jobs:
       params:
         submodules: none
   - task: build_with_orca
-    file: gpdb_src/concourse/build_with_orca.yml
+    file: gpdb_src/concourse/tasks/build_with_orca.yml
     input_mapping:
       bin_gpos: bin_gpos_centos5_release
       bin_orca: bin_orca_centos5_release
       bin_xerces: bin_xerces_centos5
   - task: package_tarball
-    file: gpdb_src/concourse/package_tarball.yml
+    file: gpdb_src/concourse/tasks/package_tarball.yml
   - put: bin_gpdb_centos6
     params:
       file: package_tarball/bin_gpdb.tar.gz
@@ -448,7 +448,7 @@ jobs:
         submodules: none
   - task: icg_with_orca
     timeout: 120m
-    file: gpdb_src/concourse/test_with_orca.yml
+    file: gpdb_src/concourse/tasks/test_with_orca.yml
     input_mapping:
       bin_gpdb: bin_gpdb_centos6
       bin_gpos: bin_gpos_centos5_release
@@ -486,7 +486,7 @@ jobs:
         submodules: none
   - task: icg_with_planner
     timeout: 120m
-    file: gpdb_src/concourse/test_with_planner.yml
+    file: gpdb_src/concourse/tasks/test_with_planner.yml
     input_mapping:
       bin_gpdb: bin_gpdb_centos6
       bin_gpos: bin_gpos_centos5_release


### PR DESCRIPTION
The gpdb/concourse repo is getting cleaned up (https://github.com/greenplum-db/gpdb/pull/1334). This commit fixes paths for consumed files that are getting moved.

[#134241435]