### PR TITLE
Improve optimization performance for large IN const array

### DIFF
--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -517,6 +517,8 @@ add_library(gpopt
             src/operators/CScalarAggFunc.cpp
             include/gpopt/operators/CScalarArray.h
             src/operators/CScalarArray.cpp
+	    include/gpopt/operators/CScalarConstArray.h
+	    src/operators/CScalarConstArray.cpp
             include/gpopt/operators/CScalarArrayCmp.h
             src/operators/CScalarArrayCmp.cpp
             include/gpopt/operators/CScalarArrayRef.h

--- a/libgpopt/CMakeLists.txt
+++ b/libgpopt/CMakeLists.txt
@@ -517,8 +517,8 @@ add_library(gpopt
             src/operators/CScalarAggFunc.cpp
             include/gpopt/operators/CScalarArray.h
             src/operators/CScalarArray.cpp
-	    include/gpopt/operators/CScalarConstArray.h
-	    src/operators/CScalarConstArray.cpp
+            include/gpopt/operators/CScalarConstArray.h
+            src/operators/CScalarConstArray.cpp
             include/gpopt/operators/CScalarArrayCmp.h
             src/operators/CScalarArrayCmp.cpp
             include/gpopt/operators/CScalarArrayRef.h

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -730,6 +730,10 @@ namespace gpopt
 			static
 			BOOL FScalarArray(CExpression *pexpr);
 
+			// check if expression is scalar const array
+			static
+			BOOL FScalarConstArray(CExpression *pexpr);
+
 			// check if expression is scalar array coerce
 			static
 			BOOL FScalarArrayCoerce(CExpression *pexpr);

--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -77,6 +77,9 @@ namespace gpopt
 			static
 			CExpression *PexprEliminateSelfComparison(IMemoryPool *pmp, CExpression *pexpr);
 
+			static
+			CExpression *PexprCollapseLargeArray(IMemoryPool *pmp, CExpression *pexpr);
+		
 			// remove CTE Anchor nodes
 			static
 			CExpression *PexprRemoveCTEAnchors(IMemoryPool *pmp, CExpression *pexpr);

--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -77,9 +77,10 @@ namespace gpopt
 			static
 			CExpression *PexprEliminateSelfComparison(IMemoryPool *pmp, CExpression *pexpr);
 
+			// collapse CScalarArray with constant values to CScalarConstArray
 			static
-			CExpression *PexprCollapseLargeArray(IMemoryPool *pmp, CExpression *pexpr);
-		
+			CExpression *PexprCollapseConstArray(IMemoryPool *pmp, CExpression *pexpr);
+
 			// remove CTE Anchor nodes
 			static
 			CExpression *PexprRemoveCTEAnchors(IMemoryPool *pmp, CExpression *pexpr);

--- a/libgpopt/include/gpopt/operators/COperator.h
+++ b/libgpopt/include/gpopt/operators/COperator.h
@@ -188,6 +188,7 @@ namespace gpopt
 				EopScalarArrayCoerceExpr,
 				EopScalarCoalesce,
 				EopScalarArray,
+				EopScalarConstArray,
 				EopScalarArrayCmp,
 				EopScalarArrayRef,
 				EopScalarArrayRefIndexList,

--- a/libgpopt/include/gpopt/operators/CScalarConstArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarConstArray.h
@@ -1,0 +1,114 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2012 EMC Corp.
+//
+//	@filename:
+//		CScalarConstArray.h
+//
+//	@doc:
+//		Class for scalar arrays of const.
+//		This class is to reduce the optization time for large IN list.
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CScalarConstArray_H
+#define GPOPT_CScalarConstArray_H
+
+#include "gpos/base.h"
+#include "naucrates/md/IMDId.h"
+
+#include "gpopt/operators/CScalar.h"
+#include "gpopt/operators/CScalarArray.h"
+
+#include "gpopt/operators/CExpression.h"
+
+namespace gpopt
+{
+
+	using namespace gpos;
+	using namespace gpmd;
+	
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CScalarConstArray
+	//
+	//	@doc:
+	//		Scalar array for constants
+	//
+	//---------------------------------------------------------------------------
+	class CScalarConstArray : public CScalarArray
+	{
+		private:
+			DrgPexpr * m_constExpressions;
+
+			// private copy ctor
+			CScalarConstArray(const CScalarConstArray &);
+		
+		public:
+		
+			// ctor
+			CScalarConstArray(IMemoryPool *pmp, CScalarArray *pArray, DrgPexpr *pExpressions);
+			
+			// dtor
+			virtual 
+			~CScalarConstArray();
+
+			// ident accessors
+			virtual 
+			EOperatorId Eopid() const
+			{
+				return EopScalarConstArray;
+			}
+			
+			// return a string for aggregate function
+			virtual 
+			const CHAR *SzId() const
+			{
+				return "CScalarConstArray";
+			}
+
+			DrgPexpr * PDrgPexpr() const
+			{
+				return m_constExpressions;
+			}
+			
+			// sensitivity to order of inputs
+			BOOL FInputOrderSensitive() const
+			{
+				return true;
+			}
+			
+			// return a copy of the operator with remapped columns
+			virtual
+			COperator *PopCopyWithRemappedColumns
+						(
+						IMemoryPool *, //pmp,
+						HMUlCr *, //phmulcr,
+						BOOL //fMustExist
+						)
+			{
+				return PopCopyDefault();
+			}
+
+			// conversion function
+			static
+			CScalarConstArray *PopConvert
+				(
+				COperator *pop
+				)
+			{
+				GPOS_ASSERT(NULL != pop);
+				GPOS_ASSERT(EopScalarConstArray == pop->Eopid());
+				
+				return reinterpret_cast<CScalarConstArray*>(pop);
+			}
+			
+			// print
+			IOstream &OsPrint(IOstream &os) const;
+
+	}; // class CScalarConstArray
+
+}
+
+
+#endif // !GPOPT_CScalarConstArray_H
+
+// EOF

--- a/libgpopt/include/gpopt/operators/CScalarConstArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarConstArray.h
@@ -70,7 +70,13 @@ namespace gpopt
 			{
 				return m_consts;
 			}
-			
+
+			// operator specific hash function
+			ULONG UlHash() const;
+
+			// match function
+			BOOL FMatch(COperator *pop) const;
+
 			// return the number of elements in the const array
 			ULONG UlSize() const;
 

--- a/libgpopt/include/gpopt/operators/CScalarConstArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarConstArray.h
@@ -71,6 +71,12 @@ namespace gpopt
 				return m_consts;
 			}
 			
+			// return the number of elements in the const array
+			ULONG UlSize() const;
+
+			// return the const element at the given position in the const array
+			CScalarConst *PopConstAt(ULONG ul);
+
 			// sensitivity to order of inputs
 			BOOL FInputOrderSensitive() const
 			{

--- a/libgpopt/include/gpopt/operators/CScalarConstArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarConstArray.h
@@ -1,13 +1,13 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2012 EMC Corp.
+//	Copyright (C) 2017 Pivotal Software, Inc.
 //
 //	@filename:
 //		CScalarConstArray.h
 //
 //	@doc:
-//		Class for scalar arrays of const.
-//		This class is to reduce the optization time for large IN list.
+//		Class for scalar array of constant values.
+//		This class is used to reduce the optimization time for large IN list.
 //---------------------------------------------------------------------------
 #ifndef GPOPT_CScalarConstArray_H
 #define GPOPT_CScalarConstArray_H
@@ -24,7 +24,7 @@ namespace gpopt
 
 	using namespace gpos;
 	using namespace gpmd;
-	
+
 	typedef CDynamicPtrArray<CScalarConst, CleanupRelease> DrgPconst;
 
 	//---------------------------------------------------------------------------
@@ -38,16 +38,17 @@ namespace gpopt
 	class CScalarConstArray : public CScalarArray
 	{
 		private:
+			// constant values
 			DrgPconst *m_consts;
 
 			// private copy ctor
 			CScalarConstArray(const CScalarConstArray &);
-		
+
 		public:
-		
+
 			// ctor
 			CScalarConstArray(IMemoryPool *pmp, IMDId *pmdidElem, IMDId *pmdidArray, BOOL fMultiDimensional, DrgPconst *pConsts);
-			
+
 			// dtor
 			virtual 
 			~CScalarConstArray();
@@ -58,7 +59,7 @@ namespace gpopt
 			{
 				return EopScalarConstArray;
 			}
-			
+
 			// return a string for aggregate function
 			virtual 
 			const CHAR *SzId() const
@@ -66,6 +67,7 @@ namespace gpopt
 				return "CScalarConstArray";
 			}
 
+			// constant values
 			DrgPconst *PConsts() const
 			{
 				return m_consts;
@@ -88,7 +90,7 @@ namespace gpopt
 			{
 				return true;
 			}
-			
+
 			// return a copy of the operator with remapped columns
 			virtual
 			COperator *PopCopyWithRemappedColumns
@@ -110,10 +112,10 @@ namespace gpopt
 			{
 				GPOS_ASSERT(NULL != pop);
 				GPOS_ASSERT(EopScalarConstArray == pop->Eopid());
-				
+
 				return reinterpret_cast<CScalarConstArray*>(pop);
 			}
-			
+
 			// print
 			IOstream &OsPrint(IOstream &os) const;
 

--- a/libgpopt/include/gpopt/operators/CScalarConstArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarConstArray.h
@@ -13,12 +13,11 @@
 #define GPOPT_CScalarConstArray_H
 
 #include "gpos/base.h"
+#include "gpos/common/CRefCount.h"
+#include "gpos/common/CDynamicPtrArray.h"
 #include "naucrates/md/IMDId.h"
-
-#include "gpopt/operators/CScalar.h"
+#include "gpopt/operators/CScalarConst.h"
 #include "gpopt/operators/CScalarArray.h"
-
-#include "gpopt/operators/CExpression.h"
 
 namespace gpopt
 {
@@ -26,6 +25,8 @@ namespace gpopt
 	using namespace gpos;
 	using namespace gpmd;
 	
+	typedef CDynamicPtrArray<CScalarConst, CleanupRelease> DrgPconst;
+
 	//---------------------------------------------------------------------------
 	//	@class:
 	//		CScalarConstArray
@@ -37,7 +38,7 @@ namespace gpopt
 	class CScalarConstArray : public CScalarArray
 	{
 		private:
-			DrgPexpr * m_constExpressions;
+			DrgPconst *m_consts;
 
 			// private copy ctor
 			CScalarConstArray(const CScalarConstArray &);
@@ -45,7 +46,7 @@ namespace gpopt
 		public:
 		
 			// ctor
-			CScalarConstArray(IMemoryPool *pmp, CScalarArray *pArray, DrgPexpr *pExpressions);
+			CScalarConstArray(IMemoryPool *pmp, IMDId *pmdidElem, IMDId *pmdidArray, BOOL fMultiDimensional, DrgPconst *pConsts);
 			
 			// dtor
 			virtual 
@@ -65,9 +66,9 @@ namespace gpopt
 				return "CScalarConstArray";
 			}
 
-			DrgPexpr * PDrgPexpr() const
+			DrgPconst *PConsts() const
 			{
-				return m_constExpressions;
+				return m_consts;
 			}
 			
 			// sensitivity to order of inputs

--- a/libgpopt/include/gpopt/operators/CScalarConstArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarConstArray.h
@@ -55,23 +55,14 @@ namespace gpopt
 
 			// ident accessors
 			virtual 
-			EOperatorId Eopid() const
-			{
-				return EopScalarConstArray;
-			}
+			EOperatorId Eopid() const;
 
 			// return a string for aggregate function
 			virtual 
-			const CHAR *SzId() const
-			{
-				return "CScalarConstArray";
-			}
+			const CHAR *SzId() const;
 
 			// constant values
-			DrgPconst *PConsts() const
-			{
-				return m_consts;
-			}
+			DrgPconst *PConsts() const;
 
 			// operator specific hash function
 			ULONG UlHash() const;
@@ -86,35 +77,19 @@ namespace gpopt
 			CScalarConst *PopConstAt(ULONG ul);
 
 			// sensitivity to order of inputs
-			BOOL FInputOrderSensitive() const
-			{
-				return true;
-			}
+			BOOL FInputOrderSensitive() const;
 
 			// return a copy of the operator with remapped columns
 			virtual
-			COperator *PopCopyWithRemappedColumns
-						(
+			COperator *PopCopyWithRemappedColumns(
 						IMemoryPool *, //pmp,
 						HMUlCr *, //phmulcr,
 						BOOL //fMustExist
-						)
-			{
-				return PopCopyDefault();
-			}
+						);
 
 			// conversion function
 			static
-			CScalarConstArray *PopConvert
-				(
-				COperator *pop
-				)
-			{
-				GPOS_ASSERT(NULL != pop);
-				GPOS_ASSERT(EopScalarConstArray == pop->Eopid());
-
-				return reinterpret_cast<CScalarConstArray*>(pop);
-			}
+			CScalarConstArray *PopConvert(COperator *pop);
 
 			// print
 			IOstream &OsPrint(IOstream &os) const;

--- a/libgpopt/include/gpopt/operators/ops.h
+++ b/libgpopt/include/gpopt/operators/ops.h
@@ -46,6 +46,7 @@
 #include "gpopt/operators/CScalarSubqueryExists.h"
 #include "gpopt/operators/CScalarSubqueryNotExists.h"
 #include "gpopt/operators/CScalarArray.h"
+#include "gpopt/operators/CScalarConstArray.h"
 #include "gpopt/operators/CScalarArrayCmp.h"
 #include "gpopt/operators/CScalarArrayRef.h"
 #include "gpopt/operators/CScalarArrayRefIndexList.h"

--- a/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -603,6 +603,9 @@ namespace gpopt
 			// translate an array
 			CDXLNode *PdxlnArray(CExpression *pexpr);
 
+			// translate an const array
+			CDXLNode *PdxlnConstArray(CExpression *pexpr);
+
 			// translate an arrayref
 			CDXLNode *PdxlnArrayRef(CExpression *pexpr);
 

--- a/libgpopt/src/base/CConstraintInterval.cpp
+++ b/libgpopt/src/base/CConstraintInterval.cpp
@@ -18,6 +18,7 @@
 #include "gpopt/base/CUtils.h"
 #include "gpopt/operators/CPredicateUtils.h"
 #include "gpopt/operators/CScalarArray.h"
+#include "gpopt/operators/CScalarConstArray.h"
 #include "gpopt/operators/CScalarIdent.h"
 #include "naucrates/md/IMDScalarOp.h"
 #include "gpopt/base/CDatumSortedSet.h"
@@ -217,7 +218,18 @@ CConstraintInterval::PcnstrIntervalFromScalarArrayCmp
 	const ULONG ulArrayExprArity = pexprArray->UlArity();
 	if (0 == ulArrayExprArity)
 	{
-		return NULL;
+		if (CUtils::FScalarConstArray(pexprArray))
+		{
+			CScalarConstArray *popScAray = CScalarConstArray::PopConvert(pexprArray->Pop());
+			if (0 == popScAray->UlSize())
+			{
+				return NULL;
+			}
+		}
+		else
+		{
+			return NULL;
+		}
 	}
 
 	const IComparator *pcomp = COptCtxt::PoctxtFromTLS()->Pcomp();

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -3960,6 +3960,24 @@ CUtils::FScalarArray
 
 //---------------------------------------------------------------------------
 //	@function:
+//		CUtils::FScalarConstArray
+//
+//	@doc:
+//		 Check if given expression is a scalar const array
+//
+//---------------------------------------------------------------------------
+BOOL
+CUtils::FScalarConstArray
+	(
+	CExpression *pexpr
+	)
+{
+	return (COperator::EopScalarConstArray == pexpr->Pop()->Eopid());
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
 //		CUtils::FScalarArrayCoerce
 //
 //	@doc:

--- a/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -1728,6 +1728,69 @@ CExpressionPreprocessor::PexprPruneEmptySubtrees
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
+CExpression *
+CExpressionPreprocessor::PexprCollapseLargeArray
+(
+	IMemoryPool *pmp,
+	CExpression *pexpr
+)
+{
+	GPOS_ASSERT(NULL != pexpr);
+
+	COperator *pop = pexpr->Pop();
+	
+	// process children
+	DrgPexpr *pdrgpexpr = GPOS_NEW(pmp) DrgPexpr(pmp);
+	
+
+	ULONG ulChildren = pexpr->UlArity();
+	
+	// if it's a scalar array of all CScalarConst, we will collapse it into an CScalarConstArray
+	if (COperator::EopScalarArray == pop->Eopid())
+	{
+		// cast the operator
+		CScalarArray *oldArray = CScalarArray::PopConvert(pop);
+
+		// process children
+		DrgPexpr *scalarConsts = GPOS_NEW(pmp) DrgPexpr(pmp);
+
+		for (ULONG ul = 0; ul < ulChildren; ul++)
+		{
+			CExpression *pexprChild = PexprCollapseLargeArray(pmp, (*pexpr)[ul]);
+			COperator *popChild = pexprChild ->Pop();
+
+			// if it's a const, remember it
+			if(COperator::EopScalarConst == popChild->Eopid())
+			{
+				// copy the child
+				CExpression *pexprCopy = PexprCollapseLargeArray(pmp, pexprChild);
+
+				// append to the output
+				scalarConsts->Append(pexprCopy);
+			} else
+			{
+				// NOT all children is CScalarConst, abort this collapsing
+				scalarConsts->Release();
+				popChild->Release();
+				pexprChild->Release();
+				break;
+			}
+		}
+
+		CScalarConstArray *newArrayOp = GPOS_NEW(pmp) CScalarConstArray(pmp, oldArray, scalarConsts);
+		
+		return GPOS_NEW(pmp) CExpression(pmp, newArrayOp, pdrgpexpr);
+	}
+
+	for (ULONG ul = 0; ul < ulChildren; ul++)
+	{
+		CExpression *pexprChild = PexprCollapseLargeArray(pmp, (*pexpr)[ul]);
+		pdrgpexpr->Append(pexprChild);
+	}
+	
+	pop->AddRef();
+	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
+}
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -2228,9 +2291,14 @@ CExpressionPreprocessor::PexprPreprocess
 
 	CAutoTimer at("\n[OPT]: Expression Preprocessing Time", GPOS_FTRACE(EopttracePrintOptStats));
 
-	// (1) remove unused CTE anchors
-	CExpression *pexprNoUnusedCTEs = PexprRemoveUnusedCTEs(pmp, pexpr);
+	// collapse large CScalarArray
+	CExpression *pexprLargeArray = PexprCollapseLargeArray(pmp, pexpr);
 	GPOS_CHECK_ABORT;
+	
+	// (1) remove unused CTE anchors
+	CExpression *pexprNoUnusedCTEs = PexprRemoveUnusedCTEs(pmp, pexprLargeArray);
+	GPOS_CHECK_ABORT;
+	pexprLargeArray->Release();
 
 	// (2) remove intermediate superfluous limit
 	CExpression *pexprSimplified = PexprRemoveSuperfluousLimit(pmp, pexprNoUnusedCTEs);

--- a/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1544,9 +1544,14 @@ CPredicateUtils::FCompareIdentToConstArray
 
 	if (!CUtils::FScalarArrayCmp(pexpr) ||
 		!CUtils::FScalarIdent((*pexpr)[0]) ||
-		!CUtils::FScalarArray((*pexpr)[1]))
+		(!CUtils::FScalarArray((*pexpr)[1]) && !CUtils::FScalarConstArray((*pexpr)[1])))
 	{
 		return false;
+	}
+
+	if (CUtils::FScalarConstArray((*pexpr)[1]))
+	{
+		return true;
 	}
 
 	CExpression *pexprArray = (*pexpr)[1];

--- a/libgpopt/src/operators/CScalarConstArray.cpp
+++ b/libgpopt/src/operators/CScalarConstArray.cpp
@@ -1,0 +1,42 @@
+//	Greenplum Database
+//	Copyright (C) 2016 Pivotal Software, Inc.
+
+
+#include "gpopt/operators/CScalarConstArray.h"
+#include "gpopt/operators/CExpression.h"
+
+using namespace gpopt;
+using namespace gpmd;
+
+CScalarConstArray::CScalarConstArray
+		(
+				IMemoryPool *pmp,
+				CScalarArray *array,
+				DrgPexpr *pConstExpressions
+		)
+		:
+		CScalarArray(pmp, array->PmdidElem(), array->PmdidArray(), array->FMultiDimensional()),
+		m_constExpressions(pConstExpressions)
+{
+	GPOS_ASSERT(pConstExpressions);
+}
+
+CScalarConstArray::~CScalarConstArray()
+{
+	m_constExpressions->Release();
+}
+
+IOstream &
+CScalarConstArray::OsPrint(IOstream &os) const
+{
+	os << "CScalarConstArray: {eleMDId: ";
+	PmdidElem()->OsPrint(os);
+	os << ", arrayMDId: ";
+	PmdidArray()->OsPrint(os);
+	if (FMultiDimensional())
+	{
+		os << ", multidimensional";
+	}
+	os << "}";
+	return os;
+}

--- a/libgpopt/src/operators/CScalarConstArray.cpp
+++ b/libgpopt/src/operators/CScalarConstArray.cpp
@@ -1,7 +1,6 @@
 //	Greenplum Database
 //	Copyright (C) 2016 Pivotal Software, Inc.
 
-
 #include "gpopt/operators/CScalarConstArray.h"
 #include "gpopt/operators/CExpression.h"
 
@@ -9,26 +8,29 @@ using namespace gpopt;
 using namespace gpmd;
 
 CScalarConstArray::CScalarConstArray
-		(
-				IMemoryPool *pmp,
-				CScalarArray *array,
-				DrgPexpr *pConstExpressions
-		)
-		:
-		CScalarArray(pmp, array->PmdidElem(), array->PmdidArray(), array->FMultiDimensional()),
-		m_constExpressions(pConstExpressions)
+	(
+	IMemoryPool *pmp,
+	IMDId *pmdidElem,
+	IMDId *pmdidArray,
+	BOOL fMultiDimensional,
+	DrgPconst *pConsts
+	)
+	:
+	CScalarArray(pmp, pmdidElem, pmdidArray, fMultiDimensional),
+	m_consts(pConsts)
 {
-	GPOS_ASSERT(pConstExpressions);
+	GPOS_ASSERT(pConsts);
 }
 
 CScalarConstArray::~CScalarConstArray()
 {
-	m_constExpressions->Release();
+	m_consts->Release();
 }
 
 IOstream &
 CScalarConstArray::OsPrint(IOstream &os) const
 {
+	// TODO: output constant values in array
 	os << "CScalarConstArray: {eleMDId: ";
 	PmdidElem()->OsPrint(os);
 	os << ", arrayMDId: ";

--- a/libgpopt/src/operators/CScalarConstArray.cpp
+++ b/libgpopt/src/operators/CScalarConstArray.cpp
@@ -27,6 +27,71 @@ CScalarConstArray::~CScalarConstArray()
 	m_consts->Release();
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalaCScalarConstArrayrArray::UlHash
+//
+//	@doc:
+//		Operator specific hash function
+//
+//---------------------------------------------------------------------------
+ULONG
+CScalarConstArray::UlHash() const
+{
+	BOOL fMultiDimensional = FMultiDimensional();
+	ULONG ulHash = gpos::UlCombineHashes
+					(
+					UlCombineHashes(PmdidElem()->UlHash(), PmdidArray()->UlHash()),
+					gpos::UlHash<BOOL>(&fMultiDimensional)
+					);
+	for (ULONG ul = 0; ul < UlSize(); ul++)
+	{
+		ulHash = gpos::UlCombineHashes(ulHash, (*m_consts)[ul]->UlHash());
+	}
+	return ulHash;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarConstArray::FMatch
+//
+//	@doc:
+//		Match function on operator level
+//
+//---------------------------------------------------------------------------
+BOOL
+CScalarConstArray::FMatch
+	(
+	COperator *pop
+	)
+	const
+{
+	if (pop->Eopid() == Eopid())
+	{
+		CScalarConstArray *popArray = CScalarConstArray::PopConvert(pop);
+
+		// match if components are identical
+		if (popArray->FMultiDimensional() == FMultiDimensional() &&
+				PmdidElem()->FEquals(popArray->PmdidElem()) &&
+				PmdidArray()->FEquals(popArray->PmdidArray()) &&
+				UlSize() == popArray->UlSize())
+		{
+			for (ULONG ul = 0; ul < UlSize(); ul++)
+			{
+				CScalarConst *popConst1 = (*m_consts)[ul];
+				CScalarConst *popConst2 = popArray->PopConstAt(ul);
+				if (!popConst1->FMatch(popConst2))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
 // return the number of elements in the const array
 ULONG
 CScalarConstArray::UlSize() const

--- a/libgpopt/src/operators/CScalarConstArray.cpp
+++ b/libgpopt/src/operators/CScalarConstArray.cpp
@@ -1,5 +1,5 @@
 //	Greenplum Database
-//	Copyright (C) 2016 Pivotal Software, Inc.
+//	Copyright (C) 2017 Pivotal Software, Inc.
 
 #include "gpopt/operators/CScalarConstArray.h"
 #include "gpopt/operators/CExpression.h"
@@ -7,6 +7,14 @@
 using namespace gpopt;
 using namespace gpmd;
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarConstArray::CScalarConstArray
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
 CScalarConstArray::CScalarConstArray
 	(
 	IMemoryPool *pmp,
@@ -22,6 +30,14 @@ CScalarConstArray::CScalarConstArray
 	GPOS_ASSERT(pConsts);
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CScalarConstArray::~CScalarConstArray
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
 CScalarConstArray::~CScalarConstArray()
 {
 	m_consts->Release();
@@ -29,7 +45,7 @@ CScalarConstArray::~CScalarConstArray()
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CScalaCScalarConstArrayrArray::UlHash
+//		CScalarConstArray::UlHash
 //
 //	@doc:
 //		Operator specific hash function

--- a/libgpopt/src/operators/CScalarConstArray.cpp
+++ b/libgpopt/src/operators/CScalarConstArray.cpp
@@ -27,10 +27,29 @@ CScalarConstArray::~CScalarConstArray()
 	m_consts->Release();
 }
 
+// return the number of elements in the const array
+ULONG
+CScalarConstArray::UlSize() const
+{
+	if (m_consts)
+	{
+		return m_consts->UlLength();
+	}
+
+	return 0;
+}
+
+// return the const element at the given position in the const array
+CScalarConst *
+CScalarConstArray::PopConstAt(ULONG ul)
+{
+	GPOS_ASSERT(ul < UlSize());
+	return (*m_consts)[ul];
+}
+
 IOstream &
 CScalarConstArray::OsPrint(IOstream &os) const
 {
-	// TODO: output constant values in array
 	os << "CScalarConstArray: {eleMDId: ";
 	PmdidElem()->OsPrint(os);
 	os << ", arrayMDId: ";
@@ -39,6 +58,17 @@ CScalarConstArray::OsPrint(IOstream &os) const
 	{
 		os << ", multidimensional";
 	}
-	os << "}";
+	os << ", elements: [";
+	ULONG ulSize = UlSize();
+	for (ULONG ul = 0; ul < ulSize; ul++)
+	{
+		const CScalarConst *popConst = (*m_consts)[ul];
+		popConst->Pdatum()->OsPrint(os);
+		if (ul < ulSize - 1)
+		{
+			os << ", ";
+		}
+	}
+	os << "]}";
 	return os;
 }

--- a/libgpopt/src/operators/CScalarConstArray.cpp
+++ b/libgpopt/src/operators/CScalarConstArray.cpp
@@ -3,18 +3,12 @@
 
 #include "gpopt/operators/CScalarConstArray.h"
 #include "gpopt/operators/CExpression.h"
+#include "gpopt/operators/CScalarArray.h"
 
 using namespace gpopt;
 using namespace gpmd;
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarConstArray::CScalarConstArray
-//
-//	@doc:
-//		Ctor
-//
-//---------------------------------------------------------------------------
+// Ctor
 CScalarConstArray::CScalarConstArray
 	(
 	IMemoryPool *pmp,
@@ -30,27 +24,35 @@ CScalarConstArray::CScalarConstArray
 	GPOS_ASSERT(pConsts);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarConstArray::~CScalarConstArray
-//
-//	@doc:
-//		Dtor
-//
-//---------------------------------------------------------------------------
+
+// Dtor
 CScalarConstArray::~CScalarConstArray()
 {
 	m_consts->Release();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarConstArray::UlHash
-//
-//	@doc:
-//		Operator specific hash function
-//
-//---------------------------------------------------------------------------
+// ident accessors
+CScalar::EOperatorId
+CScalarConstArray::Eopid() const
+{
+	return EopScalarConstArray;
+}
+
+// return a string for aggregate function
+const CHAR *
+CScalarConstArray::SzId() const
+{
+	return "CScalarConstArray";
+}
+
+// constant values
+DrgPconst *
+CScalarConstArray::PConsts() const
+{
+	return m_consts;
+}
+
+// Operator specific hash function
 ULONG
 CScalarConstArray::UlHash() const
 {
@@ -67,14 +69,7 @@ CScalarConstArray::UlHash() const
 	return ulHash;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarConstArray::FMatch
-//
-//	@doc:
-//		Match function on operator level
-//
-//---------------------------------------------------------------------------
+// Match function on operator level
 BOOL
 CScalarConstArray::FMatch
 	(
@@ -126,6 +121,35 @@ CScalarConstArray::PopConstAt(ULONG ul)
 {
 	GPOS_ASSERT(ul < UlSize());
 	return (*m_consts)[ul];
+}
+
+// sensitivity to order of inputs
+BOOL
+CScalarConstArray::FInputOrderSensitive() const
+{
+	return true;
+}
+
+// return a copy of the operator with remapped columns
+COperator *
+CScalarConstArray::PopCopyWithRemappedColumns
+	(
+	IMemoryPool *, //pmp,
+	HMUlCr *, //phmulcr,
+	BOOL //fMustExist
+	)
+{
+	return PopCopyDefault();
+}
+
+// conversion function
+CScalarConstArray *
+CScalarConstArray::PopConvert(COperator *pop)
+{
+	GPOS_ASSERT(NULL != pop);
+	GPOS_ASSERT(EopScalarConstArray == pop->Eopid());
+
+	return reinterpret_cast<CScalarConstArray*>(pop);
 }
 
 IOstream &

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -157,6 +157,7 @@ CTranslatorExprToDXL::InitScalarTranslators()
 			{COperator::EopScalarCoerceViaIO, &gpopt::CTranslatorExprToDXL::PdxlnScCoerceViaIO},
 			{COperator::EopScalarArrayCoerceExpr, &gpopt::CTranslatorExprToDXL::PdxlnScArrayCoerceExpr},
 			{COperator::EopScalarArray, &gpopt::CTranslatorExprToDXL::PdxlnArray},
+			{COperator::EopScalarConstArray, &gpopt::CTranslatorExprToDXL::PdxlnConstArray},
 			{COperator::EopScalarArrayCmp, &gpopt::CTranslatorExprToDXL::PdxlnArrayCmp},
 			{COperator::EopScalarArrayRef, &gpopt::CTranslatorExprToDXL::PdxlnArrayRef},
 			{COperator::EopScalarArrayRefIndexList, &gpopt::CTranslatorExprToDXL::PdxlnArrayRefIndexList},
@@ -6701,6 +6702,54 @@ CTranslatorExprToDXL::PdxlnArray
 	TranslateScalarChildren(pexpr, pdxlnArray);
 
 	return pdxlnArray;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorExprToDXL::PdxlnConstArray
+//
+//	@doc:
+//		Create a DXL const array node from an optimizer const array expression
+//
+//---------------------------------------------------------------------------
+CDXLNode *
+CTranslatorExprToDXL::PdxlnConstArray
+	(
+	CExpression *pexpr
+	)
+{
+	GPOS_ASSERT(NULL != pexpr);
+	CScalarConstArray *pop = CScalarConstArray::PopConvert(pexpr->Pop());
+
+	IMDId *pmdidElem = pop->PmdidElem();
+	pmdidElem->AddRef();
+
+	IMDId *pmdidArray = pop->PmdidArray();
+	pmdidArray->AddRef();
+
+	CDXLNode *pdxlnConstArray =
+			GPOS_NEW(m_pmp) CDXLNode
+						(
+						m_pmp,
+						GPOS_NEW(m_pmp) CDXLScalarArray
+									(
+									m_pmp,
+									pmdidElem,
+									pmdidArray,
+									pop->FMultiDimensional()
+									)
+						);
+
+	DrgPexpr *pConstValues = pop->PDrgPexpr();
+	const ULONG ulArity = pConstValues->UlLength();
+	for (ULONG ul = 0; ul < ulArity; ul++)
+	{
+		CExpression *pexprChild = (*pConstValues)[ul];
+		CDXLNode *pdxlnChild = PdxlnScalar(pexprChild);
+		pdxlnConstArray->AddChild(pdxlnChild);
+	}
+
+	return pdxlnConstArray;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
When there is large number of values in the array or IN list, Orca spent a lot of time on optimization. The reason is that every const item in the array is used to create a group and group expression in the MEMO structure. For scalar const values in the array, it is not necessary to create the MEMO group for it. We create a new scalar operator `CScalarConstArray` to treat the constant values in the children expression as its attribute, which avoids the MEMO group creation for constant values to achieve performance improvement.

Made in SFO->PEK UA888 Boeing 747 aircraft.

Signed-off-by: Omer Arap <oarap@pivotal.io>
Signed-off-by: Xin Zhang <xzhang@pivotal.io>
[#132930893]