### PR TITLE
[#139042295] Dedup constraints in linear time

### DIFF
--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -95,6 +95,10 @@ add_library(gpopt
 
             include/gpopt/base/CAutoOptCtxt.h
             src/base/CAutoOptCtxt.cpp
+            include/gpopt/base/CColConstraintsArrayMapper.h
+            src/base/CColConstraintsArrayMapper.cpp
+            include/gpopt/base/CColConstraintsHashMapper.h
+            src/base/CColConstraintsHashMapper.cpp
             include/gpopt/base/CColRef.h
             src/base/CColRef.cpp
             include/gpopt/base/CColRefComputed.h
@@ -211,6 +215,8 @@ add_library(gpopt
             src/base/CUtils.cpp
             include/gpopt/base/CWindowFrame.h
             src/base/CWindowFrame.cpp
+            include/gpopt/base/IColConstraintsMapper.h
+            src/base/IColConstraintsMapper.cpp
             include/gpopt/engine/CEngine.h
             src/engine/CEngine.cpp
             include/gpopt/engine/CEnumeratorConfig.h

--- a/libgpopt/include/gpopt/base/CColConstraintsArrayMapper.h
+++ b/libgpopt/include/gpopt/base/CColConstraintsArrayMapper.h
@@ -1,0 +1,32 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#ifndef GPOPT_CColConstraintsArrayMapper_H
+#define GPOPT_CColConstraintsArrayMapper_H
+
+#include "gpos/memory/IMemoryPool.h"
+
+#include "gpopt/base/CConstraint.h"
+#include "gpopt/base/IColConstraintsMapper.h"
+
+namespace gpopt
+{
+	class CColConstraintsArrayMapper : public IColConstraintsMapper
+	{
+		public:
+			CColConstraintsArrayMapper
+				(
+				gpos::IMemoryPool *pmp,
+				DrgPcnstr *pdrgpcnstr
+				);
+			virtual DrgPcnstr *PdrgPcnstrLookup(CColRef *pcr);
+
+			virtual ~CColConstraintsArrayMapper();
+
+		private:
+			gpos::IMemoryPool *m_pmp;
+			DrgPcnstr *m_pdrgpcnstr;
+	};
+}
+
+#endif //GPOPT_CColConstraintsArrayMapper_H

--- a/libgpopt/include/gpopt/base/CColConstraintsHashMapper.h
+++ b/libgpopt/include/gpopt/base/CColConstraintsHashMapper.h
@@ -1,0 +1,31 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#ifndef GPOPT_CColConstraintsHashMapper_H
+#define GPOPT_CColConstraintsHashMapper_H
+
+#include "gpos/memory/IMemoryPool.h"
+
+#include "gpopt/base/CConstraint.h"
+#include "gpopt/base/IColConstraintsMapper.h"
+
+namespace gpopt
+{
+	class CColConstraintsHashMapper : public IColConstraintsMapper
+	{
+		public:
+			CColConstraintsHashMapper
+				(
+					IMemoryPool *pmp,
+					DrgPcnstr *pdrgPcnstr
+				);
+
+			virtual DrgPcnstr *PdrgPcnstrLookup(CColRef *pcr);
+			virtual ~CColConstraintsHashMapper();
+
+		private:
+			HMColConstr *m_phmColConstr;
+	};
+}
+
+#endif //GPOPT_CColConstraintsHashMapper_H

--- a/libgpopt/include/gpopt/base/CConstraint.h
+++ b/libgpopt/include/gpopt/base/CConstraint.h
@@ -143,6 +143,9 @@ namespace gpopt
 			// mapping between columns and arrays of constraints
 			HMColConstr *Phmcolconstr(IMemoryPool *pmp, CColRefSet *pcrs, DrgPcnstr *pdrgpcnstr) const;
 
+			// mapping between columns and single column constraints in array of constraints
+			HMColConstr *PhmcolconstrSingleColConstr(IMemoryPool *pmp, DrgPcnstr *pdrgpcnstr) const;
+
 			// return a copy of the conjunction/disjunction constraint for a different column
 			CConstraint *PcnstrConjDisjRemapForColumn
 							(

--- a/libgpopt/include/gpopt/base/CConstraint.h
+++ b/libgpopt/include/gpopt/base/CConstraint.h
@@ -143,9 +143,6 @@ namespace gpopt
 			// mapping between columns and arrays of constraints
 			HMColConstr *Phmcolconstr(IMemoryPool *pmp, CColRefSet *pcrs, DrgPcnstr *pdrgpcnstr) const;
 
-			// mapping between columns and single column constraints in array of constraints
-			HMColConstr *PhmcolconstrSingleColConstr(IMemoryPool *pmp, DrgPcnstr *pdrgpcnstr) const;
-
 			// return a copy of the conjunction/disjunction constraint for a different column
 			CConstraint *PcnstrConjDisjRemapForColumn
 							(
@@ -155,10 +152,6 @@ namespace gpopt
 							BOOL fConj
 							)
 							const;
-
-			// subset of the given constraints, which reference the given column
-			static
-			DrgPcnstr *PdrgpcnstrOnColumn(IMemoryPool *pmp, DrgPcnstr *pdrgpcnstr, CColRef *pcr, BOOL fExclusive);
 
 			// create constraint from scalar array comparison expression
 			static
@@ -271,6 +264,10 @@ namespace gpopt
 			// merge equivalence classes coming from children of a bool op
 			static
 			DrgPcrs *PdrgpcrsMergeFromBoolOp(IMemoryPool *pmp, CExpression *pexpr, DrgPcrs *pdrgpcrsFst, DrgPcrs *pdrgpcrsSnd);
+
+			// subset of the given constraints, which reference the given column
+			static
+			DrgPcnstr *PdrgpcnstrOnColumn(IMemoryPool *pmp, DrgPcnstr *pdrgpcnstr, CColRef *pcr, BOOL fExclusive);
 
 	}; // class CConstraint
 

--- a/libgpopt/include/gpopt/base/IColConstraintsMapper.h
+++ b/libgpopt/include/gpopt/base/IColConstraintsMapper.h
@@ -1,0 +1,21 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#ifndef GPOPT_IColConstraintsMapper_H
+#define GPOPT_IColConstraintsMapper_H
+
+#include "gpos/common/CRefCount.h"
+#include "gpopt/base/CConstraint.h"
+
+namespace gpopt
+{
+	class IColConstraintsMapper : public CRefCount
+	{
+		public:
+			virtual DrgPcnstr* PdrgPcnstrLookup(CColRef *pcr) = 0;
+
+			virtual ~IColConstraintsMapper() = 0;
+	};
+}
+
+#endif //GPOPT_IColConstraintsMapper_H

--- a/libgpopt/src/base/CColConstraintsArrayMapper.cpp
+++ b/libgpopt/src/base/CColConstraintsArrayMapper.cpp
@@ -1,0 +1,32 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#include "gpopt/base/CColConstraintsArrayMapper.h"
+#include "gpopt/base/CConstraint.h"
+
+using namespace gpopt;
+
+DrgPcnstr *
+CColConstraintsArrayMapper::PdrgPcnstrLookup
+	(
+		CColRef *pcr
+	)
+{
+	const BOOL fExclusive = true;
+	return CConstraint::PdrgpcnstrOnColumn(m_pmp, m_pdrgpcnstr, pcr, fExclusive);
+}
+
+CColConstraintsArrayMapper::CColConstraintsArrayMapper
+	(
+		gpos::IMemoryPool *pmp,
+		DrgPcnstr *pdrgpcnstr
+	) :
+	m_pmp(pmp),
+	m_pdrgpcnstr(pdrgpcnstr)
+{
+}
+
+CColConstraintsArrayMapper::~CColConstraintsArrayMapper()
+{
+	m_pdrgpcnstr->Release();
+}

--- a/libgpopt/src/base/CColConstraintsHashMapper.cpp
+++ b/libgpopt/src/base/CColConstraintsHashMapper.cpp
@@ -1,0 +1,68 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+#include "gpos/common/CAutoRef.h"
+#include "gpopt/base/CColConstraintsHashMapper.h"
+
+using namespace gpopt;
+
+DrgPcnstr *
+CColConstraintsHashMapper::PdrgPcnstrLookup
+	(
+		CColRef *pcr
+	)
+{
+	DrgPcnstr *pdrgpcnstrCol = m_phmColConstr->PtLookup(pcr);
+	pdrgpcnstrCol->AddRef();
+	return pdrgpcnstrCol;
+}
+
+// mapping between columns and single column constraints in array of constraints
+static
+HMColConstr *
+PhmcolconstrSingleColConstr
+	(
+		IMemoryPool *pmp,
+		DrgPcnstr *drgPcnstr
+	)
+{
+	CAutoRef<DrgPcnstr> arpdrgpcnstr(drgPcnstr);
+	HMColConstr *phmcolconstr = GPOS_NEW(pmp) HMColConstr(pmp);
+
+	const ULONG ulLen = arpdrgpcnstr->UlLength();
+
+	for (ULONG ul = 0; ul < ulLen; ul++)
+	{
+		CConstraint *pcnstrChild = (*arpdrgpcnstr)[ul];
+		CColRefSet *pcrs = pcnstrChild->PcrsUsed();
+
+		if (1 == pcrs->CElements())
+		{
+			CColRef *pcr = pcrs->PcrFirst();
+			DrgPcnstr *pcnstrMapped = phmcolconstr->PtLookup(pcr);
+			if (NULL == pcnstrMapped)
+			{
+				pcnstrMapped = GPOS_NEW(pmp) DrgPcnstr(pmp);
+				phmcolconstr->FInsert(pcr, pcnstrMapped);
+			}
+			pcnstrChild->AddRef();
+			pcnstrMapped->Append(pcnstrChild);
+		}
+	}
+
+	return phmcolconstr;
+}
+
+CColConstraintsHashMapper::CColConstraintsHashMapper
+	(
+		IMemoryPool *pmp,
+		DrgPcnstr *pdrgpcnstr
+	) :
+	m_phmColConstr(PhmcolconstrSingleColConstr(pmp, pdrgpcnstr))
+{
+}
+
+CColConstraintsHashMapper::~CColConstraintsHashMapper()
+{
+	m_phmColConstr->Release();
+}

--- a/libgpopt/src/base/CConstraint.cpp
+++ b/libgpopt/src/base/CConstraint.cpp
@@ -668,8 +668,15 @@ CConstraint::PdrgpcnstrDeduplicate
 	DrgPcnstr *pdrgpcnstrNew = GPOS_NEW(pmp) DrgPcnstr(pmp);
 
 	CColRefSet *pcrsDeduped = GPOS_NEW(pmp) CColRefSet(pmp);
+	HMColConstr *phmcolconstr = NULL;
 
 	const ULONG ulLen = pdrgpcnstr->UlLength();
+
+	if (ulLen >= 5)
+	{
+		phmcolconstr = PhmcolconstrSingleColConstr(pmp,pdrgpcnstr);
+	}
+
 	for (ULONG ul = 0; ul < ulLen; ul++)
 	{
 		CConstraint *pcnstrChild = (*pdrgpcnstr)[ul];
@@ -691,8 +698,19 @@ CConstraint::PdrgpcnstrDeduplicate
 			continue;
 		}
 
-		// get all constraints from the input array that reference this column
-		DrgPcnstr *pdrgpcnstrCol = PdrgpcnstrOnColumn(pmp, pdrgpcnstr, pcr, true /*fExclusive*/);
+		DrgPcnstr *pdrgpcnstrCol = NULL;
+		if (ulLen < 5)
+		{
+			// get all constraints from the input array that reference this column
+			pdrgpcnstrCol = PdrgpcnstrOnColumn(pmp, pdrgpcnstr, pcr, true /*fExclusive*/);
+		}
+		else
+		{
+			GPOS_ASSERT(phmcolconstr);
+			pdrgpcnstrCol = phmcolconstr->PtLookup(pcr);
+			pdrgpcnstrCol->AddRef();
+		}
+
 		if (1 == pdrgpcnstrCol->UlLength())
 		{
 			// if there is only one such constraint, then no simplification
@@ -726,7 +744,55 @@ CConstraint::PdrgpcnstrDeduplicate
 
 	pcrsDeduped->Release();
 	pdrgpcnstr->Release();
+	if (ulLen >= 5)
+	{
+		phmcolconstr->Release();
+	}
+
 	return pdrgpcnstrNew;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CConstraint::PhmcolconstrSingleColConstr
+//
+//	@doc:
+//		Construct mapping between columns and arrays of constraints.
+//		Constraints that has more than one column and predicate not mapped.
+//
+//---------------------------------------------------------------------------
+HMColConstr *
+CConstraint::PhmcolconstrSingleColConstr
+	(
+	IMemoryPool *pmp,
+	DrgPcnstr *pdrgpcnstr
+	)
+const
+{
+	HMColConstr *phmcolconstr = GPOS_NEW(pmp) HMColConstr(pmp);
+
+	const ULONG ulLen = pdrgpcnstr->UlLength();
+
+	for (ULONG ul = 0; ul < ulLen; ul++)
+	{
+		CConstraint *pcnstrChild = (*pdrgpcnstr)[ul];
+		CColRefSet *pcrs = pcnstrChild->PcrsUsed();
+
+		if (1 == pcrs->CElements())
+		{
+			CColRef *pcr = pcrs->PcrFirst();
+			DrgPcnstr *pcnstrMapped = phmcolconstr->PtLookup(pcr);
+			if (NULL == pcnstrMapped)
+			{
+				pcnstrMapped = GPOS_NEW(pmp) DrgPcnstr(pmp);
+				phmcolconstr->FInsert(pcr, pcnstrMapped);
+			}
+			pcnstrChild->AddRef();
+			pcnstrMapped->Append(pcnstrChild);
+		}
+	}
+
+	return phmcolconstr;
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/base/IColConstraintsMapper.cpp
+++ b/libgpopt/src/base/IColConstraintsMapper.cpp
@@ -1,0 +1,8 @@
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Software, Inc.
+
+#include "gpopt/base/IColConstraintsMapper.h"
+
+gpopt::IColConstraintsMapper::~IColConstraintsMapper()
+{
+}


### PR DESCRIPTION
GP Orca rearranges constraints list where a constrint only refers a single
column reference as much as possible. In order to do that the previous implementation
traverse the list for every single constraint and that results in O(n^2) (quadratic)
running time.

If the number of constraints in the list is higher than some threashold
(hardcoded as 5 for now) it results in significant performance degredation.

This commit uses hash map to create a map from column referances to constraints where
a constraint only refers a single column. This will reduce the quadratic running time
of deduplication process to a linear running time. However, creating a hashmap for short
list of constraints also results in performnce degradation.