### PR TITLE
Add support for array coerce expr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 2)
 set(GPORCA_VERSION_MINOR 2)
-set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
+set(GPORCA_VERSION_PATCH_DONT_BUMP_ME 0)
+set(GPORCA_VERSION_STRING "${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR}.${GPORCA_VERSION_PATCH_DONT_BUMP_ME}")
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.
 # ABI changes include removing functions, and adding or removing function

--- a/data/dxl/minidump/ArrayCoerceExpr.mdp
+++ b/data/dxl/minidump/ArrayCoerceExpr.mdp
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.97283.1.1" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.97283.1.1" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.1" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1994.1.0"/>
+          <dxl:OpClass Mdid="0.1995.1.0"/>
+          <dxl:OpClass Mdid="0.3035.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.97283.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="d" TypeMdid="0.1043.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+            <dxl:Ident ColId="2" ColName="d" TypeMdid="0.1043.1.0"/>
+          </dxl:Cast>
+          <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" TypeModification="-1" IsExplicit="false" CoercionForm="2" Location="0">
+            <dxl:Array ArrayType="0.1015.1.0" ElementType="0.1043.1.0" MultiDimensional="false">
+              <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABWE=" LintValue="160440876"/>
+              <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABWI=" LintValue="160449068"/>
+            </dxl:Array>
+          </dxl:ArrayCoerceExpr>
+        </dxl:ArrayComp>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.97283.1.1" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="d" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="c">
+            <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="d">
+            <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="c">
+              <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="d">
+              <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:ArrayComp OperatorName="=" OperatorMdid="0.98.1.0" OperatorType="Any">
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1043.1.0"/>
+              </dxl:Cast>
+              <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" TypeModification="-1" IsExplicit="false" CoercionForm="2" Location="0">
+                <dxl:Array ArrayType="0.1015.1.0" ElementType="0.1043.1.0" MultiDimensional="false">
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABWE=" LintValue="160440876"/>
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABWI=" LintValue="160449068"/>
+                </dxl:Array>
+              </dxl:ArrayCoerceExpr>
+            </dxl:ArrayComp>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.97283.1.1" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/ArrayCoerceExpr.mdp
+++ b/data/dxl/minidump/ArrayCoerceExpr.mdp
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+create table foo (c int, d character varying(10));
+explain select * from foo where d in ('a', 'b');
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -547,6 +547,8 @@ add_library(gpopt
             src/operators/CScalarCoerceToDomain.cpp
             include/gpopt/operators/CScalarCoerceViaIO.h
             src/operators/CScalarCoerceViaIO.cpp
+            include/gpopt/operators/CScalarArrayCoerceExpr.h
+            src/operators/CScalarArrayCoerceExpr.cpp
             include/gpopt/operators/CScalarConst.h
             src/operators/CScalarConst.cpp
             include/gpopt/operators/CScalarDMLAction.h

--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -543,6 +543,8 @@ add_library(gpopt
             src/operators/CScalarCmp.cpp
             include/gpopt/operators/CScalarCoalesce.h
             src/operators/CScalarCoalesce.cpp
+            include/gpopt/operators/CScalarCoerceBase.h
+            src/operators/CScalarCoerceBase.cpp
             include/gpopt/operators/CScalarCoerceToDomain.h
             src/operators/CScalarCoerceToDomain.cpp
             include/gpopt/operators/CScalarCoerceViaIO.h

--- a/libgpopt/include/gpopt/operators/COperator.h
+++ b/libgpopt/include/gpopt/operators/COperator.h
@@ -185,6 +185,7 @@ namespace gpopt
 				EopScalarCast,
 				EopScalarCoerceToDomain,
 				EopScalarCoerceViaIO,
+				EopScalarArrayCoerceExpr,
 				EopScalarCoalesce,
 				EopScalarArray,
 				EopScalarArrayCmp,

--- a/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
+++ b/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
@@ -1,0 +1,179 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CScalarArrayCoerceExpr.h
+//
+//	@doc:
+//		Scalar Array Coerce Expr operator,
+//		the operator will apply type casting for each element in this array
+//		using the given element coercion function.
+//
+//	@owner:
+//
+//	@test:
+//
+//
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CScalarArrayCoerceExpr_H
+#define GPOPT_CScalarArrayCoerceExpr_H
+
+#include "gpos/base.h"
+#include "gpopt/base/COptCtxt.h"
+#include "gpopt/operators/CScalar.h"
+#include "gpopt/base/CDrvdProp.h"
+
+namespace gpopt
+{
+	using namespace gpos;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CScalarArrayCoerceExpr
+	//
+	//	@doc:
+	//		Scalar Array Coerce Expr operator
+	//
+	//---------------------------------------------------------------------------
+	class CScalarArrayCoerceExpr : public CScalar
+	{
+
+		private:
+
+			// catalog MDId of the element function
+			IMDId *m_pmdidElementFunc;
+		
+			// catalog MDId of the result type
+			IMDId *m_pmdidResultType;
+
+			// output type modifications
+			INT m_iMod;
+
+			// conversion semantics flag to pass to func
+			BOOL m_fIsExplicit;
+		
+			// coercion form
+			ECoercionForm m_ecf;
+
+			// location of token to be coerced
+			INT m_iLoc;
+
+			// private copy ctor
+			CScalarArrayCoerceExpr(const CScalarArrayCoerceExpr &);
+
+		public:
+
+			// ctor
+			CScalarArrayCoerceExpr
+				(
+				IMemoryPool *pmp,
+				IMDId *pmdidElementFunc,
+				IMDId *pmdidResultType,
+				INT iMod,
+				BOOL fIsExplicit,
+				ECoercionForm edxlcf,
+				INT iLoc
+				);
+
+			// dtor
+			virtual
+			~CScalarArrayCoerceExpr()
+			{
+				m_pmdidElementFunc->Release();
+				m_pmdidResultType->Release();
+			}
+		
+			// return metadata id of element coerce function
+			IMDId *PmdidElementFunc() const
+			{
+				return m_pmdidElementFunc;
+			}
+
+			// the type of the scalar expression
+			virtual
+			IMDId *PmdidType() const
+			{
+				return m_pmdidResultType;
+			}
+
+			// return type modification
+			INT IMod() const
+			{
+				return m_iMod;
+			}
+		
+			BOOL FIsExplicit() const
+			{
+				return m_fIsExplicit;
+			}
+
+			// return coercion form
+			ECoercionForm Ecf() const
+			{
+				return m_ecf;
+			}
+
+			// return token location
+			INT ILoc() const
+			{
+				return m_iLoc;
+			}
+
+			virtual
+			EOperatorId Eopid() const
+			{
+				return EopScalarArrayCoerceExpr;
+			}
+
+			// return a string for operator name
+			virtual
+			const CHAR *SzId() const
+			{
+				return "CScalarArrayCoerceExpr";
+			}
+
+			// match function
+			virtual
+			BOOL FMatch(COperator *) const;
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const
+			{
+				return false;
+			}
+
+			// return a copy of the operator with remapped columns
+			virtual
+			COperator *PopCopyWithRemappedColumns
+				(
+				IMemoryPool *, //pmp,
+				HMUlCr *, //phmulcr,
+				BOOL //fMustExist
+				)
+			{
+				return PopCopyDefault();
+			}
+
+			// conversion function
+			static
+			CScalarArrayCoerceExpr *PopConvert
+				(
+				COperator *pop
+				)
+			{
+				GPOS_ASSERT(NULL != pop);
+				GPOS_ASSERT(EopScalarArrayCoerceExpr == pop->Eopid());
+
+				return dynamic_cast<CScalarArrayCoerceExpr*>(pop);
+			}
+
+	}; // class CScalarArrayCoerceExpr
+
+}
+
+
+#endif // !GPOPT_CScalarArrayCoerceExpr_H
+
+// EOF

--- a/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
+++ b/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
@@ -20,9 +20,7 @@
 #define GPOPT_CScalarArrayCoerceExpr_H
 
 #include "gpos/base.h"
-#include "gpopt/base/COptCtxt.h"
-#include "gpopt/operators/CScalar.h"
-#include "gpopt/base/CDrvdProp.h"
+#include "gpopt/operators/CScalarCoerceBase.h"
 
 namespace gpopt
 {
@@ -36,29 +34,16 @@ namespace gpopt
 	//		Scalar Array Coerce Expr operator
 	//
 	//---------------------------------------------------------------------------
-	class CScalarArrayCoerceExpr : public CScalar
+	class CScalarArrayCoerceExpr : public CScalarCoerceBase
 	{
 
 		private:
-
 			// catalog MDId of the element function
 			IMDId *m_pmdidElementFunc;
 		
-			// catalog MDId of the result type
-			IMDId *m_pmdidResultType;
-
-			// output type modifications
-			INT m_iMod;
-
 			// conversion semantics flag to pass to func
 			BOOL m_fIsExplicit;
 		
-			// coercion form
-			ECoercionForm m_ecf;
-
-			// location of token to be coerced
-			INT m_iLoc;
-
 			// private copy ctor
 			CScalarArrayCoerceExpr(const CScalarArrayCoerceExpr &);
 
@@ -81,7 +66,6 @@ namespace gpopt
 			~CScalarArrayCoerceExpr()
 			{
 				m_pmdidElementFunc->Release();
-				m_pmdidResultType->Release();
 			}
 		
 			// return metadata id of element coerce function
@@ -90,34 +74,9 @@ namespace gpopt
 				return m_pmdidElementFunc;
 			}
 
-			// the type of the scalar expression
-			virtual
-			IMDId *PmdidType() const
-			{
-				return m_pmdidResultType;
-			}
-
-			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
-			}
-		
 			BOOL FIsExplicit() const
 			{
 				return m_fIsExplicit;
-			}
-
-			// return coercion form
-			ECoercionForm Ecf() const
-			{
-				return m_ecf;
-			}
-
-			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
 			}
 
 			virtual
@@ -136,25 +95,6 @@ namespace gpopt
 			// match function
 			virtual
 			BOOL FMatch(COperator *) const;
-
-			// sensitivity to order of inputs
-			virtual
-			BOOL FInputOrderSensitive() const
-			{
-				return false;
-			}
-
-			// return a copy of the operator with remapped columns
-			virtual
-			COperator *PopCopyWithRemappedColumns
-				(
-				IMemoryPool *, //pmp,
-				HMUlCr *, //phmulcr,
-				BOOL //fMustExist
-				)
-			{
-				return PopCopyDefault();
-			}
 
 			// conversion function
 			static

--- a/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
+++ b/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
@@ -40,10 +40,10 @@ namespace gpopt
 		private:
 			// catalog MDId of the element function
 			IMDId *m_pmdidElementFunc;
-		
+
 			// conversion semantics flag to pass to func
 			BOOL m_fIsExplicit;
-		
+
 			// private copy ctor
 			CScalarArrayCoerceExpr(const CScalarArrayCoerceExpr &);
 
@@ -63,51 +63,37 @@ namespace gpopt
 
 			// dtor
 			virtual
-			~CScalarArrayCoerceExpr()
-			{
-				m_pmdidElementFunc->Release();
-			}
+			~CScalarArrayCoerceExpr();
 		
 			// return metadata id of element coerce function
-			IMDId *PmdidElementFunc() const
-			{
-				return m_pmdidElementFunc;
-			}
+			IMDId *PmdidElementFunc() const;
 
-			BOOL FIsExplicit() const
-			{
-				return m_fIsExplicit;
-			}
+			BOOL FIsExplicit() const;
 
 			virtual
-			EOperatorId Eopid() const
-			{
-				return EopScalarArrayCoerceExpr;
-			}
+			EOperatorId Eopid() const;
 
 			// return a string for operator name
 			virtual
-			const CHAR *SzId() const
-			{
-				return "CScalarArrayCoerceExpr";
-			}
+			const CHAR *SzId() const;
 
 			// match function
 			virtual
-			BOOL FMatch(COperator *) const;
+			BOOL FMatch
+				(
+				COperator *pop
+				) const;
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const;
 
 			// conversion function
 			static
 			CScalarArrayCoerceExpr *PopConvert
 				(
 				COperator *pop
-				)
-			{
-				GPOS_ASSERT(NULL != pop);
-				GPOS_ASSERT(EopScalarArrayCoerceExpr == pop->Eopid());
-
-				return dynamic_cast<CScalarArrayCoerceExpr*>(pop);
-			}
+				);
 
 	}; // class CScalarArrayCoerceExpr
 

