### PR TITLE
No-Op Motion requires distribution of relational child

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 1)
-set(GPORCA_VERSION_MINOR 693)
+set(GPORCA_VERSION_MINOR 694)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BLD_TOP := $(shell sh -c pwd)
 include make/gpo.mk
 
 LIB_NAME = optimizer
-LIB_VERSION = 1.689
+LIB_VERSION = 1.694
 ## ----------------------------------------------------------------------
 ## top level variables; only used in this makefile
 ## ----------------------------------------------------------------------

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -17,7 +17,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
-      <dxl:TraceFlags Value="101013,102006,102120,103001,103014,103015,103022,103025,104004,104005,105000"/>
+      <dxl:TraceFlags Value="102006,102120,103001,103014,103015,103022,103025,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
@@ -306,7 +306,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="12.001088" Rows="1.000000" Width="12"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/NoOpMotionUsesOnlyGroupOutputColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/NoOpMotionUsesOnlyGroupOutputColumns.mdp
@@ -1,0 +1,547 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CREATE TABLE foo (a int, b int) DISTRIBUTED BY (a);
+
+EXPLAIN SELECT b, a FROM foo UNION ALL SELECT b, a FROM foo INTERSECT ALL SELECT b, a FROM foo;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+    <dxl:Thread Id="0">
+        <dxl:OptimizerConfig>
+            <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+            <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+            <dxl:CTEConfig CTEInliningCutoff="0"/>
+            <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+            <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10"/>
+            <dxl:TraceFlags Value="102120,103001,103014,103015,103022,103025,104004,104005,105000"/>
+        </dxl:OptimizerConfig>
+        <dxl:Metadata SystemIds="0.GPDB">
+            <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+                <dxl:EqualityOp Mdid="0.91.1.0"/>
+                <dxl:InequalityOp Mdid="0.85.1.0"/>
+                <dxl:LessThanOp Mdid="0.58.1.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+                <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+                <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+                <dxl:ArrayType Mdid="0.1000.1.0"/>
+                <dxl:MinAgg Mdid="0.0.0.0"/>
+                <dxl:MaxAgg Mdid="0.0.0.0"/>
+                <dxl:AvgAgg Mdid="0.0.0.0"/>
+                <dxl:SumAgg Mdid="0.0.0.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+                <dxl:EqualityOp Mdid="0.410.1.0"/>
+                <dxl:InequalityOp Mdid="0.411.1.0"/>
+                <dxl:LessThanOp Mdid="0.412.1.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+                <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+                <dxl:ComparisonOp Mdid="0.351.1.0"/>
+                <dxl:ArrayType Mdid="0.1016.1.0"/>
+                <dxl:MinAgg Mdid="0.2131.1.0"/>
+                <dxl:MaxAgg Mdid="0.2115.1.0"/>
+                <dxl:AvgAgg Mdid="0.2100.1.0"/>
+                <dxl:SumAgg Mdid="0.2107.1.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+                <dxl:EqualityOp Mdid="0.96.1.0"/>
+                <dxl:InequalityOp Mdid="0.518.1.0"/>
+                <dxl:LessThanOp Mdid="0.97.1.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+                <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+                <dxl:ComparisonOp Mdid="0.351.1.0"/>
+                <dxl:ArrayType Mdid="0.1007.1.0"/>
+                <dxl:MinAgg Mdid="0.2132.1.0"/>
+                <dxl:MaxAgg Mdid="0.2116.1.0"/>
+                <dxl:AvgAgg Mdid="0.2101.1.0"/>
+                <dxl:SumAgg Mdid="0.2108.1.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+                <dxl:LeftType Mdid="0.20.1.0"/>
+                <dxl:RightType Mdid="0.20.1.0"/>
+                <dxl:ResultType Mdid="0.16.1.0"/>
+                <dxl:OpFunc Mdid="0.467.1.0"/>
+                <dxl:Commutator Mdid="0.410.1.0"/>
+                <dxl:InverseOp Mdid="0.411.1.0"/>
+                <dxl:OpClasses>
+                    <dxl:OpClass Mdid="0.1976.1.0"/>
+                    <dxl:OpClass Mdid="0.1977.1.0"/>
+                    <dxl:OpClass Mdid="0.3028.1.0"/>
+                </dxl:OpClasses>
+            </dxl:GPDBScalarOp>
+            <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+                <dxl:EqualityOp Mdid="0.607.1.0"/>
+                <dxl:InequalityOp Mdid="0.608.1.0"/>
+                <dxl:LessThanOp Mdid="0.609.1.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+                <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+                <dxl:ComparisonOp Mdid="0.356.1.0"/>
+                <dxl:ArrayType Mdid="0.1028.1.0"/>
+                <dxl:MinAgg Mdid="0.2118.1.0"/>
+                <dxl:MaxAgg Mdid="0.2134.1.0"/>
+                <dxl:AvgAgg Mdid="0.0.0.0"/>
+                <dxl:SumAgg Mdid="0.0.0.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+                <dxl:EqualityOp Mdid="0.387.1.0"/>
+                <dxl:InequalityOp Mdid="0.402.1.0"/>
+                <dxl:LessThanOp Mdid="0.2799.1.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+                <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+                <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+                <dxl:ArrayType Mdid="0.1010.1.0"/>
+                <dxl:MinAgg Mdid="0.2798.1.0"/>
+                <dxl:MaxAgg Mdid="0.2797.1.0"/>
+                <dxl:AvgAgg Mdid="0.0.0.0"/>
+                <dxl:SumAgg Mdid="0.0.0.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+                <dxl:EqualityOp Mdid="0.385.1.0"/>
+                <dxl:InequalityOp Mdid="0.0.0.0"/>
+                <dxl:LessThanOp Mdid="0.0.0.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+                <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+                <dxl:ComparisonOp Mdid="0.0.0.0"/>
+                <dxl:ArrayType Mdid="0.1012.1.0"/>
+                <dxl:MinAgg Mdid="0.0.0.0"/>
+                <dxl:MaxAgg Mdid="0.0.0.0"/>
+                <dxl:AvgAgg Mdid="0.0.0.0"/>
+                <dxl:SumAgg Mdid="0.0.0.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+                <dxl:EqualityOp Mdid="0.352.1.0"/>
+                <dxl:InequalityOp Mdid="0.0.0.0"/>
+                <dxl:LessThanOp Mdid="0.0.0.0"/>
+                <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+                <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+                <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+                <dxl:ComparisonOp Mdid="0.0.0.0"/>
+                <dxl:ArrayType Mdid="0.1011.1.0"/>
+                <dxl:MinAgg Mdid="0.0.0.0"/>
+                <dxl:MaxAgg Mdid="0.0.0.0"/>
+                <dxl:AvgAgg Mdid="0.0.0.0"/>
+                <dxl:SumAgg Mdid="0.0.0.0"/>
+                <dxl:CountAgg Mdid="0.2147.1.0"/>
+            </dxl:Type>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:RelationStatistics Mdid="2.25025.1.1" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+            <dxl:Relation Mdid="0.25025.1.1" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+                <dxl:Columns>
+                    <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                    <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+                        <dxl:DefaultValue/>
+                    </dxl:Column>
+                </dxl:Columns>
+                <dxl:Indexes/>
+                <dxl:Triggers/>
+                <dxl:CheckConstraints/>
+            </dxl:Relation>
+            <dxl:MDCast Mdid="3.20.1.0;20.1.0" Name="int8" BinaryCoercible="true" SourceTypeId="0.20.1.0" DestinationTypeId="0.20.1.0" CastFuncId="0.0.0.0"/>
+            <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
+            <dxl:GPDBFunc Mdid="0.7000.1.0" Name="row_number" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="false">
+                <dxl:ResultType Mdid="0.20.1.0"/>
+            </dxl:GPDBFunc>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+                <dxl:LeftType Mdid="0.23.1.0"/>
+                <dxl:RightType Mdid="0.23.1.0"/>
+                <dxl:ResultType Mdid="0.16.1.0"/>
+                <dxl:OpFunc Mdid="0.66.1.0"/>
+                <dxl:Commutator Mdid="0.521.1.0"/>
+                <dxl:InverseOp Mdid="0.525.1.0"/>
+                <dxl:OpClasses>
+                    <dxl:OpClass Mdid="0.1976.1.0"/>
+                    <dxl:OpClass Mdid="0.3027.1.0"/>
+                </dxl:OpClasses>
+            </dxl:GPDBScalarOp>
+            <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+                <dxl:LeftType Mdid="0.23.1.0"/>
+                <dxl:RightType Mdid="0.23.1.0"/>
+                <dxl:ResultType Mdid="0.16.1.0"/>
+                <dxl:OpFunc Mdid="0.65.1.0"/>
+                <dxl:Commutator Mdid="0.96.1.0"/>
+                <dxl:InverseOp Mdid="0.518.1.0"/>
+                <dxl:OpClasses>
+                    <dxl:OpClass Mdid="0.1976.1.0"/>
+                    <dxl:OpClass Mdid="0.1977.1.0"/>
+                    <dxl:OpClass Mdid="0.3027.1.0"/>
+                </dxl:OpClasses>
+            </dxl:GPDBScalarOp>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+            <dxl:ColumnStatistics Mdid="1.25025.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+        </dxl:Metadata>
+        <dxl:Query>
+            <dxl:OutputColumns>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:OutputColumns>
+            <dxl:CTEList/>
+            <dxl:UnionAll InputColumns="2,1;11,10" CastAcrossInputs="false">
+                <dxl:Columns>
+                    <dxl:Column ColId="2" Attno="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+                <dxl:LogicalGet>
+                    <dxl:TableDescriptor Mdid="0.25025.1.1" TableName="foo">
+                        <dxl:Columns>
+                            <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:Columns>
+                    </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+                <dxl:IntersectAll InputColumns="11,10;20,19" CastAcrossInputs="false">
+                    <dxl:Columns>
+                        <dxl:Column ColId="11" Attno="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="10" Attno="2" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                    <dxl:LogicalGet>
+                        <dxl:TableDescriptor Mdid="0.25025.1.1" TableName="foo">
+                            <dxl:Columns>
+                                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                        </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                    <dxl:LogicalGet>
+                        <dxl:TableDescriptor Mdid="0.25025.1.1" TableName="foo">
+                            <dxl:Columns>
+                                <dxl:Column ColId="19" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="20" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                        </dxl:TableDescriptor>
+                    </dxl:LogicalGet>
+                </dxl:IntersectAll>
+            </dxl:UnionAll>
+        </dxl:Query>
+        <dxl:Plan Id="0" SpaceSize="0">
+            <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.001324" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:Append IsTarget="false" IsZapped="false">
+                    <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="862.001294" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                            <dxl:ProjElem ColId="1" Alias="b">
+                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="0" Alias="a">
+                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                            <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                                <dxl:ProjElem ColId="1" Alias="b">
+                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="0" Alias="a">
+                                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.25025.1.1" TableName="foo">
+                                <dxl:Columns>
+                                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                            </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                        <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="862.001294" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                            <dxl:ProjElem ColId="10" Alias="b">
+                                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="9" Alias="a">
+                                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:HashJoin JoinType="In">
+                            <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="862.001294" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                                <dxl:ProjElem ColId="10" Alias="b">
+                                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="9" Alias="a">
+                                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:JoinFilter/>
+                            <dxl:HashCondList>
+                                <dxl:Not>
+                                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                                        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:IsDistinctFrom>
+                                </dxl:Not>
+                                <dxl:Not>
+                                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                        <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:IsDistinctFrom>
+                                </dxl:Not>
+                                <dxl:Not>
+                                    <dxl:IsDistinctFrom OperatorMdid="0.410.1.0">
+                                        <dxl:Ident ColId="27" ColName="row_number" TypeMdid="0.20.1.0"/>
+                                        <dxl:Ident ColId="28" ColName="row_number" TypeMdid="0.20.1.0"/>
+                                    </dxl:IsDistinctFrom>
+                                </dxl:Not>
+                            </dxl:HashCondList>
+                            <dxl:Window PartitionColumns="10,9">
+                                <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="16"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                    <dxl:ProjElem ColId="27" Alias="row_number">
+                                        <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="9" Alias="a">
+                                        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="10" Alias="b">
+                                        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:Sort SortDiscardDuplicates="false">
+                                    <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                        <dxl:ProjElem ColId="9" Alias="a">
+                                            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="10" Alias="b">
+                                            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList>
+                                        <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                        <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    </dxl:SortingColumnList>
+                                    <dxl:LimitCount/>
+                                    <dxl:LimitOffset/>
+                                    <dxl:TableScan>
+                                        <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                            <dxl:ProjElem ColId="9" Alias="a">
+                                                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="10" Alias="b">
+                                                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="0.25025.1.1" TableName="foo">
+                                            <dxl:Columns>
+                                                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                            </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                    </dxl:TableScan>
+                                </dxl:Sort>
+                                <dxl:WindowKeyList>
+                                    <dxl:WindowKey>
+                                        <dxl:SortingColumnList/>
+                                    </dxl:WindowKey>
+                                </dxl:WindowKeyList>
+                            </dxl:Window>
+                            <dxl:Window PartitionColumns="19,18">
+                                <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="16"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                    <dxl:ProjElem ColId="28" Alias="row_number">
+                                        <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="18" Alias="a">
+                                        <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="19" Alias="b">
+                                        <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:Sort SortDiscardDuplicates="false">
+                                    <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                        <dxl:ProjElem ColId="18" Alias="a">
+                                            <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                        <dxl:ProjElem ColId="19" Alias="b">
+                                            <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                                        </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:SortingColumnList>
+                                        <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                        <dxl:SortingColumn ColId="18" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                    </dxl:SortingColumnList>
+                                    <dxl:LimitCount/>
+                                    <dxl:LimitOffset/>
+                                    <dxl:TableScan>
+                                        <dxl:Properties>
+                                            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                            <dxl:ProjElem ColId="18" Alias="a">
+                                                <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                            <dxl:ProjElem ColId="19" Alias="b">
+                                                <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
+                                            </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="0.25025.1.1" TableName="foo">
+                                            <dxl:Columns>
+                                                <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                                <dxl:Column ColId="19" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                                <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                                <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                                <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                                <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                                <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                                <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                                <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                            </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                    </dxl:TableScan>
+                                </dxl:Sort>
+                                <dxl:WindowKeyList>
+                                    <dxl:WindowKey>
+                                        <dxl:SortingColumnList/>
+                                    </dxl:WindowKey>
+                                </dxl:WindowKeyList>
+                            </dxl:Window>
+                        </dxl:HashJoin>
+                    </dxl:RedistributeMotion>
+                </dxl:Append>
+            </dxl:GatherMotion>
+        </dxl:Plan>
+    </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-ConstTable.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-ConstTable.mdp
@@ -231,7 +231,7 @@
         </dxl:LogicalGet>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000186" Rows="9.000000" Width="4"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
