### PR TITLE
Update Version number macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 2)
-set(GPORCA_VERSION_MINOR 0)
+set(GPORCA_VERSION_MINOR 1)
 set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.

--- a/libgpopt/version.h.in
+++ b/libgpopt/version.h.in
@@ -12,8 +12,7 @@
 #ifndef GPORCA_version_H
 #define GPORCA_version_H
 
-#cmakedefine GPORCA_VERSION_MAJOR ${GPORCA_VERSION_MAJOR}
-#cmakedefine GPORCA_VERSION_MINOR ${GPORCA_VERSION_MINOR}
+#cmakedefine GPORCA_VERSION_STRING "${GPORCA_VERSION_STRING}"
 
 #endif  // GPORCA_version_H
 // EOF


### PR DESCRIPTION
We bumped the GPORCA version to 2.0 after merging GPOS with GPORCA.
Cmake undefs the GPORCA_VERSION_MINOR when the minor number is 0. 0 is
considered as a false constant by cmake.

In gpdb, use GPORCA_VERSION_STRING instead of separate GPORCA_VERSION_MAJOR
and GPORCA_VERSION_MINOR.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>