--- a/libgpopt/include/gpopt/operators/CScalarCoerceBase.h
+++ b/libgpopt/include/gpopt/operators/CScalarCoerceBase.h
@@ -66,58 +66,29 @@ namespace gpopt
 
 			// dtor
 			virtual
-			~CScalarCoerceBase()
-			{
-				m_pmdidResultType->Release();
-			}
+			~CScalarCoerceBase();
 
 			// the type of the scalar expression
 			virtual
-			IMDId *PmdidType() const
-			{
-				return m_pmdidResultType;
-			}
+			IMDId *PmdidType() const;
 
 			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
-			}
+			INT IMod() const;
 
 			// return coercion form
-			ECoercionForm Ecf() const
-			{
-				return m_ecf;
-			}
+			ECoercionForm Ecf() const;
 
 			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
-			}
-
-			// match function
-			virtual
-			BOOL FMatch(COperator *) const;
-
-			// sensitivity to order of inputs
-			virtual
-			BOOL FInputOrderSensitive() const
-			{
-				return false;
-			}
+			INT ILoc() const;
 
 			// return a copy of the operator with remapped columns
 			virtual
 			COperator *PopCopyWithRemappedColumns
 				(
-				IMemoryPool *, //pmp,
-				HMUlCr *, //phmulcr,
-				BOOL //fMustExist
-				)
-			{
-				return PopCopyDefault();
-			}
+				IMemoryPool *pmp,
+				HMUlCr *phmulcr,
+				BOOL fMustExist
+				);
 
 	}; // class CScalarCoerceBase
 

--- a/libgpopt/include/gpopt/operators/CScalarCoerceBase.h
+++ b/libgpopt/include/gpopt/operators/CScalarCoerceBase.h
@@ -1,0 +1,129 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CScalarCoerceBase.h
+//
+//	@doc:
+//		Scalar coerce operator base class
+//
+//	@owner:
+//
+//	@test:
+//
+//
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CScalarCoerceBase_H
+#define GPOPT_CScalarCoerceBase_H
+
+#include "gpos/base.h"
+#include "gpopt/operators/CScalar.h"
+
+namespace gpopt
+{
+	using namespace gpos;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CScalarCoerceBase
+	//
+	//	@doc:
+	//		Scalar coerce operator base class
+	//
+	//---------------------------------------------------------------------------
+	class CScalarCoerceBase : public CScalar
+	{
+
+		private:
+
+			// catalog MDId of the result type
+			IMDId *m_pmdidResultType;
+
+			// output type modifications
+			INT m_iMod;
+
+			// coercion form
+			ECoercionForm m_ecf;
+
+			// location of token to be coerced
+			INT m_iLoc;
+
+			// private copy ctor
+			CScalarCoerceBase(const CScalarCoerceBase &);
+
+		public:
+
+			// ctor
+			CScalarCoerceBase
+				(
+				IMemoryPool *pmp,
+				IMDId *pmdidType,
+				INT iMod,
+				ECoercionForm edxlcf,
+				INT iLoc
+				);
+
+			// dtor
+			virtual
+			~CScalarCoerceBase()
+			{
+				m_pmdidResultType->Release();
+			}
+
+			// the type of the scalar expression
+			virtual
+			IMDId *PmdidType() const
+			{
+				return m_pmdidResultType;
+			}
+
+			// return type modification
+			INT IMod() const
+			{
+				return m_iMod;
+			}
+
+			// return coercion form
+			ECoercionForm Ecf() const
+			{
+				return m_ecf;
+			}
+
+			// return token location
+			INT ILoc() const
+			{
+				return m_iLoc;
+			}
+
+			// match function
+			virtual
+			BOOL FMatch(COperator *) const;
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const
+			{
+				return false;
+			}
+
+			// return a copy of the operator with remapped columns
+			virtual
+			COperator *PopCopyWithRemappedColumns
+				(
+				IMemoryPool *, //pmp,
+				HMUlCr *, //phmulcr,
+				BOOL //fMustExist
+				)
+			{
+				return PopCopyDefault();
+			}
+
+	}; // class CScalarCoerceBase
+
+}
+
+
+#endif // !GPOPT_CScalarCoerceBase_H
+
+// EOF

--- a/libgpopt/include/gpopt/operators/CScalarCoerceToDomain.h
+++ b/libgpopt/include/gpopt/operators/CScalarCoerceToDomain.h
@@ -74,6 +74,17 @@ namespace gpopt
 				return "CScalarCoerceToDomain";
 			}
 
+			// match function
+			virtual
+			BOOL FMatch(COperator *) const;
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const
+			{
+				return false;
+			}
+
 			// boolean expression evaluation
 			virtual
 			EBoolEvalResult Eber(DrgPul *pdrgpulChildren) const;

--- a/libgpopt/include/gpopt/operators/CScalarCoerceToDomain.h
+++ b/libgpopt/include/gpopt/operators/CScalarCoerceToDomain.h
@@ -19,9 +19,7 @@
 #define GPOPT_CScalarCoerceToDomain_H
 
 #include "gpos/base.h"
-#include "gpopt/base/COptCtxt.h"
-#include "gpopt/operators/CScalar.h"
-#include "gpopt/base/CDrvdProp.h"
+#include "gpopt/operators/CScalarCoerceBase.h"
 
 namespace gpopt
 {
@@ -35,23 +33,10 @@ namespace gpopt
 	//		Scalar CoerceToDomain operator
 	//
 	//---------------------------------------------------------------------------
-	class CScalarCoerceToDomain : public CScalar
+	class CScalarCoerceToDomain : public CScalarCoerceBase
 	{
 
 		private:
-
-			// catalog MDId of the result type
-			IMDId *m_pmdidResultType;
-
-			// output type modifications
-			INT m_iMod;
-
-			// coercion form
-			ECoercionForm m_ecf;
-
-			// location of token to be coerced
-			INT m_iLoc;
-
 			// does operator return NULL on NULL input?
 			BOOL m_fReturnsNullOnNullInput;
 
@@ -74,32 +59,6 @@ namespace gpopt
 			virtual
 			~CScalarCoerceToDomain()
 			{
-				m_pmdidResultType->Release();
-			}
-
-			// the type of the scalar expression
-			virtual
-			IMDId *PmdidType() const
-			{
-				return m_pmdidResultType;
-			}
-
-			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
-			}
-
-			// return coercion form
-			ECoercionForm Ecf() const
-			{
-				return m_ecf;
-			}
-
-			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
 			}
 
 			virtual
@@ -113,29 +72,6 @@ namespace gpopt
 			const CHAR *SzId() const
 			{
 				return "CScalarCoerceToDomain";
-			}
-
-			// match function
-			virtual
-			BOOL FMatch(COperator *) const;
-
-			// sensitivity to order of inputs
-			virtual
-			BOOL FInputOrderSensitive() const
-			{
-				return false;
-			}
-
-			// return a copy of the operator with remapped columns
-			virtual
-			COperator *PopCopyWithRemappedColumns
-				(
-				IMemoryPool *, //pmp,
-				HMUlCr *, //phmulcr,
-				BOOL //fMustExist
-				)
-			{
-				return PopCopyDefault();
 			}
 
 			// boolean expression evaluation

--- a/libgpopt/include/gpopt/operators/CScalarCoerceViaIO.h
+++ b/libgpopt/include/gpopt/operators/CScalarCoerceViaIO.h
@@ -21,9 +21,7 @@
 #define GPOPT_CScalarCoerceViaIO_H
 
 #include "gpos/base.h"
-#include "gpopt/base/COptCtxt.h"
-#include "gpopt/operators/CScalar.h"
-#include "gpopt/base/CDrvdProp.h"
+#include "gpopt/operators/CScalarCoerceBase.h"
 
 namespace gpopt
 {
@@ -37,23 +35,10 @@ namespace gpopt
 	//		Scalar CoerceViaIO operator
 	//
 	//---------------------------------------------------------------------------
-	class CScalarCoerceViaIO : public CScalar
+	class CScalarCoerceViaIO : public CScalarCoerceBase
 	{
 
 		private:
-
-			// catalog MDId of the result type
-			IMDId *m_pmdidResultType;
-
-			// output type modifications
-			INT m_iMod;
-
-			// coercion form
-			ECoercionForm m_ecf;
-
-			// location of token to be coerced
-			INT m_iLoc;
-
 			// private copy ctor
 			CScalarCoerceViaIO(const CScalarCoerceViaIO &);
 
@@ -73,32 +58,6 @@ namespace gpopt
 			virtual
 			~CScalarCoerceViaIO()
 			{
-				m_pmdidResultType->Release();
-			}
-
-			// the type of the scalar expression
-			virtual
-			IMDId *PmdidType() const
-			{
-				return m_pmdidResultType;
-			}
-
-			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
-			}
-
-			// return coercion form
-			ECoercionForm Ecf() const
-			{
-				return m_ecf;
-			}
-
-			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
 			}
 
 			virtual
@@ -112,29 +71,6 @@ namespace gpopt
 			const CHAR *SzId() const
 			{
 				return "CScalarCoerceViaIO";
-			}
-
-			// match function
-			virtual
-			BOOL FMatch(COperator *) const;
-
-			// sensitivity to order of inputs
-			virtual
-			BOOL FInputOrderSensitive() const
-			{
-				return false;
-			}
-
-			// return a copy of the operator with remapped columns
-			virtual
-			COperator *PopCopyWithRemappedColumns
-				(
-				IMemoryPool *, //pmp,
-				HMUlCr *, //phmulcr,
-				BOOL //fMustExist
-				)
-			{
-				return PopCopyDefault();
 			}
 
 			// conversion function

--- a/libgpopt/include/gpopt/operators/CScalarCoerceViaIO.h
+++ b/libgpopt/include/gpopt/operators/CScalarCoerceViaIO.h
@@ -73,6 +73,17 @@ namespace gpopt
 				return "CScalarCoerceViaIO";
 			}
 
+			// match function
+			virtual
+			BOOL FMatch(COperator *) const;
+
+			// sensitivity to order of inputs
+			virtual
+			BOOL FInputOrderSensitive() const
+			{
+				return false;
+			}
+
 			// conversion function
 			static
 			CScalarCoerceViaIO *PopConvert

--- a/libgpopt/include/gpopt/operators/ops.h
+++ b/libgpopt/include/gpopt/operators/ops.h
@@ -37,6 +37,7 @@
 #include "gpopt/operators/CScalarCast.h"
 #include "gpopt/operators/CScalarCoerceToDomain.h"
 #include "gpopt/operators/CScalarCoerceViaIO.h"
+#include "gpopt/operators/CScalarArrayCoerceExpr.h"
 #include "gpopt/operators/CScalarCoalesce.h"
 #include "gpopt/operators/CScalarMinMax.h"
 #include "gpopt/operators/CScalarSubquery.h"

--- a/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -332,6 +332,9 @@ namespace gpopt
 			// translate a DXL scalar coerce a scalar coerce using I/O functions
 			CExpression *PexprScalarCoerceViaIO(const CDXLNode *pdxlnCoerce);
 
+			// translate a DXL scalar array coerce expression using given element coerce function
+			CExpression *PexprScalarArrayCoerceExpr(const CDXLNode *pdxlnArrayCoerceExpr);
+
 			// translate a DXL scalar subquery operator into a scalar subquery expression
 			CExpression *PexprScalarSubquery(const CDXLNode *pdxlnSubquery);
 			

--- a/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -597,6 +597,9 @@ namespace gpopt
 			// translate a scalar coerce using I/O functions
 			CDXLNode *PdxlnScCoerceViaIO(CExpression *pexprScCoerce);
 