@@ -185,7 +185,7 @@ INSERT INTO t VALUES (11),(12),(13);
         </dxl:UnionAll>
       </dxl:LogicalInsert>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:DMLInsert Columns="0" ActionCol="3" OidCol="4" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.046901" Rows="3.000000" Width="4"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNoRedistributableColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNoRedistributableColumns.mdp
@@ -227,7 +227,7 @@ EXPLAIN SELECT xmin FROM tbl1 UNION ALL SELECT xmin FROM tbl2;
         </dxl:LogicalGet>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNotEqualNumOfDistrColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNotEqualNumOfDistrColumns.mdp
@@ -238,7 +238,7 @@ EXPLAIN SELECT a,b FROM foo UNION ALL SELECT c,d FROM bar;
         </dxl:LogicalGet>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000066" Rows="1.000000" Width="8"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithSingleNotRedistributableColumn.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithSingleNotRedistributableColumn.mdp
@@ -13,7 +13,7 @@ EXPLAIN SELECT * FROM foo UNION ALL SELECT * FROM bar;
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
       <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25"/>
-      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,103025,104004,104005,105000"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,103025,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/RandomDistributedChildrenUnhashableColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/RandomDistributedChildrenUnhashableColumns.mdp
@@ -236,7 +236,7 @@ EXPLAIN SELECT xmin FROM foo UNION ALL SELECT xmin FROM bar;
         </dxl:LogicalGet>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000029" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/RedundantMotionParallelUnionAll.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/RedundantMotionParallelUnionAll.mdp
