### PR TITLE
132930893 large in new

### DIFF
--- a/data/dxl/expressiontests/CScalarConstArray.xml
+++ b/data/dxl/expressiontests/CScalarConstArray.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Query>
+    <dxl:OutputColumns>
+      <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+    </dxl:OutputColumns>
+    <dxl:CTEList/>
+    <dxl:LogicalSelect>
+      <dxl:ArrayComp OperatorName="=" OperatorMdid="0.96.1.0" OperatorType="Any">
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="6"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7"/>
+        </dxl:Array>
+      </dxl:ArrayComp>
+      <dxl:LogicalGet>
+        <dxl:TableDescriptor Mdid="0.1607030.1.1" TableName="r">
+          <dxl:Columns>
+            <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.25.1.0"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:LogicalGet>
+    </dxl:LogicalSelect>
+  </dxl:Query>
+</dxl:DXLMessage>

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -730,6 +730,35 @@ namespace gpopt
 			static
 			BOOL FScalarArray(CExpression *pexpr);
 
+			// returns number of children or constants of it is all constants
+			static
+			ULONG UlScalarArrayArity(CExpression *pexpr);
+
+			// returns constant operator of a scalar array expression
+			static
+			CScalarConst *PScalarArrayConstChildAt(CExpression *pexprArray, ULONG ul);
+
+			// returns constant expression of a scalar array expression
+			static
+			CExpression *PScalarArrayExprChildAt(IMemoryPool *pmp, CExpression *pexprArray, ULONG ul);
+
+			// returns the scalar array expression child of CScalarArrayComp
+			static
+			CExpression *PexprScalarArrayChild(CExpression *pexpr);
+
+			// returns if the scalar array has all constant elements or children
+			static
+			BOOL FScalarConstArray(CExpression *pexpr);
+
+			// returns if the scalar constant array has already been collapased
+			static
+			BOOL FScalarArrayCollapsed(CExpression *pexprArray);
+
+			// If it's a scalar array of all CScalarConst, collapse it into a single
+			// expression but keep the constants in the operator.
+			static
+			CExpression *PexprCollapseConstArray(IMemoryPool *pmp, CExpression *pexprArray);
+
 			// check if expression is scalar array coerce
 			static
 			BOOL FScalarArrayCoerce(CExpression *pexpr);

--- a/libgpopt/include/gpopt/operators/CScalarArray.h
+++ b/libgpopt/include/gpopt/operators/CScalarArray.h
@@ -15,13 +15,16 @@
 #include "naucrates/md/IMDId.h"
 
 #include "gpopt/operators/CScalar.h"