+			// translate a scalar array coerce expr with element coerce function
+			CDXLNode *PdxlnScArrayCoerceExpr(CExpression *pexprScArrayCoerceExpr);
+
 			// translate an array
 			CDXLNode *PdxlnArray(CExpression *pexpr);
 

--- a/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
+++ b/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
@@ -1,0 +1,99 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CScalarArrayCoerceExpr.cpp
+//
+//	@doc:
+//		Implementation of scalar array coerce expr operator
+//
+//	@owner:
+//
+//	@test:
+//
+//
+//---------------------------------------------------------------------------
+
+#include "gpos/base.h"
+
+#include "gpopt/base/CDrvdPropScalar.h"
+#include "gpopt/base/CColRefSet.h"
+
+#include "gpopt/mdcache/CMDAccessorUtils.h"
+
+#include "gpopt/operators/CScalarArrayCoerceExpr.h"
+#include "gpopt/operators/CExpressionHandle.h"
+
+#include "naucrates/md/IMDTypeBool.h"
+
+using namespace gpopt;
+using namespace gpmd;
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::CScalarArrayCoerceExpr
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CScalarArrayCoerceExpr::CScalarArrayCoerceExpr
+	(
+	IMemoryPool *pmp,
+	IMDId *pmdidElementFunc,
+	IMDId *pmdidResultType,
+	INT iMod,
+	BOOL fIsExplicit,
+	ECoercionForm ecf,
+	INT iLoc
+	)
+	:
+	CScalar(pmp),
+	m_pmdidElementFunc(pmdidElementFunc),
+	m_pmdidResultType(pmdidResultType),
+	m_iMod(iMod),
+	m_fIsExplicit(fIsExplicit),
+	m_ecf(ecf),
+	m_iLoc(iLoc)
+{
+	GPOS_ASSERT(NULL != pmdidElementFunc);
+	
+	GPOS_ASSERT(NULL != pmdidResultType);
+	GPOS_ASSERT(pmdidResultType->FValid());
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::FMatch
+//
+//	@doc:
+//		Match function on operator level
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarArrayCoerceExpr::FMatch
+	(
+	COperator *pop
+	)
+	const
+{
+	if (pop->Eopid() != Eopid())
+	{
+		return false;
+	}
+
+	CScalarArrayCoerceExpr *popCoerce = CScalarArrayCoerceExpr::PopConvert(pop);
+
+	return popCoerce->PmdidElementFunc()->FEquals(m_pmdidElementFunc) &&
+			popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
+			popCoerce->IMod() == m_iMod &&
+			popCoerce->FIsExplicit() == m_fIsExplicit &&
+			popCoerce->Ecf() == m_ecf &&
+			popCoerce->ILoc() == m_iLoc;
+}
+
+// EOF
+

--- a/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
+++ b/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
@@ -16,16 +16,7 @@
 //---------------------------------------------------------------------------
 
 #include "gpos/base.h"
-
-#include "gpopt/base/CDrvdPropScalar.h"
-#include "gpopt/base/CColRefSet.h"
-
-#include "gpopt/mdcache/CMDAccessorUtils.h"
-
 #include "gpopt/operators/CScalarArrayCoerceExpr.h"
-#include "gpopt/operators/CExpressionHandle.h"
-
-#include "naucrates/md/IMDTypeBool.h"
 
 using namespace gpopt;
 using namespace gpmd;
@@ -50,18 +41,11 @@ CScalarArrayCoerceExpr::CScalarArrayCoerceExpr
 	INT iLoc
 	)
 	:
-	CScalar(pmp),
+	CScalarCoerceBase(pmp, pmdidResultType, iMod, ecf, iLoc),
 	m_pmdidElementFunc(pmdidElementFunc),
-	m_pmdidResultType(pmdidResultType),
-	m_iMod(iMod),
-	m_fIsExplicit(fIsExplicit),
-	m_ecf(ecf),
-	m_iLoc(iLoc)
+	m_fIsExplicit(fIsExplicit)
 {
 	GPOS_ASSERT(NULL != pmdidElementFunc);
-	
-	GPOS_ASSERT(NULL != pmdidResultType);
-	GPOS_ASSERT(pmdidResultType->FValid());
 }
 
 
@@ -88,11 +72,11 @@ CScalarArrayCoerceExpr::FMatch
 	CScalarArrayCoerceExpr *popCoerce = CScalarArrayCoerceExpr::PopConvert(pop);
 
 	return popCoerce->PmdidElementFunc()->FEquals(m_pmdidElementFunc) &&
-			popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
-			popCoerce->IMod() == m_iMod &&
+			popCoerce->PmdidType()->FEquals(PmdidType()) &&
+			popCoerce->IMod() == IMod() &&
 			popCoerce->FIsExplicit() == m_fIsExplicit &&
-			popCoerce->Ecf() == m_ecf &&
-			popCoerce->ILoc() == m_iLoc;
+			popCoerce->Ecf() == Ecf() &&
+			popCoerce->ILoc() == ILoc();
 }
 
 // EOF