@@ -330,7 +330,7 @@ select * from t, (select * from t union all select * from t) tt where t.c = tt.c
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.000610" Rows="1.000000" Width="16"/>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/TwoHashedTables.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/TwoHashedTables.mdp
@@ -225,7 +225,7 @@ EXPLAIN SELECT * FROM foo UNION ALL SELECT * FROM bar;
         </dxl:LogicalGet>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000041" Rows="1.000000" Width="4"/>

--- a/libgpopt/include/gpopt/operators/CPhysicalMotionHashDistribute.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalMotionHashDistribute.h
@@ -149,8 +149,19 @@ namespace gpopt
 			
 			// conversion function
 			static
-			CPhysicalMotionHashDistribute *PopConvert(COperator *pop);			
-					
+			CPhysicalMotionHashDistribute *PopConvert(COperator *pop);
+
+			virtual
+			CDistributionSpec *PdsRequired
+				(
+				IMemoryPool *pmp,
+				CExpressionHandle &exprhdl,
+				CDistributionSpec *pdsRequired,
+				ULONG ulChildIndex,
+				DrgPdp *pdrgpdpCtxt,
+				ULONG ulOptReq
+				) const;
+
 	}; // class CPhysicalMotionHashDistribute
 
 }

--- a/libgpopt/src/base/CDistributionSpecHashedNoOp.cpp
+++ b/libgpopt/src/base/CDistributionSpecHashedNoOp.cpp
@@ -39,11 +39,12 @@ CDistributionSpecHashedNoOp::AppendEnforcers
 	CDrvdProp *pdp = exprhdl.Pdp();
 	CDistributionSpec *pdsChild = CDrvdPropPlan::Pdpplan(pdp)->Pds();
 	CDistributionSpecHashed *pdsChildHashed = dynamic_cast<CDistributionSpecHashed *>(pdsChild);