+#include "gpopt/operators/CScalarConst.h"
 
 namespace gpopt
 {
 
 	using namespace gpos;
 	using namespace gpmd;
-	
+
+	typedef CDynamicPtrArray<CScalarConst, CleanupRelease> DrgPconst;
+
 	//---------------------------------------------------------------------------
 	//	@class:
 	//		CScalarArray
@@ -42,7 +45,10 @@ namespace gpopt
 			
 			// is array multidimensional
 			BOOL m_fMultiDimensional;
-	
+
+			// const values
+			DrgPconst *m_pdrgPconst;
+
 			// private copy ctor
 			CScalarArray(const CScalarArray &);
 		
@@ -50,7 +56,10 @@ namespace gpopt
 		
 			// ctor
 			CScalarArray(IMemoryPool *pmp, IMDId *pmdidElem, IMDId *pmdidArray, BOOL fMultiDimensional);
-			
+
+			// ctor
+			CScalarArray(IMemoryPool *pmp, IMDId *pmdidElem, IMDId *pmdidArray, BOOL fMultiDimensional, DrgPconst *pdrgPconst);
+
 			// dtor
 			virtual 
 			~CScalarArray();
@@ -119,6 +128,9 @@ namespace gpopt
 			// type of expression's result
 			virtual 
 			IMDId *PmdidType() const;
+
+			// CScalarConst array
+			DrgPconst *PdrgPconst() const;
 
 			// print
 			IOstream &OsPrint(IOstream &os) const;

--- a/libgpopt/src/base/CConstraint.cpp
+++ b/libgpopt/src/base/CConstraint.cpp
@@ -104,9 +104,9 @@ CConstraint::PcnstrFromScalarArrayCmp
 
 		// get comparison type
 		IMDType::ECmpType ecmpt = CUtils::Ecmpt(popScArrayCmp->PmdidOp());
-		CExpression *pexprArray = (*pexpr)[1];
+		CExpression *pexprArray = CUtils::PexprScalarArrayChild(pexpr);
 
-		const ULONG ulArity = pexprArray->UlArity();
+		const ULONG ulArity = CUtils::UlScalarArrayArity(pexprArray);
 
 		// When array size exceeds the threshold, don't expand it into a DNF
 		COptimizerConfig *poconf = COptCtxt::PoctxtFromTLS()->Poconf();
@@ -121,9 +121,7 @@ CConstraint::PcnstrFromScalarArrayCmp
 
 		for (ULONG ul = 0; ul < ulArity; ul++)
 		{
-			GPOS_ASSERT(CUtils::FScalarConst((*pexprArray)[ul]) && "expecting a constant");
-
-			CScalarConst *popScConst = CScalarConst::PopConvert((*pexprArray)[ul]->Pop());
+			CScalarConst *popScConst = CUtils::PScalarArrayConstChildAt(pexprArray,ul);
 			CConstraintInterval *pci =  CConstraintInterval::PciIntervalFromColConstCmp(pmp, pcr, ecmpt, popScConst);
 			pdrgpcnstr->Append(pci);
 		}

--- a/libgpopt/src/base/CConstraintInterval.cpp
+++ b/libgpopt/src/base/CConstraintInterval.cpp
@@ -213,8 +213,8 @@ CConstraintInterval::PcnstrIntervalFromScalarArrayCmp
 	IMDType::ECmpType ecmpt = CUtils::Ecmpt(popScArrayCmp->PmdidOp());
 
 
-	CExpression *pexprArray = (*pexpr)[1];
-	const ULONG ulArrayExprArity = pexprArray->UlArity();
+	CExpression *pexprArray = CUtils::PexprScalarArrayChild(pexpr);
+	const ULONG ulArrayExprArity = CUtils::UlScalarArrayArity(pexprArray);
 	if (0 == ulArrayExprArity)
 	{
 		return NULL;

--- a/libgpopt/src/base/CDatumSortedSet.cpp
+++ b/libgpopt/src/base/CDatumSortedSet.cpp
@@ -19,15 +19,15 @@ CDatumSortedSet::CDatumSortedSet
 	DrgPdatum(pmp),
 	m_fIncludesNull(false)
 {
-	GPOS_ASSERT(0 < pexprArray->UlArity());
 	GPOS_ASSERT(COperator::EopScalarArray == pexprArray->Pop()->Eopid());
 
-	const ULONG ulArrayExprArity = pexprArray->UlArity();
+	const ULONG ulArrayExprArity = CUtils::UlScalarArrayArity(pexprArray);
+	GPOS_ASSERT(0 < ulArrayExprArity);
 
 	gpos::CAutoRef<DrgPdatum> aprngdatum(GPOS_NEW(pmp) DrgPdatum(pmp));
 	for (ULONG ul = 0; ul < ulArrayExprArity; ul++)
 	{
-		CScalarConst *popScConst = CScalarConst::PopConvert((*pexprArray)[ul]->Pop());
+		CScalarConst *popScConst = CUtils::PScalarArrayConstChildAt(pexprArray, ul);
 		IDatum *pdatum = popScConst->Pdatum();
 		if (pdatum->FNull())
 		{

--- a/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1549,16 +1549,8 @@ CPredicateUtils::FCompareIdentToConstArray
 		return false;
 	}
 
-	CExpression *pexprArray = (*pexpr)[1];
-	const ULONG ulArity = pexprArray->UlArity();
-
-	BOOL fAllConsts = true;
-	for (ULONG ul = 0; fAllConsts && ul < ulArity; ul++)
-	{
-		fAllConsts = CUtils::FScalarConst((*pexprArray)[ul]);
-	}
-
-	return fAllConsts;
+	CExpression *pexprArray = CUtils::PexprScalarArrayChild(pexpr);
+	return CUtils::FScalarConstArray(pexprArray);
 }
 
 

--- a/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -3166,7 +3166,13 @@ CTranslatorDXLToExpr::PexprArray
 	
 	DrgPexpr *pdrgpexprChildren = PdrgpexprChildren(pdxln);
 
-	return GPOS_NEW(m_pmp) CExpression(m_pmp, popArray, pdrgpexprChildren);
+	CExpression *pexprArray = GPOS_NEW(m_pmp) CExpression(m_pmp, popArray, pdrgpexprChildren);
+
+	CExpression *pexprCollapsedArray = CUtils::PexprCollapseConstArray(m_pmp, pexprArray);
+
+	pexprArray->Release();
+
+	return pexprCollapsedArray;
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -6698,7 +6698,15 @@ CTranslatorExprToDXL::PdxlnArray
 									)
 						);
 
-	TranslateScalarChildren(pexpr, pdxlnArray);
+	const ULONG ulArity = CUtils::UlScalarArrayArity(pexpr);
+
+	for (ULONG ul = 0; ul < ulArity; ul++)
+	{
+		CExpression *pexprChild = CUtils::PScalarArrayExprChildAt(m_pmp, pexpr, ul);
+		CDXLNode *pdxlnChild = PdxlnScalar(pexprChild);
+		pdxlnArray->AddChild(pdxlnChild);
+		pexprChild->Release();
+	}
 
 	return pdxlnArray;
 }

--- a/server/include/unittest/gpopt/translate/CTranslatorDXLToExprTest.h
+++ b/server/include/unittest/gpopt/translate/CTranslatorDXLToExprTest.h
@@ -83,6 +83,7 @@ namespace gpopt
 			static GPOS_RESULT EresUnittest_LimitNoOffset();
 			static GPOS_RESULT EresUnittest_ScalarSubquery();
 			static GPOS_RESULT EresUnittest_TVF();
+			static GPOS_RESULT EresUnittest_SelectQueryWithConstInList();
 			
 	}; // class CTranslatorDXLToExprTest
 }


### PR DESCRIPTION
This is a new approach to achieve the cleaner code for the previous pull request.

Instead of creating a new operator, `CScalarArray` is updated and utility functions are created to consume new operator's features in the codebase. The collapsed constants are stored in the `CScalarArray` in itself. 

"When there is large number of values in the array or IN list, Orca spent a lot of time on optimization. The reason is that every const item in the array is used to create a group and group expression in the MEMO structure. For scalar const values in the array, it is not necessary to create the MEMO group for it. We create a new scalar operator CScalarConstArray to treat the constant values in the children expression as its attribute, which avoids the MEMO group creation for constant values to achieve performance improvement."