--- a/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
+++ b/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
@@ -48,6 +48,79 @@ CScalarArrayCoerceExpr::CScalarArrayCoerceExpr
 	GPOS_ASSERT(NULL != pmdidElementFunc);
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::~CScalarArrayCoerceExpr
+//
+//	@doc:
+//		dtor
+//
+//---------------------------------------------------------------------------
+CScalarArrayCoerceExpr::~CScalarArrayCoerceExpr()
+{
+	m_pmdidElementFunc->Release();
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::PmdidElementFunc
+//
+//	@doc:
+//		Return metadata id of element coerce function
+//
+//---------------------------------------------------------------------------
+IMDId *
+CScalarArrayCoerceExpr::PmdidElementFunc() const
+{
+	return m_pmdidElementFunc;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::FIsExplicit
+//
+//	@doc:
+//		Conversion semantics flag to pass to func
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarArrayCoerceExpr::FIsExplicit() const
+{
+	return m_fIsExplicit;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::Eopid
+//
+//	@doc:
+//		Return operator identifier
+//
+//---------------------------------------------------------------------------
+CScalar::EOperatorId
+CScalarArrayCoerceExpr::Eopid() const
+{
+	return EopScalarArrayCoerceExpr;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::SzId
+//
+//	@doc:
+//		Return a string for operator name
+//
+//---------------------------------------------------------------------------
+const CHAR *
+CScalarArrayCoerceExpr::SzId() const
+{
+	return "CScalarArrayCoerceExpr";
+}
+
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -78,6 +151,43 @@ CScalarArrayCoerceExpr::FMatch
 			popCoerce->Ecf() == Ecf() &&
 			popCoerce->ILoc() == ILoc();
 }
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::FInputOrderSensitive
+//
+//	@doc:
+//		Sensitivity to order of inputs
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarArrayCoerceExpr::FInputOrderSensitive() const
+{
+	return false;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarArrayCoerceExpr::PopConvert
+//
+//	@doc:
+//		Conversion function
+//
+//---------------------------------------------------------------------------
+CScalarArrayCoerceExpr *
+CScalarArrayCoerceExpr::PopConvert
+	(
+	COperator *pop
+	)
+{
+	GPOS_ASSERT(NULL != pop);
+	GPOS_ASSERT(EopScalarArrayCoerceExpr == pop->Eopid());
+
+	return dynamic_cast<CScalarArrayCoerceExpr*>(pop);
+}
+
 
 // EOF
 

--- a/libgpopt/src/operators/CScalarCoerceBase.cpp
+++ b/libgpopt/src/operators/CScalarCoerceBase.cpp
@@ -47,38 +47,101 @@ CScalarCoerceBase::CScalarCoerceBase
 {
 	GPOS_ASSERT(NULL != pmdidType);
 	GPOS_ASSERT(pmdidType->FValid());
-
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CScalarCoerceBase::FMatch
+//		CScalarCoerceBase::~CScalarCoerceBase
 //
 //	@doc:
-//		Match function on operator level
+//		Dtor
 //
 //---------------------------------------------------------------------------
-BOOL
-CScalarCoerceBase::FMatch
-	(
-	COperator *pop
-	)
-	const
+CScalarCoerceBase::~CScalarCoerceBase()
 {
-	if (pop->Eopid() == Eopid())
-	{
-		CScalarCoerceBase *popCoerce = dynamic_cast<CScalarCoerceBase*>(pop);
-
-		return popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
-				popCoerce->IMod() == m_iMod &&
-				popCoerce->Ecf() == m_ecf &&
-				popCoerce->ILoc() == m_iLoc;
-	}
-
-	return false;
+	m_pmdidResultType->Release();
 }
 
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarCoerceBase::PmdidType
+//
+//	@doc:
+//		Return type of the scalar expression
+//
+//---------------------------------------------------------------------------
+IMDId*
+CScalarCoerceBase::PmdidType() const
+{
+	return m_pmdidResultType;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarCoerceBase::IMod
+//
+//	@doc:
+//		Return type modification
+//
+//---------------------------------------------------------------------------
+INT
+CScalarCoerceBase::IMod() const
+{
+	return m_iMod;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarCoerceBase::Ecf
+//
+//	@doc:
+//		Return coercion form
+//
+//---------------------------------------------------------------------------
+CScalar::ECoercionForm
+CScalarCoerceBase::Ecf() const
+{
+	return m_ecf;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarCoerceBase::ILoc
+//
+//	@doc:
+//		Return token location
+//
+//---------------------------------------------------------------------------
+INT
+CScalarCoerceBase::ILoc() const
+{
+	return m_iLoc;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarCoerceBase::PopCopyWithRemappedColumns
+//
+//	@doc:
+//		return a copy of the operator with remapped columns
+//
+//---------------------------------------------------------------------------
+COperator*
+CScalarCoerceBase::PopCopyWithRemappedColumns
+	(
+	IMemoryPool *, //pmp,
+	HMUlCr *, //phmulcr,
+	BOOL //fMustExist
+	)
+{
+	return PopCopyDefault();
+}
 
 // EOF
 

--- a/libgpopt/src/operators/CScalarCoerceBase.cpp
+++ b/libgpopt/src/operators/CScalarCoerceBase.cpp
@@ -1,12 +1,12 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2014 Pivotal Inc.
+//	Copyright (C) 2017 Pivotal Inc.
 //
 //	@filename:
-//		CScalarCoerceViaIO.cpp
+//		CScalarCoerceBase.cpp
 //
 //	@doc:
-//		Implementation of scalar CoerceViaIO operators
+//		Implementation of scalar coerce operator base class
 //
 //	@owner:
 //
@@ -16,7 +16,7 @@
 //---------------------------------------------------------------------------
 
 #include "gpos/base.h"
-#include "gpopt/operators/CScalarCoerceViaIO.h"
+#include "gpopt/operators/CScalarCoerceBase.h"
 
 using namespace gpopt;
 using namespace gpmd;
@@ -24,13 +24,13 @@ using namespace gpmd;
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CScalarCoerceViaIO::CScalarCoerceViaIO
+//		CScalarCoerceBase::CScalarCoerceBase
 //
 //	@doc:
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CScalarCoerceViaIO::CScalarCoerceViaIO
+CScalarCoerceBase::CScalarCoerceBase
 	(
 	IMemoryPool *pmp,
 	IMDId *pmdidType,
@@ -39,38 +39,45 @@ CScalarCoerceViaIO::CScalarCoerceViaIO
 	INT iLoc
 	)
 	:
-	CScalarCoerceBase(pmp, pmdidType, iMod, ecf, iLoc)
+	CScalar(pmp),
+	m_pmdidResultType(pmdidType),
+	m_iMod(iMod),
+	m_ecf(ecf),
+	m_iLoc(iLoc)
 {
+	GPOS_ASSERT(NULL != pmdidType);
+	GPOS_ASSERT(pmdidType->FValid());
+
 }
 
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CScalarCoerceViaIO::FMatch
+//		CScalarCoerceBase::FMatch
 //
 //	@doc:
 //		Match function on operator level
 //
 //---------------------------------------------------------------------------
-//BOOL
-//CScalarCoerceViaIO::FMatch
-//	(
-//	COperator *pop
-//	)
-//	const
-//{
-//	if (pop->Eopid() == Eopid())
-//	{
-//		CScalarCoerceViaIO *popCoerce = CScalarCoerceViaIO::PopConvert(pop);
-//
-//		return popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
-//				popCoerce->IMod() == m_iMod &&
-//				popCoerce->Ecf() == m_ecf &&
-//				popCoerce->ILoc() == m_iLoc;
-//	}
-//
-//	return false;
-//}
+BOOL
+CScalarCoerceBase::FMatch
+	(
+	COperator *pop
+	)
+	const
+{
+	if (pop->Eopid() == Eopid())
+	{
+		CScalarCoerceBase *popCoerce = dynamic_cast<CScalarCoerceBase*>(pop);
+
+		return popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
+				popCoerce->IMod() == m_iMod &&
+				popCoerce->Ecf() == m_ecf &&
+				popCoerce->ILoc() == m_iLoc;
+	}
+
+	return false;
+}
 
 
 // EOF

--- a/libgpopt/src/operators/CScalarCoerceToDomain.cpp
+++ b/libgpopt/src/operators/CScalarCoerceToDomain.cpp
@@ -41,6 +41,35 @@ CScalarCoerceToDomain::CScalarCoerceToDomain
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CScalarCoerceToDomain::FMatch
+//
+//	@doc:
+//		Match function on operator level
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarCoerceToDomain::FMatch
+	(
+	COperator *pop
+	)
+	const
+{
+	if (pop->Eopid() == Eopid())
+	{
+		CScalarCoerceToDomain *popCoerce = CScalarCoerceToDomain::PopConvert(pop);
+
+		return popCoerce->PmdidType()->FEquals(PmdidType()) &&
+				popCoerce->IMod() == IMod() &&
+				popCoerce->Ecf() == Ecf() &&
+				popCoerce->ILoc() == ILoc();
+	}
+
+	return false;
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CScalarCoerceToDomain::Eber
 //
 //	@doc:

--- a/libgpopt/src/operators/CScalarCoerceToDomain.cpp
+++ b/libgpopt/src/operators/CScalarCoerceToDomain.cpp
@@ -10,16 +10,7 @@
 //---------------------------------------------------------------------------
 
 #include "gpos/base.h"
-
-#include "gpopt/base/CDrvdPropScalar.h"
-#include "gpopt/base/CColRefSet.h"
-
-#include "gpopt/mdcache/CMDAccessorUtils.h"
-
 #include "gpopt/operators/CScalarCoerceToDomain.h"
-#include "gpopt/operators/CExpressionHandle.h"
-
-#include "naucrates/md/IMDTypeBool.h"
 
 using namespace gpopt;
 using namespace gpmd;
@@ -42,45 +33,9 @@ CScalarCoerceToDomain::CScalarCoerceToDomain
 	INT iLoc
 	)
 	:
-	CScalar(pmp),
-	m_pmdidResultType(pmdidType),
-	m_iMod(iMod),
-	m_ecf(ecf),
-	m_iLoc(iLoc),
+	CScalarCoerceBase(pmp, pmdidType, iMod, ecf, iLoc),
 	m_fReturnsNullOnNullInput(false)
 {
-	GPOS_ASSERT(NULL != pmdidType);
-	GPOS_ASSERT(pmdidType->FValid());
-
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarCoerceToDomain::FMatch
-//
-//	@doc:
-//		Match function on operator level
-//
-//---------------------------------------------------------------------------
-BOOL
-CScalarCoerceToDomain::FMatch
-	(
-	COperator *pop
-	)
-	const
-{
-	if (pop->Eopid() == Eopid())
-	{
-		CScalarCoerceToDomain *popCoerce = CScalarCoerceToDomain::PopConvert(pop);
-
-		return popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
-				popCoerce->IMod() == m_iMod &&
-				popCoerce->Ecf() == m_ecf &&
-				popCoerce->ILoc() == m_iLoc;
-	}
-
-	return false;
 }
 
 

--- a/libgpopt/src/operators/CScalarCoerceViaIO.cpp
+++ b/libgpopt/src/operators/CScalarCoerceViaIO.cpp
@@ -52,25 +52,25 @@ CScalarCoerceViaIO::CScalarCoerceViaIO
 //		Match function on operator level
 //
 //---------------------------------------------------------------------------
-//BOOL
-//CScalarCoerceViaIO::FMatch
-//	(
-//	COperator *pop
-//	)
-//	const
-//{
-//	if (pop->Eopid() == Eopid())
-//	{
-//		CScalarCoerceViaIO *popCoerce = CScalarCoerceViaIO::PopConvert(pop);
-//
-//		return popCoerce->PmdidType()->FEquals(m_pmdidResultType) &&
-//				popCoerce->IMod() == m_iMod &&
-//				popCoerce->Ecf() == m_ecf &&
-//				popCoerce->ILoc() == m_iLoc;
-//	}
-//
-//	return false;
-//}
+BOOL
+CScalarCoerceViaIO::FMatch
+	(
+	COperator *pop
+	)
+	const
+{
+	if (pop->Eopid() == Eopid())
+	{
+		CScalarCoerceViaIO *popCoerce = CScalarCoerceViaIO::PopConvert(pop);
+
+		return popCoerce->PmdidType()->FEquals(PmdidType()) &&
+				popCoerce->IMod() == IMod() &&
+				popCoerce->Ecf() == Ecf() &&
+				popCoerce->ILoc() == ILoc();
+	}
+
+	return false;
+}
 
 
 // EOF

--- a/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -3681,21 +3681,21 @@ CTranslatorDXLToExpr::PexprScalarArrayCoerceExpr
 	)
 {
 	GPOS_ASSERT(NULL != pdxlnArrayCoerceExpr);
-	
+
 	CDXLScalarArrayCoerceExpr *pdxlop = CDXLScalarArrayCoerceExpr::PdxlopConvert(pdxlnArrayCoerceExpr->Pdxlop());
-	
+
 	GPOS_ASSERT(1 == pdxlnArrayCoerceExpr->UlArity());
 	CDXLNode *pdxlnChild = (*pdxlnArrayCoerceExpr)[0];
 	CExpression *pexprChild = Pexpr(pdxlnChild);
 
 	IMDId *pmdidElementFunc = pdxlop->PmdidElementFunc();
 	pmdidElementFunc->AddRef();
-	
+
 	IMDId *pmdidResultType = pdxlop->PmdidResultType();
 	pmdidResultType->AddRef();
-	
+
 	EdxlCoercionForm edxlcf = pdxlop->Edxlcf();
-	
+
 	return GPOS_NEW(m_pmp) CExpression
 				(
 				m_pmp,

--- a/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -57,6 +57,7 @@ const CSubqueryHandler::SOperatorHandler CSubqueryHandler::m_rgophdlr[] =
 	{COperator::EopScalarCast, FRecursiveHandler},
 	{COperator::EopScalarCoerceToDomain, FRecursiveHandler},
 	{COperator::EopScalarCoerceViaIO, FRecursiveHandler},
+	{COperator::EopScalarArrayCoerceExpr, FRecursiveHandler},
 	{COperator::EopScalarAggFunc, FRecursiveHandler},
 	{COperator::EopScalarWindowFunc, FRecursiveHandler},
 	{COperator::EopScalarArray, FRecursiveHandler},

--- a/libgpos/config.h.in
+++ b/libgpos/config.h.in
@@ -25,5 +25,5 @@
 #cmakedefine GPOS_32BIT
 #cmakedefine GPOS_64BIT
 
-#endif  // GPOS_config_Hve
+#endif  // GPOS_config_H
 // EOF

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -345,6 +345,8 @@ add_library(naucrates
             src/operators/CDXLScalarCoerceToDomain.cpp
             include/naucrates/dxl/operators/CDXLScalarCoerceViaIO.h
             src/operators/CDXLScalarCoerceViaIO.cpp
+            include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
+            src/operators/CDXLScalarArrayCoerceExpr.cpp
             include/naucrates/dxl/operators/CDXLScalarComp.h
             src/operators/CDXLScalarComp.cpp
             include/naucrates/dxl/operators/CDXLScalarConstValue.h
@@ -683,6 +685,8 @@ add_library(naucrates
             src/parser/CParseHandlerScalarCoerceToDomain.cpp
             include/naucrates/dxl/parser/CParseHandlerScalarCoerceViaIO.h
             src/parser/CParseHandlerScalarCoerceViaIO.cpp
+            include/naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h
+            src/parser/CParseHandlerScalarArrayCoerceExpr.cpp
             include/naucrates/dxl/parser/CParseHandlerScalarComp.h
             src/parser/CParseHandlerScalarComp.cpp
             include/naucrates/dxl/parser/CParseHandlerScalarConstValue.h

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -341,6 +341,8 @@ add_library(naucrates
             src/operators/CDXLScalarCast.cpp
             include/naucrates/dxl/operators/CDXLScalarCoalesce.h
             src/operators/CDXLScalarCoalesce.cpp
+            include/naucrates/dxl/operators/CDXLScalarCoerceBase.h
+            src/operators/CDXLScalarCoerceBase.cpp
             include/naucrates/dxl/operators/CDXLScalarCoerceToDomain.h
             src/operators/CDXLScalarCoerceToDomain.cpp
             include/naucrates/dxl/operators/CDXLScalarCoerceViaIO.h

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
@@ -99,6 +99,7 @@ namespace gpdxl
 		EdxlopScalarCast,
 		EdxlopScalarCoerceToDomain,
 		EdxlopScalarCoerceViaIO,
+		EdxlopScalarArrayCoerceExpr,
 		EdxlopScalarAggref,
 		EdxlopScalarArrayComp,
 		EdxlopScalarBooleanTest,

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLOperatorFactory.h
@@ -322,6 +322,10 @@ namespace gpdxl
 			static
 			CDXLScalar *PdxlopCoerceViaIO(CDXLMemoryManager *pmm, const Attributes &attrs);
 
+			// create a ArrayCoerceExpr
+			static
+			CDXLScalar *PdxlopArrayCoerceExpr(CDXLMemoryManager *pmm, const Attributes &attrs);
+
 			// create a scalar identifier operator
 			static
 			CDXLScalar *PdxlopScalarIdent(CDXLMemoryManager *pmm, const Attributes &attrs);

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
@@ -19,7 +19,7 @@
 #define GPDXL_CDXLScalarArrayCoerceExpr_H
 
 #include "gpos/base.h"
-#include "naucrates/dxl/operators/CDXLScalar.h"
+#include "naucrates/dxl/operators/CDXLScalarCoerceBase.h"
 #include "naucrates/md/IMDId.h"
 
 namespace gpdxl
@@ -34,30 +34,18 @@ namespace gpdxl
 	//	@doc:
 	//		Class for representing DXL array coerce operator
 	//---------------------------------------------------------------------------
-	class CDXLScalarArrayCoerceExpr : public CDXLScalar
+	class CDXLScalarArrayCoerceExpr : public CDXLScalarCoerceBase
 	{
 		private:
 			// catalog MDId of element coerce function
 			IMDId *m_pmdidElementFunc;
-		
-			// catalog MDId of the result type
-			IMDId *m_pmdidResultType;
-
-			// output type modifications
-			INT m_iMod;
 
 			// conversion semantics flag to pass to func
 			BOOL m_fIsExplicit;
 
-			// coercion form
-			EdxlCoercionForm m_edxlcf;
-
-			// location of token to be coerced
-			INT m_iLoc;
-
 			// private copy ctor
 			CDXLScalarArrayCoerceExpr(const CDXLScalarArrayCoerceExpr&);
-		
+
 		public:
 			CDXLScalarArrayCoerceExpr
 				(
@@ -69,9 +57,13 @@ namespace gpdxl
 				EdxlCoercionForm edxlcf,
 				INT iLoc
 				);
-		
-			~CDXLScalarArrayCoerceExpr();
-		
+
+			virtual
+			~CDXLScalarArrayCoerceExpr()
+			{
+				m_pmdidElementFunc->Release();
+			}
+
 			// ident accessor
 			virtual
 			Edxlopid Edxlop() const
@@ -79,45 +71,16 @@ namespace gpdxl
 				return EdxlopScalarArrayCoerceExpr;
 			}
 
-		
 			// return metadata id of element coerce function
 			IMDId *PmdidElementFunc() const
 			{
 				return m_pmdidElementFunc;
-			}
-		
-			// return result type
-			IMDId *PmdidResultType() const
-			{
-				return m_pmdidResultType;
-			}
-
-			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
 			}
 
 			BOOL FIsExplicit() const
 			{
 				return m_fIsExplicit;
 			}
-		
-			// return coercion form
-			EdxlCoercionForm Edxlcf() const
-			{
-				return m_edxlcf;
-			}
-
-			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
-			}
-
-			// does the operator return a boolean result
-			virtual
-			BOOL FBoolean(CMDAccessor *pmda) const;
 
 			// name of the DXL operator name
 			virtual
@@ -139,13 +102,6 @@ namespace gpdxl
 
 				return dynamic_cast<CDXLScalarArrayCoerceExpr*>(pdxlop);
 			}
-
-#ifdef GPOS_DEBUG
-			// checks whether the operator has valid structure, i.e. number and
-			// types of child nodes
-			virtual
-			void AssertValid(const CDXLNode *pdxln, BOOL fValidateChildren) const;
-#endif // GPOS_DEBUG
 	};
 }
 

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
@@ -1,0 +1,154 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CDXLScalarArrayCoerceExpr.h
+//
+//	@doc:
+//		Class for representing DXL ArrayCoerceExpr operation,
+//		the operator will apply type casting for each element in this array
+//		using the given element coercion function.
+//	@owner:
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CDXLScalarArrayCoerceExpr_H
+#define GPDXL_CDXLScalarArrayCoerceExpr_H
+
+#include "gpos/base.h"
+#include "naucrates/dxl/operators/CDXLScalar.h"
+#include "naucrates/md/IMDId.h"
+
+namespace gpdxl
+{
+	using namespace gpos;
+	using namespace gpmd;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CDXLScalarArrayCoerceExpr
+	//
+	//	@doc:
+	//		Class for representing DXL array coerce operator
+	//---------------------------------------------------------------------------
+	class CDXLScalarArrayCoerceExpr : public CDXLScalar
+	{
+		private:
+			// catalog MDId of element coerce function
+			IMDId *m_pmdidElementFunc;
+		
+			// catalog MDId of the result type
+			IMDId *m_pmdidResultType;
+
+			// output type modifications
+			INT m_iMod;
+
+			// conversion semantics flag to pass to func
+			BOOL m_fIsExplicit;
+
+			// coercion form
+			EdxlCoercionForm m_edxlcf;
+
+			// location of token to be coerced
+			INT m_iLoc;
+
+			// private copy ctor
+			CDXLScalarArrayCoerceExpr(const CDXLScalarArrayCoerceExpr&);
+		
+		public:
+			CDXLScalarArrayCoerceExpr
+				(
+				IMemoryPool *pmp,
+				IMDId *pmdidElementFunc,
+				IMDId *pmdidResultType,
+				INT iMod,
+				BOOL fIsExplicit,
+				EdxlCoercionForm edxlcf,
+				INT iLoc
+				);
+		
+			~CDXLScalarArrayCoerceExpr();
+		
+			// ident accessor
+			virtual
+			Edxlopid Edxlop() const
+			{
+				return EdxlopScalarArrayCoerceExpr;
+			}
+
+		
+			// return metadata id of element coerce function
+			IMDId *PmdidElementFunc() const
+			{
+				return m_pmdidElementFunc;
+			}
+		
+			// return result type
+			IMDId *PmdidResultType() const
+			{
+				return m_pmdidResultType;
+			}
+
+			// return type modification
+			INT IMod() const
+			{
+				return m_iMod;
+			}
+
+			BOOL FIsExplicit() const
+			{
+				return m_fIsExplicit;
+			}
+		
+			// return coercion form
+			EdxlCoercionForm Edxlcf() const
+			{
+				return m_edxlcf;
+			}
+
+			// return token location
+			INT ILoc() const
+			{
+				return m_iLoc;
+			}
+
+			// does the operator return a boolean result
+			virtual
+			BOOL FBoolean(CMDAccessor *pmda) const;
+
+			// name of the DXL operator name
+			virtual
+			const CWStringConst *PstrOpName() const;
+
+			// serialize operator in DXL format
+			virtual
+			void SerializeToDXL(CXMLSerializer *pxmlser, const CDXLNode *pdxln) const;
+
+			// conversion function
+			static
+			CDXLScalarArrayCoerceExpr *PdxlopConvert
+				(
+				CDXLOperator *pdxlop
+				)
+			{
+				GPOS_ASSERT(NULL != pdxlop);
+				GPOS_ASSERT(EdxlopScalarArrayCoerceExpr == pdxlop->Edxlop());
+
+				return dynamic_cast<CDXLScalarArrayCoerceExpr*>(pdxlop);
+			}
+
+#ifdef GPOS_DEBUG
+			// checks whether the operator has valid structure, i.e. number and
+			// types of child nodes
+			virtual
+			void AssertValid(const CDXLNode *pdxln, BOOL fValidateChildren) const;
+#endif // GPOS_DEBUG
+	};
+}
+
+#endif // !GPDXL_CDXLScalarArrayCoerceExpr_H
+
+// EOF

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLScalarCoerceBase.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLScalarCoerceBase.h
@@ -1,0 +1,114 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CDXLScalarCoerceBase.h
+//
+//	@doc:
+//		Base class for representing DXL coerce operators
+//
+//	@owner:
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CDXLScalarCoerceBase_H
+#define GPDXL_CDXLScalarCoerceBase_H
+
+#include "gpos/base.h"
+#include "naucrates/dxl/operators/CDXLScalar.h"
+#include "naucrates/md/IMDId.h"
+
+namespace gpdxl
+{
+	using namespace gpos;
+	using namespace gpmd;
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CDXLScalarCoerceBase
+	//
+	//	@doc:
+	//		Base class for representing DXL coerce operators
+	//
+	//---------------------------------------------------------------------------
+	class CDXLScalarCoerceBase : public CDXLScalar
+	{
+
+		private:
+
+			// catalog MDId of the result type
+			IMDId *m_pmdidResultType;
+
+			// output type modifications
+			INT m_iMod;
+
+			// coercion form
+			EdxlCoercionForm m_edxlcf;
+
+			// location of token to be coerced
+			INT m_iLoc;
+
+			// private copy ctor
+			CDXLScalarCoerceBase(const CDXLScalarCoerceBase&);
+
+		public:
+			// ctor/dtor
+			CDXLScalarCoerceBase
+				(
+				IMemoryPool *pmp,
+				IMDId *pmdidType,
+				INT iMod,
+				EdxlCoercionForm edxlcf,
+				INT iLoc
+				);
+
+			virtual
+			~CDXLScalarCoerceBase();
+
+			// return result type
+			IMDId *PmdidResultType() const
+			{
+				return m_pmdidResultType;
+			}
+
+			// return type modification
+			INT IMod() const
+			{
+				return m_iMod;
+			}
+
+			// return coercion form
+			EdxlCoercionForm Edxlcf() const
+			{
+				return m_edxlcf;
+			}
+
+			// return token location
+			INT ILoc() const
+			{
+				return m_iLoc;
+			}
+
+			// does the operator return a boolean result
+			virtual
+			BOOL FBoolean(CMDAccessor *pmda) const;
+
+#ifdef GPOS_DEBUG
+			// checks whether the operator has valid structure, i.e. number and
+			// types of child nodes
+			virtual
+			void AssertValid(const CDXLNode *pdxln, BOOL fValidateChildren) const;
+#endif // GPOS_DEBUG
+
+			// serialize operator in DXL format
+			virtual
+			void SerializeToDXL(CXMLSerializer *pxmlser, const CDXLNode *pdxln) const;
+	};
+}
+
+#endif // !GPDXL_CDXLScalarCoerceBase_H
+
+// EOF

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLScalarCoerceToDomain.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLScalarCoerceToDomain.h
@@ -25,7 +25,7 @@
 #define GPDXL_CDXLScalarCoerceToDomain_H
 
 #include "gpos/base.h"
-#include "naucrates/dxl/operators/CDXLScalar.h"
+#include "naucrates/dxl/operators/CDXLScalarCoerceBase.h"
 #include "naucrates/md/IMDId.h"
 
 namespace gpdxl
@@ -41,23 +41,10 @@ namespace gpdxl
 	//		Class for representing DXL casting operator
 	//
 	//---------------------------------------------------------------------------
-	class CDXLScalarCoerceToDomain : public CDXLScalar
+	class CDXLScalarCoerceToDomain : public CDXLScalarCoerceBase
 	{
 
 		private:
-
-			// catalog MDId of the result type
-			IMDId *m_pmdidResultType;
-
-			// output type modifications
-			INT m_iMod;
-
-			// coercion form
-			EdxlCoercionForm m_edxlcf;
-
-			// location of token to be coerced
-			INT m_iLoc;
-
 			// private copy ctor
 			CDXLScalarCoerceToDomain(const CDXLScalarCoerceToDomain&);
 
@@ -73,7 +60,9 @@ namespace gpdxl
 				);
 
 			virtual
-			~CDXLScalarCoerceToDomain();
+			~CDXLScalarCoerceToDomain()
+			{
+			}
 
 			// ident accessor
 			virtual
@@ -81,35 +70,6 @@ namespace gpdxl
 			{
 				return EdxlopScalarCoerceToDomain;
 			}
-
-			// return result type
-			IMDId *PmdidResultType() const
-			{
-				return m_pmdidResultType;
-			}
-
-			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
-			}
-
-			// return coercion form
-			EdxlCoercionForm Edxlcf() const
-			{
-				return m_edxlcf;
-			}
-
-			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
-			}
-
-			// does the operator return a boolean result
-			virtual
-			BOOL FBoolean(CMDAccessor *pmda) const;
-
 
 			// name of the DXL operator name
 			virtual
@@ -127,17 +87,6 @@ namespace gpdxl
 
 				return dynamic_cast<CDXLScalarCoerceToDomain*>(pdxlop);
 			}
-
-#ifdef GPOS_DEBUG
-			// checks whether the operator has valid structure, i.e. number and
-			// types of child nodes
-			virtual
-			void AssertValid(const CDXLNode *pdxln, BOOL fValidateChildren) const;
-#endif // GPOS_DEBUG
-
-			// serialize operator in DXL format
-			virtual
-			void SerializeToDXL(CXMLSerializer *pxmlser, const CDXLNode *pdxln) const;
 	};
 }
 

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLScalarCoerceViaIO.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLScalarCoerceViaIO.h
@@ -21,7 +21,7 @@
 #define GPDXL_CDXLScalarCoerceViaIO_H
 
 #include "gpos/base.h"
-#include "naucrates/dxl/operators/CDXLScalar.h"
+#include "naucrates/dxl/operators/CDXLScalarCoerceBase.h"
 #include "naucrates/md/IMDId.h"
 
 namespace gpdxl
@@ -37,23 +37,10 @@ namespace gpdxl
 	//		Class for representing DXL casting operator
 	//
 	//---------------------------------------------------------------------------
-	class CDXLScalarCoerceViaIO : public CDXLScalar
+	class CDXLScalarCoerceViaIO : public CDXLScalarCoerceBase
 	{
 
 		private:
-
-			// catalog MDId of the result type
-			IMDId *m_pmdidResultType;
-
-			// output type modifications
-			INT m_iMod;
-
-			// coercion form
-			EdxlCoercionForm m_edxlcf;
-
-			// location of token to be coerced
-			INT m_iLoc;
-
 			// private copy ctor
 			CDXLScalarCoerceViaIO(const CDXLScalarCoerceViaIO&);
 
@@ -69,7 +56,9 @@ namespace gpdxl
 				);
 
 			virtual
-			~CDXLScalarCoerceViaIO();
+			~CDXLScalarCoerceViaIO()
+			{
+			}
 
 			// ident accessor
 			virtual
@@ -77,35 +66,6 @@ namespace gpdxl
 			{
 				return EdxlopScalarCoerceViaIO;
 			}
-
-			// return result type
-			IMDId *PmdidResultType() const
-			{
-				return m_pmdidResultType;
-			}
-
-			// return type modification
-			INT IMod() const
-			{
-				return m_iMod;
-			}
-
-			// return coercion form
-			EdxlCoercionForm Edxlcf() const
-			{
-				return m_edxlcf;
-			}
-
-			// return token location
-			INT ILoc() const
-			{
-				return m_iLoc;
-			}
-
-			// does the operator return a boolean result
-			virtual
-			BOOL FBoolean(CMDAccessor *pmda) const;
-
 
 			// name of the DXL operator name
 			virtual
@@ -123,17 +83,6 @@ namespace gpdxl
 
 				return dynamic_cast<CDXLScalarCoerceViaIO*>(pdxlop);
 			}
-
-#ifdef GPOS_DEBUG
-			// checks whether the operator has valid structure, i.e. number and
-			// types of child nodes
-			virtual
-			void AssertValid(const CDXLNode *pdxln, BOOL fValidateChildren) const;
-#endif // GPOS_DEBUG
-
-			// serialize operator in DXL format
-			virtual
-			void SerializeToDXL(CXMLSerializer *pxmlser, const CDXLNode *pdxln) const;
 	};
 }
 

--- a/libnaucrates/include/naucrates/dxl/operators/dxlops.h
+++ b/libnaucrates/include/naucrates/dxl/operators/dxlops.h
@@ -92,6 +92,7 @@
 #include "naucrates/dxl/operators/CDXLScalarCast.h"
 #include "naucrates/dxl/operators/CDXLScalarCoerceToDomain.h"
 #include "naucrates/dxl/operators/CDXLScalarCoerceViaIO.h"
+#include "naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h"
 #include "naucrates/dxl/operators/CDXLScalarBooleanTest.h"
 #include "naucrates/dxl/operators/CDXLScalarInitPlan.h"
 #include "naucrates/dxl/operators/CDXLScalarArray.h"

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
@@ -937,6 +937,15 @@ namespace gpdxl
 				CParseHandlerBase *pphRoot
 				);
 