+
 	if (NULL == pdsChildHashed)
 	{
 		return;
 	}
-	
+
 	DrgPexpr *pdrgpexprNoOpRedistributionColumns = pdsChildHashed->Pdrgpexpr();
 	pdrgpexprNoOpRedistributionColumns->AddRef();
 	CDistributionSpecHashedNoOp* pdsNoOp = GPOS_NEW(pmp) CDistributionSpecHashedNoOp(pdrgpexprNoOpRedistributionColumns);

--- a/libgpopt/src/operators/CPhysicalMotionHashDistribute.cpp
+++ b/libgpopt/src/operators/CPhysicalMotionHashDistribute.cpp
@@ -74,10 +74,10 @@ CPhysicalMotionHashDistribute::FMatch
 	{
 		return false;
 	}
-	
-	CPhysicalMotionHashDistribute *popHashDistribute = 
+
+	CPhysicalMotionHashDistribute *popHashDistribute =
 			CPhysicalMotionHashDistribute::PopConvert(pop);
-	
+
 	return m_pdsHashed->FEqual(popHashDistribute->m_pdsHashed);
 }
 
@@ -164,7 +164,7 @@ CPhysicalMotionHashDistribute::PosRequired
 	IMemoryPool *pmp,
 	CExpressionHandle &, // exprhdl
 	COrderSpec *,//posInput
