### PR TITLE
Append `.0` to version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project(gpopt LANGUAGES CXX C)
 
 set(GPORCA_VERSION_MAJOR 2)
 set(GPORCA_VERSION_MINOR 2)
-set(GPORCA_VERSION_STRING ${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR})
+set(GPORCA_VERSION_PATCH_DONT_BUMP_ME 0)
+set(GPORCA_VERSION_STRING "${GPORCA_VERSION_MAJOR}.${GPORCA_VERSION_MINOR}.${GPORCA_VERSION_PATCH_DONT_BUMP_ME}")
 
 # Whenever an ABI-breaking change is made to GPORCA, this should be incremented.
 # ABI changes include removing functions, and adding or removing function


### PR DESCRIPTION
This patch adds a `.0` (or as they call it over semver.org, the "patch"
number) to our version. This makes our version semver-compliant. It also
makes it abundantly clear that our version number (say `2.1.0`) is not a
decimal floating point number. ("What is newer? 2.2 or 2.19?")

N.B. our practice is only bumping the minor and major version numbers.
This change doesn't not signal a change in that practice.

I'm also hiding this commit from CI so that it only impacts the next
push (so it will be, say, `2.2.0` if we are currently on `2.1`).
[ci skip]