+			// construct a ArrayCoerceExpr parse handler
+			static
+			CParseHandlerBase *PphScalarArrayCoerceExpr
+				(
+				IMemoryPool *pmp,
+				CParseHandlerManager *pphm,
+				CParseHandlerBase *pphRoot
+				);
+
 			// construct an init plan parse handler
 			static
 			CParseHandlerBase *PphScalarInitPlan

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2014 Pivotal Inc.
+//	Copyright (C) 2017 Pivotal Inc.
 //
 //	@filename:
 //		CParseHandlerScalarArrayCoerceExpr.h
@@ -36,7 +36,7 @@ namespace gpdxl
 	//		CParseHandlerScalarArrayCoerceExpr
 	//
 	//	@doc:
-	//		Parse handler for parsing  parsing ArrayCoerceExpr operator
+	//		Parse handler for parsing ArrayCoerceExpr operator
 	//
 	//---------------------------------------------------------------------------
 	class CParseHandlerScalarArrayCoerceExpr : public CParseHandlerScalarOp

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h
@@ -1,0 +1,83 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2014 Pivotal Inc.
+//
+//	@filename:
+//		CParseHandlerScalarArrayCoerceExpr.h
+//
+//	@doc:
+//
+//		SAX parse handler class for parsing ArrayCoerceExpr operator.
+//
+//	@owner:
+//
+//	@test:
+//
+//
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CParseHandlerScalarArrayCoerceExpr_H
+#define GPDXL_CParseHandlerScalarArrayCoerceExpr_H
+
+#include "gpos/base.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+
+#include "naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h"
+
+
+namespace gpdxl
+{
+	using namespace gpos;
+
+	XERCES_CPP_NAMESPACE_USE
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CParseHandlerScalarArrayCoerceExpr
+	//
+	//	@doc:
+	//		Parse handler for parsing  parsing ArrayCoerceExpr operator
+	//
+	//---------------------------------------------------------------------------
+	class CParseHandlerScalarArrayCoerceExpr : public CParseHandlerScalarOp
+	{
+		private:
+
+			// private copy ctor
+			CParseHandlerScalarArrayCoerceExpr(const CParseHandlerScalarArrayCoerceExpr &);
+
+			// process the start of an element
+			void StartElement
+					(
+					const XMLCh* const xmlszUri, 		// URI of element's namespace
+					const XMLCh* const xmlszLocalname,	// local part of element's name
+					const XMLCh* const xmlszQname,		// element's qname
+					const Attributes& attr				// element's attributes
+					);
+
+			// process the end of an element
+			void EndElement
+					(
+					const XMLCh* const xmlszUri, 		// URI of element's namespace
+					const XMLCh* const xmlszLocalname,	// local part of element's name
+					const XMLCh* const xmlszQname		// element's qname
+					);
+
+		public:
+			// ctor/dtor
+			CParseHandlerScalarArrayCoerceExpr
+					(
+					IMemoryPool *pmp,
+					CParseHandlerManager *pphm,
+					CParseHandlerBase *pphRoot
+					);
+
+			virtual
+			~CParseHandlerScalarArrayCoerceExpr(){};
+
+	};
+
+}
+#endif // GPDXL_CParseHandlerScalarArrayCoerceExpr_H
+
+//EOF

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarCoerceToDomain.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarCoerceToDomain.h
@@ -30,7 +30,7 @@ namespace gpdxl
 	//		CParseHandlerScalarCoerceToDomain
 	//
 	//	@doc:
