### PR TITLE
Add config.h, for options that affect binary compatibility.

### DIFF
--- a/libgpdbcost/CMakeLists.txt
+++ b/libgpdbcost/CMakeLists.txt
@@ -3,6 +3,8 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libgpopt/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libnaucrates/include)
+# for the generated config.h file.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
 add_library(gpdbcost
             include/gpdbcost/CCostModelGPDB.h
             src/CCostModelGPDB.cpp

--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -8,6 +8,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libnaucrates/include)
 configure_file(version.h.in
         ${PROJECT_BINARY_DIR}/libgpopt/include/libgpopt/version.h)
 
+# for the generated config.h file.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
+
 add_library(gpopt
             include/gpopt/base/CDistributionSpec.h
             include/gpopt/base/CDistributionSpecAny.h

--- a/libgpos/CMakeLists.txt
+++ b/libgpos/CMakeLists.txt
@@ -17,6 +17,12 @@ endif()
 
 include_directories(include)
 
+configure_file(config.h.in
+        ${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h)
+
+# for the generated config.h file.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
+
 # Compile .cpp source files under libgpos/src into monolithic gpos library.
 add_library(gpos
             include/gpos/assert.h
@@ -280,9 +286,11 @@ if (VERBOSE_INSTALL_PATH)
   get_filename_component(full_install_name_dir "${installpath}/lib" ABSOLUTE)
   install(TARGETS gpos DESTINATION "${installpath}/lib")
   install(DIRECTORY include/gpos DESTINATION "${installpath}/include")
+  install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h" DESTINATION "${installpath}/include/gpos")
 else()
   get_filename_component(full_install_name_dir "${CMAKE_INSTALL_PREFIX}/lib" ABSOLUTE)
   install(TARGETS gpos DESTINATION lib)
   install(DIRECTORY include/gpos DESTINATION include)
+  install(FILES "${PROJECT_BINARY_DIR}/libgpos/include/gpos/config.h" DESTINATION include/gpos)
 endif()
 

--- a/libgpos/config.h.in
+++ b/libgpos/config.h.in
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2016 Greenplum, Inc.
+//
+//	@filename:
+//		config.h
+//
+//	@doc:
+//		Various compile-time options that affect binary
+//		compatibility.
+//
+//---------------------------------------------------------------------------
+#ifndef GPOS_config_H
+#define GPOS_config_H
+
+#cmakedefine GPOS_DEBUG
+
+// These come from CMAKE_SYSTEM_PROCESSOR
+#cmakedefine GPOS_i386
+#cmakedefine GPOS_i686
+#cmakedefine GPOS_x86_64
+#cmakedefine GPOS_sparc
+
+// These come from CMAKE_ARCH_BITS (based on CMAKE_SIZEOF_VOID_P)
+#cmakedefine GPOS_32BIT
+#cmakedefine GPOS_64BIT
+
+#endif  // GPOS_config_Hve
+// EOF

--- a/libgpos/include/gpos/_api.h
+++ b/libgpos/include/gpos/_api.h
@@ -17,6 +17,8 @@
 #ifndef GPOS_api_H
 #define GPOS_api_H
 
+#include "gpos/config.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/libgpos/include/gpos/assert.h
+++ b/libgpos/include/gpos/assert.h
@@ -22,6 +22,7 @@
 #ifndef GPOS_assert_H
 #define GPOS_assert_H
 
+#include "gpos/config.h"
 
 // retail assert; available in all builds
 #define GPOS_RTL_ASSERT(x)		((x) ? ((void)0) : \

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -3,6 +3,9 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libgpopt/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libgpdbcost/include)
+# for the generated config.h file.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
+
 add_library(naucrates
             include/naucrates/base/IDatum.h
             include/naucrates/base/IDatumBool.h

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/libgpdbcost/include"
                     "${CMAKE_SOURCE_DIR}/libgpopt/include"
                     "${CMAKE_SOURCE_DIR}/libnaucrates/include")
+# for the generated config.h file.
+include_directories(${PROJECT_BINARY_DIR}/libgpos/include/)
 
 # Some tests use C99 long long integer constants, but the C++ dialect may not
 # explicitly include C99. We supress such errors here.


### PR DESCRIPTION
Before this patch, consumers of ORCA had to know out-of-band which
flags were used to compile ORCA, because e.g. ORCA compiled with
GPOS_DEBUG would only work if the application using ORCA was also
compiled with GPOS_DEBUG. This is because many of the structs differ
depending on GPOS_DEBUG. Same for the architecture flags, like GPOS_i386.

The new config.h file is #included from a few central other header files,
to make sure it gets included in any application that uses other gpos
headers. We probably should include config.h from all other gpos header
files, to be sure, but this seems to be enough for ORCA itself and GPDB at
least.