### PR TITLE
Fix populating config.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,16 +94,15 @@ endif()
 
 # Turn on GPOS_DEBUG define for DEBUG builds.
 cmake_policy(SET CMP0043 NEW)
-set_property(
-    DIRECTORY
-    APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:GPOS_DEBUG>)
+
+STRING(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+if (CMAKE_BUILD_TYPE_LOWER STREQUAL  "debug")
+  set(GPOS_DEBUG 1)
+endif()
 
 # Turn on platform-specific defines.
-set_property(
-    DIRECTORY
-    APPEND PROPERTY COMPILE_DEFINITIONS
-        GPOS_${CMAKE_SYSTEM_NAME}
-        GPOS_${CMAKE_SYSTEM_PROCESSOR})
+set(GPOS_${CMAKE_SYSTEM_NAME} 1)
+set(GPOS_${CMAKE_SYSTEM_PROCESSOR} 1)
 
 # Autodetect bit-width if not already set by toolchain file.
 if (NOT GPOS_ARCH_BITS)
@@ -117,10 +116,7 @@ if (NOT GPOS_ARCH_BITS)
   endif()
 endif()
 
-set_property(
-    DIRECTORY
-    APPEND PROPERTY COMPILE_DEFINITIONS
-        GPOS_${GPOS_ARCH_BITS}BIT)
+set (GPOS_${GPOS_ARCH_BITS}BIT 1)
 
 # Library dependencies for optimizer.
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/cmake/FindAtomics.cmake
+++ b/cmake/FindAtomics.cmake
@@ -16,13 +16,7 @@ int main() {
 
   return static_cast<int>(prev);
 }
-" COMPILER_HAS_FETCH_ADD_32)
-if (COMPILER_HAS_FETCH_ADD_32)
-  set_property(
-      DIRECTORY
-      APPEND PROPERTY COMPILE_DEFINITIONS
-          GPOS_GCC_FETCH_ADD_32)
-endif()
+" GPOS_GCC_FETCH_ADD_32)
 
 CHECK_CXX_SOURCE_COMPILES("
 #include <stdint.h>
@@ -34,13 +28,7 @@ int main() {
 
   return static_cast<int>(prev);
 }
-" COMPILER_HAS_FETCH_ADD_64)
-if (COMPILER_HAS_FETCH_ADD_64)
-  set_property(
-      DIRECTORY
-      APPEND PROPERTY COMPILE_DEFINITIONS
-          GPOS_GCC_FETCH_ADD_64)
-endif()
+" GPOS_GCC_FETCH_ADD_64)
 
 CHECK_CXX_SOURCE_COMPILES("
 #include <stdint.h>
@@ -53,13 +41,7 @@ int main() {
 
   return success ? 0 : 1;
 }
-" COMPILER_HAS_CAS_32)
-if (COMPILER_HAS_CAS_32)
-  set_property(
-      DIRECTORY
-      APPEND PROPERTY COMPILE_DEFINITIONS
-          GPOS_GCC_CAS_32)
-endif()
+" GPOS_GCC_CAS_32)
 
 CHECK_CXX_SOURCE_COMPILES("
 #include <stdint.h>
@@ -72,10 +54,4 @@ int main() {
 
   return success ? 0 : 1;
 }
-" COMPILER_HAS_CAS_64)
-if (COMPILER_HAS_CAS_64)
-  set_property(
-      DIRECTORY
-      APPEND PROPERTY COMPILE_DEFINITIONS
-          GPOS_GCC_CAS_64)
-endif()
+" GPOS_GCC_CAS_64)

--- a/libgpos/CMakeLists.txt
+++ b/libgpos/CMakeLists.txt
@@ -7,8 +7,8 @@ endif()
 # Try to find atomic operations.
 include(FindAtomics)
 
-if ((NOT (COMPILER_HAS_FETCH_ADD_32 AND COMPILER_HAS_FETCH_ADD_64
-          AND COMPILER_HAS_CAS_32 AND COMPILER_HAS_CAS_64))
+if ((NOT (GPOS_GCC_FETCH_ADD_32 AND GPOS_GCC_FETCH_ADD_64
+          AND GPOS_GCC_CAS_32 AND GPOS_GCC_CAS_64))
     AND (NOT (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")))
   message(FATAL_ERROR "Could not find GCC-style atomic built-ins or Solaris "
                       "atomic headers. GPOS will fail to build. Please try "

--- a/libgpos/config.h.in
+++ b/libgpos/config.h.in
@@ -25,6 +25,11 @@
 #cmakedefine GPOS_32BIT 1
 #cmakedefine GPOS_64BIT 1
 
+// These come from CMAKE_SYSTEM_NAME
+#cmakedefine GPOS_Linux
+#cmakedefine GPOS_Darwin
+#cmakedefine GPOS_SunOS
+
 // Atomics, detected by cmake/FindAtomics.cmake
 #cmakedefine GPOS_GCC_FETCH_ADD_32
 #cmakedefine GPOS_GCC_FETCH_ADD_64

--- a/libgpos/config.h.in
+++ b/libgpos/config.h.in
@@ -16,14 +16,20 @@
 #cmakedefine GPOS_DEBUG
 
 // These come from CMAKE_SYSTEM_PROCESSOR
-#cmakedefine GPOS_i386
-#cmakedefine GPOS_i686
-#cmakedefine GPOS_x86_64
-#cmakedefine GPOS_sparc
+#cmakedefine GPOS_i386 1
+#cmakedefine GPOS_i686 1
+#cmakedefine GPOS_x86_64 1
+#cmakedefine GPOS_sparc 1
 
 // These come from CMAKE_ARCH_BITS (based on CMAKE_SIZEOF_VOID_P)
-#cmakedefine GPOS_32BIT
-#cmakedefine GPOS_64BIT
+#cmakedefine GPOS_32BIT 1
+#cmakedefine GPOS_64BIT 1
+
+// Atomics, detected by cmake/FindAtomics.cmake
+#cmakedefine GPOS_GCC_FETCH_ADD_32
+#cmakedefine GPOS_GCC_FETCH_ADD_64
+#cmakedefine GPOS_GCC_CAS_32
+#cmakedefine GPOS_GCC_CAS_64
 
 #endif  // GPOS_config_H
 // EOF


### PR DESCRIPTION
Commmit 76af81942a, to generate a config.h with all the required GPOS_*
flags that affect the API of the resulting binaries, most notably
GPOS_DEBUG, was broken. It didn't derive the GPOS_DEBUG flag from
from CMAKE_BUILD_TYPE sit should've. It did the right thing if you set
"GPOS_DEBUG=1" property on the cmake command line, but that property was
not set automatically with CMAKE_BUILD_TYPE=Debug. CMAKE_BUILD_TYPE=Debug
added GPOS_DEBUG=1 to the COMPILE_DEFINITIONS property, but that's different
from having a stand-along GPOS_DEBUG property.

Likewise, the GPOS_<arch> and GPOS_32BIT/64BIT variables were also not set
correctly. The reason I didn't notice this while testing was that the
flags in COMPILE_DEFINITIONS were still set, even though if config.h was
generated correctly, those would not have been necessary aynmore.

To fix, remove those flags from COMPILE_DEFINITIONS so that they are not
passed to the compiler command line anymore. The defines are now always
read from the config.h file, and the defines are set correctly in config.h.

Per report off-list by Jesse Zhang.