-	//		Parse handler for parsing  parsing CoerceToDomain operator
+	//		Parse handler for parsing CoerceToDomain operator
 	//
 	//---------------------------------------------------------------------------
 	class CParseHandlerScalarCoerceToDomain : public CParseHandlerScalarOp

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarCoerceViaIO.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerScalarCoerceViaIO.h
@@ -36,7 +36,7 @@ namespace gpdxl
 	//		CParseHandlerScalarCoerceViaIO
 	//
 	//	@doc:
-	//		Parse handler for parsing  parsing CoerceViaIO operator
+	//		Parse handler for parsing CoerceViaIO operator
 	//
 	//---------------------------------------------------------------------------
 	class CParseHandlerScalarCoerceViaIO : public CParseHandlerScalarOp

--- a/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
+++ b/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
@@ -83,6 +83,7 @@
 #include "naucrates/dxl/parser/CParseHandlerScalarCast.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarCoerceToDomain.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarCoerceViaIO.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarSubquery.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarBitmapBoolOp.h"
 

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -163,6 +163,7 @@ namespace gpdxl
 		EdxltokenScalarCast,
 		EdxltokenScalarCoerceToDomain,
 		EdxltokenScalarCoerceViaIO,
+		EdxltokenScalarArrayCoerceExpr,
 		EdxltokenScalarSortCol,
 		EdxltokenScalarSortColList,
 		EdxltokenScalarGroupingColList,
@@ -260,10 +261,12 @@ namespace gpdxl
 		EdxltokenConstTuple,
 		EdxltokenDatum,
 
-		// CoerceToDomain and CoerceViaIO related tokens
+		// CoerceToDomain and CoerceViaIO and ArrayCoerceExpr related tokens
 		EdxltokenTypeMod,
 		EdxltokenCoercionForm,
 		EdxltokenLocation,
+		EdxltokenElementFunc,
+		EdxltokenIsExplicit,
 
 		EdxltokenJoinType,
 		EdxltokenJoinInner,

--- a/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1085,6 +1085,33 @@ CDXLOperatorFactory::PdxlopCoerceViaIO
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CDXLOperatorFactory::PdxlopArrayCoerceExpr
+//
+//	@doc:
+//		Construct a scalar array coerce expression
+//
+//---------------------------------------------------------------------------
+CDXLScalar *
+CDXLOperatorFactory::PdxlopArrayCoerceExpr
+	(
+	CDXLMemoryManager *pmm,
+	const Attributes &attrs
+	)
+{
+	IMemoryPool *pmp = pmm->Pmp();
+
+	IMDId *pmdidElementFunc = PmdidFromAttrs(pmm, attrs, EdxltokenElementFunc, EdxltokenScalarArrayCoerceExpr);
+	IMDId *pmdidType = PmdidFromAttrs(pmm, attrs, EdxltokenTypeId, EdxltokenScalarArrayCoerceExpr);
+	INT iMod = IValueFromAttrs(pmm, attrs, EdxltokenTypeMod, EdxltokenScalarArrayCoerceExpr);
+	BOOL fIsExplicit = FValueFromAttrs(pmm, attrs, EdxltokenIsExplicit, EdxltokenScalarArrayCoerceExpr);
+	ULONG ulCoercionForm = UlValueFromAttrs(pmm, attrs, EdxltokenCoercionForm, EdxltokenScalarArrayCoerceExpr);
+	INT iLoc = IValueFromAttrs(pmm, attrs, EdxltokenLocation, EdxltokenScalarArrayCoerceExpr);
+
+	return GPOS_NEW(pmp) CDXLScalarArrayCoerceExpr(pmp, pmdidElementFunc, pmdidType, iMod, fIsExplicit, (EdxlCoercionForm) ulCoercionForm, iLoc);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CDXLOperatorFactory::PdxlopConstValue
 //
 //	@doc:

--- a/libnaucrates/src/operators/CDXLScalarArrayCoerceExpr.cpp
+++ b/libnaucrates/src/operators/CDXLScalarArrayCoerceExpr.cpp
@@ -1,0 +1,165 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CDXLScalarArrayCoerceExpr.cpp
+//
+//	@doc:
+//		Implementation of DXL scalar array coerce expr
+//
+//	@owner:
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h"
+#include "naucrates/dxl/operators/CDXLNode.h"
+#include "naucrates/dxl/xml/dxltokens.h"
+#include "naucrates/dxl/xml/CXMLSerializer.h"
+
+#include "gpopt/mdcache/CMDAccessor.h"
+
+using namespace gpopt;
+using namespace gpos;
+using namespace gpdxl;
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarArrayCoerceExpr::CDXLScalarArrayCoerceExpr
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CDXLScalarArrayCoerceExpr::CDXLScalarArrayCoerceExpr
+	(
+	IMemoryPool *pmp,
+	IMDId *pmdidElementFunc,
+	IMDId *pmdidResultType,
+	INT iMod,
+	BOOL fIsExplicit,
+	EdxlCoercionForm edxlcf,
+	INT iLoc
+	)
+	:
+	CDXLScalar(pmp),
+	m_pmdidElementFunc(pmdidElementFunc),
+	m_pmdidResultType(pmdidResultType),
+	m_iMod(iMod),
+	m_fIsExplicit(fIsExplicit),
+	m_edxlcf(edxlcf),
+	m_iLoc(iLoc)
+{
+	GPOS_ASSERT(NULL != pmdidElementFunc);
+	GPOS_ASSERT(NULL != pmdidResultType);
+	GPOS_ASSERT(pmdidResultType->FValid());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarArrayCoerceExpr::~CDXLScalarArrayCoerceExpr
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CDXLScalarArrayCoerceExpr::~CDXLScalarArrayCoerceExpr()
+{
+	m_pmdidElementFunc->Release();
+	m_pmdidResultType->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarArrayCoerceExpr::FBoolean
+//
+//	@doc:
+//		Does the operator return a boolean result
+//
+//---------------------------------------------------------------------------
+BOOL
+CDXLScalarArrayCoerceExpr::FBoolean
+	(
+	CMDAccessor *pmda
+	)
+	const
+{
+	return (IMDType::EtiBool == pmda->Pmdtype(m_pmdidResultType)->Eti());
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarArrayCoerceExpr::PstrOpName
+//
+//	@doc:
+//		Operator name
+//
+//---------------------------------------------------------------------------
+const CWStringConst *
+CDXLScalarArrayCoerceExpr::PstrOpName() const
+{
+	return CDXLTokens::PstrToken(EdxltokenScalarArrayCoerceExpr);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarArrayCoerceExpr::SerializeToDXL
+//
+//	@doc:
+//		Serialize operator in DXL format
+//
+//---------------------------------------------------------------------------
+void
+CDXLScalarArrayCoerceExpr::SerializeToDXL
+	(
+	CXMLSerializer *pxmlser,
+	const CDXLNode *pdxln
+	)
+	const
+{
+	const CWStringConst *pstrElemName = PstrOpName();
+
+	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
+
+	m_pmdidElementFunc->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenElementFunc));
+	m_pmdidResultType->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenTypeId));
+
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenTypeMod), m_iMod);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenIsExplicit), m_fIsExplicit);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCoercionForm), (ULONG) m_edxlcf);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenLocation), m_iLoc);
+
+	pdxln->SerializeChildrenToDXL(pxmlser);
+	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
+}
+
+#ifdef GPOS_DEBUG
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarArrayCoerceExpr::AssertValid
+//
+//	@doc:
+//		Checks whether operator node is well-structured
+//
+//---------------------------------------------------------------------------
+void
+CDXLScalarArrayCoerceExpr::AssertValid
+	(
+	const CDXLNode *pdxln,
+	BOOL fValidateChildren
+	) const
+{
+	GPOS_ASSERT(1 == pdxln->UlArity());
+
+	CDXLNode *pdxlnChild = (*pdxln)[0];
+	GPOS_ASSERT(EdxloptypeScalar == pdxlnChild->Pdxlop()->Edxloperatortype());
+
+	if (fValidateChildren)
+	{
+		pdxlnChild->Pdxlop()->AssertValid(pdxlnChild, fValidateChildren);
+	}
+}
+#endif // GPOS_DEBUG
+// EOF