-	ULONG 
+	ULONG
 #ifdef GPOS_DEBUG
 	ulChildIndex
 #endif // GPOS_DEBUG

--- a/server/src/unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.cpp
@@ -14,6 +14,7 @@ static ULONG ulCounter = 0;
 
 static const CHAR *rgszFileNames[] =
 	{
+		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/NoOpMotionUsesOnlyGroupOutputColumns.mdp",
 		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/RedundantMotionParallelUnionAll.mdp",
 		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNoRedistributableColumns.mdp",
 		"../data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithSingleNotRedistributableColumn.mdp",

--- a/server/src/unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.cpp
@@ -30,12 +30,16 @@ namespace gpopt
 {
 	GPOS_RESULT CPhysicalParallelUnionAllTest::EresUnittest()
 	{
+		BOOL fMatchPlans = true;
+		BOOL fTestSpacePruning = true;
 		CAutoTraceFlag atfParallelAppend(gpos::EopttraceEnableParallelAppend, true);
-		return CTestUtils::EresUnittest_RunTests
+		return CTestUtils::EresUnittest_RunTestsWithoutAdditionalTraceFlags
 			(
 				rgszFileNames,
 				&ulCounter,
-				GPOS_ARRAY_SIZE(rgszFileNames)
+				GPOS_ARRAY_SIZE(rgszFileNames),
+				fMatchPlans,
+				fTestSpacePruning
 			);
 	}
 


### PR DESCRIPTION
Before no-op motions were introduced, a hash-redistribute motion was
intended to really move tuples around, and it was justifiable that they
required 'ANY' distribution, and hence they shared optimization contexts
when everything else were identical.
A no-op motion, however, was intended to _not_ move tuples. i.e. A no-op
motion to hash-redistribute by column `b` on top of a relation that's
hash-distributed on column `a` is not only undesirable, it's completely
unintended. To rule out such plans, we made hash-redistribute motions a
bit more intelligent when their distribution specifications say `no-op`:
they should require the relation under them to be distributed exactly as
the motions (as opposed to `ANY`).
A nice side-effect of this change is, no-op motions that distribute on
columns that are not covered by the output columns of the child group
will no longer match any group expressions. This is a bit nuanced, but a
minimal query to reproduce looks something like:

```
CREATE TABLE foo (a int, b int) DISTRIBUTED BY (a);

EXPLAIN SELECT b, a FROM foo UNION ALL SELECT b, a FROM foo INTERSECT ALL SELECT b, a FROM foo;
```

And a (wrong) plan before this change looked like the following:

```
Physical plan:
+--CPhysicalMotionGather(master)
   +--CPhysicalParallelUnionAll
      |--CPhysicalMotionHashDistribute HASHED NO-OP: "a" (0)
      |  +--CPhysicalTableScan "foo" ("foo")
      +--CPhysicalMotionHashDistribute HASHED NO-OP: "gp_segment_id" (17)
         +--CPhysicalLeftSemiHashJoin
            |--CPhysicalSequenceProject (HASHED: "b" (10) "a" (9)
            |  |--CPhysicalSort  ( (97,1.0), "b" (10), NULLsLast ) ( (97,1.0), "a" (9), NULLsLast )
            |  |  +--CPhysicalTableScan "foo" ("foo")
            |  +--CScalarProjectList
            |     +--CScalarProjectElement "row_number" (27)
            |        +--CScalarWindowFunc (row_number , Agg: false , Distinct: false)
            |--CPhysicalSequenceProject (HASHED: "b" (19) "a" (18)
            |  |--CPhysicalSort  ( (97,1.0), "b" (19), NULLsLast ) ( (97,1.0), "a" (18), NULLsLast )
            |  |  +--CPhysicalTableScan "foo" ("foo")
            |  +--CScalarProjectList
            |     +--CScalarProjectElement "row_number" (28)
            |        +--CScalarWindowFunc (row_number , Agg: false , Distinct: false)
            +--CScalarBoolOp (EboolopAnd)
               |--CScalarBoolOp (EboolopNot)
               |  +--CScalarIsDistinctFrom (=)
               |     |--CScalarIdent "b" (10)
               |     +--CScalarIdent "b" (19)
               |--CScalarBoolOp (EboolopNot)
               |  +--CScalarIsDistinctFrom (=)
               |     |--CScalarIdent "a" (9)
               |     +--CScalarIdent "a" (18)
               +--CScalarBoolOp (EboolopNot)
                  +--CScalarIsDistinctFrom (=)
                     |--CScalarIdent "row_number" (27)
                     +--CScalarIdent "row_number" (28)
```

Where the memo group of the no-op motion on `gp_segment_id (17)` was
like:

```
Group 3 (#GExprs: 14):
  0: CLogicalIntersectAll Output: ("b" (10), "a" (9)), Input: [("b" (10), "a" (9)), ("b" (19), "a" (18))] [ 1 2 ]
  1: CLogicalLeftSemiJoin [ 8 11 24 ]
  2: CLogicalGbAggDeduplicate( Global ) Grp Cols: ["a" (9), "b" (10), "ctid" (11), "gp_segment_id" (17), "row_number" (27)], Minimal Grp Cols: [], Join Child Keys: ["ctid" (11), "gp_segment_id" (17)], Generates Duplicates :[ 0 ]  [ 25 26 ]
  3: CLogicalGbAggDeduplicate( Global ) Grp Cols: ["a" (9), "b" (10), "ctid" (11), "gp_segment_id" (17), "row_number" (27)], Minimal Grp Cols: ["a" (9), "b" (10), "ctid" (11), "gp_segment_id" (17), "row_number" (27)], Join Child Keys: ["ctid" (11), "gp_segment_id" (17)], Generates Duplicates :[ 1 ]  [ 27 26 ]
  4: CPhysicalStreamAggDeduplicate( Global ) Grp Cols: ["a" (9), "b" (10), "ctid" (11), "gp_segment_id" (17), "row_number" (27)], Key Cols:["ctid" (11), "gp_segment_id" (17)], Generates Duplicates :[ 1 ]  (High) [ 27 26 ]
    Cost Ctxts:
      main ctxt (stage 0)1.1, child ctxts:[0], rows:1.000000 (group), cost: 862.001458
      main ctxt (stage 0)3.1, child ctxts:[0], rows:1.000000 (group), cost: 862.001458
  5: CPhysicalStreamAggDeduplicate( Global ) Grp Cols: ["a" (9), "b" (10), "ctid" (11), "gp_segment_id" (17), "row_number" (27)], Key Cols:["ctid" (11), "gp_segment_id" (17)], Generates Duplicates :[ 0 ]  [ 25 26 ]
    Cost Ctxts:
      main ctxt (stage 0)1.1, child ctxts:[4], rows:1.000000 (group), cost: 862.001429
      main ctxt (stage 0)3.1, child ctxts:[4], rows:1.000000 (group), cost: 862.001429
  6: CPhysicalLeftSemiHashJoin (High) [ 8 11 24 ]
    Cost Ctxts:
      main ctxt (stage 0)1.0, child ctxts:[5, 6], rows:1.000000 (group), cost: 862.001394
      main ctxt (stage 0)1.1, child ctxts:[3, 5], rows:1.000000 (group), cost: 862.001294
      main ctxt (stage 0)1.2, child ctxts:[4, 4], rows:1.000000 (group), cost: 862.001375
      main ctxt (stage 0)1.3, child ctxts:[3, 3], rows:1.000000 (group), cost: 862.001294
      main ctxt (stage 0)1.5, child ctxts:[2, 2], rows:1.000000 (group), cost: 862.002153
      main ctxt (stage 0)1.6, child ctxts:[0, 0], rows:1.000000 (group), cost: 862.001652
      main ctxt (stage 0)3.0, child ctxts:[5, 6], rows:1.000000 (group), cost: 862.001394
      main ctxt (stage 0)3.1, child ctxts:[3, 5], rows:1.000000 (group), cost: 862.001294
      main ctxt (stage 0)3.2, child ctxts:[4, 4], rows:1.000000 (group), cost: 862.001375
      main ctxt (stage 0)3.3, child ctxts:[3, 3], rows:1.000000 (group), cost: 862.001294
      main ctxt (stage 0)3.5, child ctxts:[2, 2], rows:1.000000 (group), cost: 862.002153
  7: CPhysicalLeftSemiNLJoin [ 8 11 24 ]
    Cost Ctxts:
      main ctxt (stage 0)2.1, cost lower bound: 1290.000233	 PRUNED
      main ctxt (stage 0)1.1, cost lower bound: 1290.000233	 PRUNED
      main ctxt (stage 0)3.1, cost lower bound: 1290.000233	 PRUNED
      main ctxt (stage 0)0.1, cost lower bound: 1290.000233	 PRUNED
  8: CPhysicalMotionHashDistribute HASHED NO-OP: [ +--CScalarIdent "a" (9)
 , nulls colocated ] [ 3 ]
    Cost Ctxts:
      main ctxt (stage 0)0.0, child ctxts:[1], rows:1.000000 (group), cost: 862.001294
  9: CPhysicalMotionHashDistribute HASHED NO-OP: [ +--CScalarIdent "row_number" (27)   origin: [Grp:20, GrpExpr:0]
 , nulls colocated ] [ 3 ]
    Cost Ctxts:
      main ctxt (stage 0)0.0, child ctxts:[1], rows:1.000000 (group), cost: 862.001294
  10: CPhysicalMotionHashDistribute HASHED NO-OP: [ +--CScalarIdent "b" (10)   origin: [Grp:12, GrpExpr:0]
 , nulls colocated ] [ 3 ]
    Cost Ctxts:
      main ctxt (stage 0)0.0, child ctxts:[1], rows:1.000000 (group), cost: 862.001294
  11: CPhysicalMotionHashDistribute HASHED NO-OP: [ +--CScalarIdent "gp_segment_id" (17)
 , nulls colocated ] [ 3 ]
    Cost Ctxts:
      main ctxt (stage 0)0.0, child ctxts:[1], rows:1.000000 (group), cost: 862.001294
  12: CPhysicalMotionHashDistribute STRICT HASHED: [ +--CScalarIdent "b" (10)
 +--CScalarIdent "a" (9)
 , nulls colocated ] [ 3 ]
    Cost Ctxts:
      main ctxt (stage 0)2.0, child ctxts:[1], rows:1.000000 (group), cost: 862.001315
  13: CPhysicalMotionRandom [ 3 ]
    Cost Ctxts:
  Grp OptCtxts:
    2 (stage 0): (req cols: ["a" (9), "b" (10)], req CTEs: [], req order: [<empty> match: satisfy ], req dist: [STRICT HASHED: [ +--CScalarIdent "b" (10)
 +--CScalarIdent "a" (9)
 , nulls colocated ] match: exact], req rewind: [NON-REWINDABLE match: satisfy], req partition propagation: [Filters: [] match: satisfy ]) => Best Expr:12
    1 (stage 0): (req cols: ["a" (9), "b" (10)], req CTEs: [], req order: [<empty> match: satisfy ], req dist: [ANY  EOperatorId: 122  match: satisfy], req rewind: [NON-REWINDABLE match: satisfy], req partition propagation: [Filters: [] match: satisfy ]) => Best Expr:6
    3 (stage 0): (req cols: ["a" (9), "b" (10)], req CTEs: [], req order: [<empty> match: satisfy ], req dist: [NON-SINGLETON  (NON-REPLICATED) match: satisfy], req rewind: [NON-REWINDABLE match: satisfy], req partition propagation: [Filters: [] match: satisfy ]) => Best Expr:6
    0 (stage 0): (req cols: ["a" (9), "b" (10)], req CTEs: [], req order: [<empty> match: satisfy ], req dist: [HASHED NO-OP: [ +--CScalarIdent "b" (10)
 , nulls colocated ] match: exact], req rewind: [NON-REWINDABLE match: satisfy], req partition propagation: [Filters: [] match: satisfy ]) => Best Expr:11
```

After this change, we got our expected plan:

```
+--CPhysicalMotionGather(master)
   +--CPhysicalParallelUnionAll
      |--CPhysicalMotionHashDistribute HASHED NO-OP: [ +--CScalarIdent "a" (0)
 , nulls colocated ]
      |  +--CPhysicalTableScan "foo" ("foo")
      +--CPhysicalMotionHashDistribute HASHED NO-OP: [ +--CScalarIdent "a" (9) , nulls colocated ]
         +--CPhysicalLeftSemiHashJoin
            |--CPhysicalSequenceProject (HASHED: [ +--CScalarIdent "b" (10) +--CScalarIdent "a" (9)
 , nulls colocated ], [<empty>], [EMPTY FRAME])
            |  |--CPhysicalSort  ( (97,1.0), "b" (10), NULLsLast ) ( (97,1.0), "a" (9), NULLsLast )
            |  |  +--CPhysicalTableScan "foo" ("foo")
            |  +--CScalarProjectList
            |     +--CScalarProjectElement "row_number" (27)
            |        +--CScalarWindowFunc (row_number , Agg: false , Distinct: false)
            |--CPhysicalSequenceProject (HASHED: [ +--CScalarIdent "b" (19) +--CScalarIdent "a" (18)
 , nulls colocated ], [<empty>], [EMPTY FRAME])
            |  |--CPhysicalSort  ( (97,1.0), "b" (19), NULLsLast ) ( (97,1.0), "a" (18), NULLsLast )
            |  |  +--CPhysicalTableScan "foo" ("foo")
            |  +--CScalarProjectList
            |     +--CScalarProjectElement "row_number" (28)
            |        +--CScalarWindowFunc (row_number , Agg: false , Distinct: false)
            +--CScalarBoolOp (EboolopAnd)
               |--CScalarBoolOp (EboolopNot)
               |  +--CScalarIsDistinctFrom (=)
               |     |--CScalarIdent "b" (10)
               |     +--CScalarIdent "b" (19)
               |--CScalarBoolOp (EboolopNot)
               |  +--CScalarIsDistinctFrom (=)
               |     |--CScalarIdent "a" (9)
               |     +--CScalarIdent "a" (18)
               +--CScalarBoolOp (EboolopNot)
                  +--CScalarIsDistinctFrom (=)
                     |--CScalarIdent "row_number" (27)
                     +--CScalarIdent "row_number" (28)
```