--- a/libnaucrates/src/operators/CDXLScalarArrayCoerceExpr.cpp
+++ b/libnaucrates/src/operators/CDXLScalarArrayCoerceExpr.cpp
@@ -19,8 +19,6 @@
 #include "naucrates/dxl/xml/dxltokens.h"
 #include "naucrates/dxl/xml/CXMLSerializer.h"
 
-#include "gpopt/mdcache/CMDAccessor.h"
-
 using namespace gpopt;
 using namespace gpos;
 using namespace gpdxl;
@@ -44,49 +42,11 @@ CDXLScalarArrayCoerceExpr::CDXLScalarArrayCoerceExpr
 	INT iLoc
 	)
 	:
-	CDXLScalar(pmp),
+	CDXLScalarCoerceBase(pmp, pmdidResultType, iMod, edxlcf, iLoc),
 	m_pmdidElementFunc(pmdidElementFunc),
-	m_pmdidResultType(pmdidResultType),
-	m_iMod(iMod),
-	m_fIsExplicit(fIsExplicit),
-	m_edxlcf(edxlcf),
-	m_iLoc(iLoc)
+	m_fIsExplicit(fIsExplicit)
 {
 	GPOS_ASSERT(NULL != pmdidElementFunc);
-	GPOS_ASSERT(NULL != pmdidResultType);
-	GPOS_ASSERT(pmdidResultType->FValid());
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarArrayCoerceExpr::~CDXLScalarArrayCoerceExpr
-//
-//	@doc:
-//		Dtor
-//
-//---------------------------------------------------------------------------
-CDXLScalarArrayCoerceExpr::~CDXLScalarArrayCoerceExpr()
-{
-	m_pmdidElementFunc->Release();
-	m_pmdidResultType->Release();
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarArrayCoerceExpr::FBoolean
-//
-//	@doc:
-//		Does the operator return a boolean result
-//
-//---------------------------------------------------------------------------
-BOOL
-CDXLScalarArrayCoerceExpr::FBoolean
-	(
-	CMDAccessor *pmda
-	)
-	const
-{
-	return (IMDType::EtiBool == pmda->Pmdtype(m_pmdidResultType)->Eti());
 }
 
 //---------------------------------------------------------------------------
@@ -124,42 +84,15 @@ CDXLScalarArrayCoerceExpr::SerializeToDXL
 	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
 
 	m_pmdidElementFunc->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenElementFunc));
-	m_pmdidResultType->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenTypeId));
+	PmdidResultType()->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenTypeId));
 
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenTypeMod), m_iMod);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenTypeMod), IMod());
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenIsExplicit), m_fIsExplicit);
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCoercionForm), (ULONG) m_edxlcf);
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenLocation), m_iLoc);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCoercionForm), (ULONG) Edxlcf());
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenLocation), ILoc());
 
 	pdxln->SerializeChildrenToDXL(pxmlser);
 	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
 }
 
-#ifdef GPOS_DEBUG
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarArrayCoerceExpr::AssertValid
-//
-//	@doc:
-//		Checks whether operator node is well-structured
-//
-//---------------------------------------------------------------------------
-void
-CDXLScalarArrayCoerceExpr::AssertValid
-	(
-	const CDXLNode *pdxln,
-	BOOL fValidateChildren
-	) const
-{
-	GPOS_ASSERT(1 == pdxln->UlArity());
-
-	CDXLNode *pdxlnChild = (*pdxln)[0];
-	GPOS_ASSERT(EdxloptypeScalar == pdxlnChild->Pdxlop()->Edxloperatortype());
-
-	if (fValidateChildren)
-	{
-		pdxlnChild->Pdxlop()->AssertValid(pdxlnChild, fValidateChildren);
-	}
-}
-#endif // GPOS_DEBUG
 // EOF

--- a/libnaucrates/src/operators/CDXLScalarCoerceBase.cpp
+++ b/libnaucrates/src/operators/CDXLScalarCoerceBase.cpp
@@ -1,0 +1,147 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Inc.
+//
+//	@filename:
+//		CDXLScalarCoerceBase.cpp
+//
+//	@doc:
+//		Implementation of DXL scalar coerce base class
+//
+//	@owner:
+//
+//	@test:
+//
+//
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/operators/CDXLScalarCoerceBase.h"
+#include "naucrates/dxl/operators/CDXLNode.h"
+#include "naucrates/dxl/xml/dxltokens.h"
+#include "naucrates/dxl/xml/CXMLSerializer.h"
+
+#include "gpopt/mdcache/CMDAccessor.h"
+
+using namespace gpopt;
+using namespace gpos;
+using namespace gpdxl;
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarCoerceBase::CDXLScalarCoerceBase
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CDXLScalarCoerceBase::CDXLScalarCoerceBase
+	(
+	IMemoryPool *pmp,
+	IMDId *pmdidType,
+	INT iMod,
+	EdxlCoercionForm edxlcf,
+	INT iLoc
+	)
+	:
+	CDXLScalar(pmp),
+	m_pmdidResultType(pmdidType),
+	m_iMod(iMod),
+	m_edxlcf(edxlcf),
+	m_iLoc(iLoc)
+{
+	GPOS_ASSERT(NULL != pmdidType);
+	GPOS_ASSERT(pmdidType->FValid());
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarCoerceBase::~CDXLScalarCoerceBase
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CDXLScalarCoerceBase::~CDXLScalarCoerceBase()
+{
+	m_pmdidResultType->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarCoerceBase::SerializeToDXL
+//
+//	@doc:
+//		Serialize operator in DXL format
+//
+//---------------------------------------------------------------------------
+void
+CDXLScalarCoerceBase::SerializeToDXL
+	(
+	CXMLSerializer *pxmlser,
+	const CDXLNode *pdxln
+	)
+	const
+{
+	const CWStringConst *pstrElemName = PstrOpName();
+
+	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
+
+	m_pmdidResultType->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenTypeId));
+
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenTypeMod), m_iMod);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCoercionForm), (ULONG) m_edxlcf);
+	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenLocation), m_iLoc);
+
+	pdxln->SerializeChildrenToDXL(pxmlser);
+	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarCoerceBase::FBoolean
+//
+//	@doc:
+//		Does the operator return a boolean result
+//
+//---------------------------------------------------------------------------
+BOOL
+CDXLScalarCoerceBase::FBoolean
+	(
+	CMDAccessor *pmda
+	)
+	const
+{
+	return (IMDType::EtiBool == pmda->Pmdtype(m_pmdidResultType)->Eti());
+}
+
+#ifdef GPOS_DEBUG
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLScalarCoerceBase::AssertValid
+//
+//	@doc:
+//		Checks whether operator node is well-structured
+//
+//---------------------------------------------------------------------------
+void
+CDXLScalarCoerceBase::AssertValid
+	(
+	const CDXLNode *pdxln,
+	BOOL fValidateChildren
+	) const
+{
+	GPOS_ASSERT(1 == pdxln->UlArity());
+
+	CDXLNode *pdxlnChild = (*pdxln)[0];
+	GPOS_ASSERT(EdxloptypeScalar == pdxlnChild->Pdxlop()->Edxloperatortype());
+
+	if (fValidateChildren)
+	{
+		pdxlnChild->Pdxlop()->AssertValid(pdxlnChild, fValidateChildren);
+	}
+}
+#endif // GPOS_DEBUG
+
+// EOF

--- a/libnaucrates/src/operators/CDXLScalarCoerceToDomain.cpp
+++ b/libnaucrates/src/operators/CDXLScalarCoerceToDomain.cpp
@@ -10,11 +10,7 @@
 //---------------------------------------------------------------------------
 
 #include "naucrates/dxl/operators/CDXLScalarCoerceToDomain.h"
-#include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/dxl/xml/dxltokens.h"
-#include "naucrates/dxl/xml/CXMLSerializer.h"
-
-#include "gpopt/mdcache/CMDAccessor.h"
 
 using namespace gpopt;
 using namespace gpos;
@@ -37,28 +33,8 @@ CDXLScalarCoerceToDomain::CDXLScalarCoerceToDomain
 	INT iLoc
 	)
 	:
-	CDXLScalar(pmp),
-	m_pmdidResultType(pmdidType),
-	m_iMod(iMod),
-	m_edxlcf(edxlcf),
-	m_iLoc(iLoc)
+	CDXLScalarCoerceBase(pmp, pmdidType, iMod, edxlcf, iLoc)
 {
-	GPOS_ASSERT(NULL != pmdidType);
-	GPOS_ASSERT(pmdidType->FValid());
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceToDomain::~CDXLScalarCoerceToDomain
-//
-//	@doc:
-//		Dtor
-//
-//---------------------------------------------------------------------------
-CDXLScalarCoerceToDomain::~CDXLScalarCoerceToDomain()
-{
-	m_pmdidResultType->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -74,82 +50,5 @@ CDXLScalarCoerceToDomain::PstrOpName() const
 {
 	return CDXLTokens::PstrToken(EdxltokenScalarCoerceToDomain);
 }
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceToDomain::SerializeToDXL
-//
-//	@doc:
-//		Serialize operator in DXL format
-//
-//---------------------------------------------------------------------------
-void
-CDXLScalarCoerceToDomain::SerializeToDXL
-	(
-	CXMLSerializer *pxmlser,
-	const CDXLNode *pdxln
-	)
-	const
-{
-	const CWStringConst *pstrElemName = PstrOpName();
-
-	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
-
-	m_pmdidResultType->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenTypeId));
-
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenTypeMod), m_iMod);
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCoercionForm), (ULONG) m_edxlcf);
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenLocation), m_iLoc);
-
-	pdxln->SerializeChildrenToDXL(pxmlser);
-	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceToDomain::FBoolean
-//
-//	@doc:
-//		Does the operator return a boolean result
-//
-//---------------------------------------------------------------------------
-BOOL
-CDXLScalarCoerceToDomain::FBoolean
-	(
-	CMDAccessor *pmda
-	)
-	const
-{
-	return (IMDType::EtiBool == pmda->Pmdtype(m_pmdidResultType)->Eti());
-}
-
-#ifdef GPOS_DEBUG
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceToDomain::AssertValid
-//
-//	@doc:
-//		Checks whether operator node is well-structured
-//
-//---------------------------------------------------------------------------
-void
-CDXLScalarCoerceToDomain::AssertValid
-	(
-	const CDXLNode *pdxln,
-	BOOL fValidateChildren
-	) const
-{
-	GPOS_ASSERT(1 == pdxln->UlArity());
-
-	CDXLNode *pdxlnChild = (*pdxln)[0];
-	GPOS_ASSERT(EdxloptypeScalar == pdxlnChild->Pdxlop()->Edxloperatortype());
-
-	if (fValidateChildren)
-	{
-		pdxlnChild->Pdxlop()->AssertValid(pdxlnChild, fValidateChildren);
-	}
-}
-#endif // GPOS_DEBUG
 
 // EOF

--- a/libnaucrates/src/operators/CDXLScalarCoerceViaIO.cpp
+++ b/libnaucrates/src/operators/CDXLScalarCoerceViaIO.cpp
@@ -16,11 +16,7 @@
 //---------------------------------------------------------------------------
 
 #include "naucrates/dxl/operators/CDXLScalarCoerceViaIO.h"
-#include "naucrates/dxl/operators/CDXLNode.h"
 #include "naucrates/dxl/xml/dxltokens.h"
-#include "naucrates/dxl/xml/CXMLSerializer.h"
-
-#include "gpopt/mdcache/CMDAccessor.h"
 
 using namespace gpopt;
 using namespace gpos;
@@ -43,28 +39,8 @@ CDXLScalarCoerceViaIO::CDXLScalarCoerceViaIO
 	INT iLoc
 	)
 	:
-	CDXLScalar(pmp),
-	m_pmdidResultType(pmdidType),
-	m_iMod(iMod),
-	m_edxlcf(edxlcf),
-	m_iLoc(iLoc)
+	CDXLScalarCoerceBase(pmp, pmdidType, iMod, edxlcf, iLoc)
 {
-	GPOS_ASSERT(NULL != pmdidType);
-	GPOS_ASSERT(pmdidType->FValid());
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceViaIO::~CDXLScalarCoerceViaIO
-//
-//	@doc:
-//		Dtor
-//
-//---------------------------------------------------------------------------
-CDXLScalarCoerceViaIO::~CDXLScalarCoerceViaIO()
-{
-	m_pmdidResultType->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -80,82 +56,5 @@ CDXLScalarCoerceViaIO::PstrOpName() const
 {
 	return CDXLTokens::PstrToken(EdxltokenScalarCoerceViaIO);
 }
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceViaIO::SerializeToDXL
-//
-//	@doc:
-//		Serialize operator in DXL format
-//
-//---------------------------------------------------------------------------
-void
-CDXLScalarCoerceViaIO::SerializeToDXL
-	(
-	CXMLSerializer *pxmlser,
-	const CDXLNode *pdxln
-	)
-	const
-{
-	const CWStringConst *pstrElemName = PstrOpName();
-
-	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
-
-	m_pmdidResultType->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenTypeId));
-
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenTypeMod), m_iMod);
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenCoercionForm), (ULONG) m_edxlcf);
-	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenLocation), m_iLoc);
-
-	pdxln->SerializeChildrenToDXL(pxmlser);
-	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceViaIO::FBoolean
-//
-//	@doc:
-//		Does the operator return a boolean result
-//
-//---------------------------------------------------------------------------
-BOOL
-CDXLScalarCoerceViaIO::FBoolean
-	(
-	CMDAccessor *pmda
-	)
-	const
-{
-	return (IMDType::EtiBool == pmda->Pmdtype(m_pmdidResultType)->Eti());
-}
-
-#ifdef GPOS_DEBUG
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLScalarCoerceViaIO::AssertValid
-//
-//	@doc:
-//		Checks whether operator node is well-structured
-//
-//---------------------------------------------------------------------------
-void
-CDXLScalarCoerceViaIO::AssertValid
-	(
-	const CDXLNode *pdxln,
-	BOOL fValidateChildren
-	) const
-{
-	GPOS_ASSERT(1 == pdxln->UlArity());
-
-	CDXLNode *pdxlnChild = (*pdxln)[0];
-	GPOS_ASSERT(EdxloptypeScalar == pdxlnChild->Pdxlop()->Edxloperatortype());
-
-	if (fValidateChildren)
-	{
-		pdxlnChild->Pdxlop()->AssertValid(pdxlnChild, fValidateChildren);
-	}
-}
-#endif // GPOS_DEBUG
 
 // EOF

--- a/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -185,6 +185,7 @@ CParseHandlerFactory::Init
 			{EdxltokenScalarCast, &PphScalarCast},
 			{EdxltokenScalarCoerceToDomain, PphScalarCoerceToDomain},
 			{EdxltokenScalarCoerceViaIO, PphScalarCoerceViaIO},
+			{EdxltokenScalarArrayCoerceExpr, PphScalarArrayCoerceExpr},
 			{EdxltokenScalarHashExpr, &PphHashExpr},
 			{EdxltokenScalarHashCondList, &PphCondList},
 			{EdxltokenScalarMergeCondList, &PphCondList},
@@ -2030,6 +2031,25 @@ CParseHandlerFactory::PphScalarCoerceViaIO
 	)
 {
 	return GPOS_NEW(pmp) CParseHandlerScalarCoerceViaIO(pmp, pphm, pphRoot);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerFactory::PphScalarArrayCoerceExpr
+//
+//	@doc:
+//		Creates a parse handler for parsing an array coerce expression operator
+//
+//---------------------------------------------------------------------------
+CParseHandlerBase *
+CParseHandlerFactory::PphScalarArrayCoerceExpr
+	(
+	IMemoryPool *pmp,
+	CParseHandlerManager *pphm,
+	CParseHandlerBase *pphRoot
+	)
+{
+	return GPOS_NEW(pmp) CParseHandlerScalarArrayCoerceExpr(pmp, pphm, pphRoot);
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/parser/CParseHandlerScalarArrayCoerceExpr.cpp
+++ b/libnaucrates/src/parser/CParseHandlerScalarArrayCoerceExpr.cpp
@@ -1,0 +1,126 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2014 Pivotal Inc.
+//
+//	@filename:
+//		CParseHandlerScalarArrayCoerceExpr.cpp
+//
+//	@doc:
+//
+//		Implementation of the SAX parse handler class for parsing scalar array coerce expression operator.
+//
+//	@owner:
+//
+//	@test:
+//
+//
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+#include "naucrates/dxl/parser/CParseHandlerFactory.h"
+#include "naucrates/dxl/CDXLUtils.h"
+#include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+
+#include "naucrates/dxl/parser/CParseHandlerScalarArrayCoerceExpr.h"
+
+
+using namespace gpdxl;
+
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerScalarArrayCoerceExpr::CParseHandlerScalarArrayCoerceExpr
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CParseHandlerScalarArrayCoerceExpr::CParseHandlerScalarArrayCoerceExpr
+	(
+	IMemoryPool *pmp,
+	CParseHandlerManager *pphm,
+	CParseHandlerBase *pphRoot
+	)
+	:
+	CParseHandlerScalarOp(pmp, pphm, pphRoot)
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerScalarArrayCoerceExpr::StartElement
+//
+//	@doc:
+//		Processes a Xerces start element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerScalarArrayCoerceExpr::StartElement
+	(
+	const XMLCh* const, // xmlszUri,
+	const XMLCh* const xmlszLocalname,
+	const XMLCh* const, // xmlszQname
+	const Attributes& attrs
+	)
+{
+	if(0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenScalarArrayCoerceExpr), xmlszLocalname))
+	{
+		if (NULL != m_pdxln)
+		{
+			CWStringDynamic *pstr = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), xmlszLocalname);
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, pstr->Wsz());
+		}
+
+		// parse and create scalar coerce
+		CDXLScalarArrayCoerceExpr *pdxlop = (CDXLScalarArrayCoerceExpr*) CDXLOperatorFactory::PdxlopArrayCoerceExpr(m_pphm->Pmm(), attrs);
+
+		m_pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlop);
+
+		// parse handler for child scalar node
+		CParseHandlerBase *pphChild = CParseHandlerFactory::Pph(m_pmp, CDXLTokens::XmlstrToken(EdxltokenScalar), m_pphm, this);
+		m_pphm->ActivateParseHandler(pphChild);
+
+		// store parse handler
+		this->Append(pphChild);
+	}
+	else
+	{
+		CWStringDynamic *pstr = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), xmlszLocalname);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, pstr->Wsz());
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerScalarArrayCoerceExpr::EndElement
+//
+//	@doc:
+//		Processes a Xerces end element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerScalarArrayCoerceExpr::EndElement
+	(
+	const XMLCh* const, // xmlszUri,
+	const XMLCh* const xmlszLocalname,
+	const XMLCh* const // xmlszQname
+	)
+{
+	if(0 != XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenScalarArrayCoerceExpr), xmlszLocalname))
+	{
+		CWStringDynamic *pstr = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), xmlszLocalname);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, pstr->Wsz());
+	}
+	GPOS_ASSERT(1 == this->UlLength());
+
+	// add constructed child from child parse handlers
+	CParseHandlerScalarOp *pphChild = dynamic_cast<CParseHandlerScalarOp*>((*this)[0]);
+	AddChildFromParseHandler(pphChild);
+
+	// deactivate handler
+	m_pphm->DeactivateHandler();
+}
+
+// EOF

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -205,6 +205,7 @@ CDXLTokens::Init
 			{EdxltokenScalarCast, GPOS_WSZ_LIT("Cast")},
 			{EdxltokenScalarCoerceToDomain, GPOS_WSZ_LIT("CoerceToDomain")},
 			{EdxltokenScalarCoerceViaIO, GPOS_WSZ_LIT("CoerceViaIO")},
+			{EdxltokenScalarArrayCoerceExpr, GPOS_WSZ_LIT("ArrayCoerceExpr")},
 			{EdxltokenScalarSortCol, GPOS_WSZ_LIT("SortingColumn")},
 			{EdxltokenScalarSortColList, GPOS_WSZ_LIT("SortingColumnList")},
 			{EdxltokenScalarGroupingColList, GPOS_WSZ_LIT("GroupingColumns")},
@@ -267,6 +268,8 @@ CDXLTokens::Init
 			{EdxltokenTypeMod, GPOS_WSZ_LIT("TypeModification")},
 			{EdxltokenCoercionForm, GPOS_WSZ_LIT("CoercionForm")},
 			{EdxltokenLocation, GPOS_WSZ_LIT("Location")},
+			{EdxltokenElementFunc, GPOS_WSZ_LIT("ElementFunc")},
+			{EdxltokenIsExplicit, GPOS_WSZ_LIT("IsExplicit")},
 
 			{EdxltokenJoinType, GPOS_WSZ_LIT("JoinType")},
 			{EdxltokenJoinInner, GPOS_WSZ_LIT("Inner")},

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -40,6 +40,7 @@ ULONG CICGTest::m_ulNegativeIndexApplyTestCounter = 0;
 // minidump files
 const CHAR *rgszFileNames[] =
 	{
+		"../data/dxl/minidump/ArrayCoerceExpr.mdp",
 		"../data/dxl/minidump/DisableLargeTableBroadcast.mdp",
 		"../data/dxl/minidump/InferPredicatesForLimit.mdp",
 		"../data/dxl/minidump/OR-WithIsNullPred.mdp",


### PR DESCRIPTION
`ARRAYCOERCEEXPR` is a new added operator when merging with pg8.3. This patch add the scalar operator `CScalarArrayCoerceExpr` to handle the new expression type in GPDB 5.

Also we refactored the coerce operators and corresponding DXL nodes to inherit a base class to reuse most of the common functions.