### PR TITLE
[#141511349] Improve HashMap iterator implementation

### DIFF
--- a/libgpos/include/gpos/common/CHashMap.h
+++ b/libgpos/include/gpos/common/CHashMap.h
@@ -102,7 +102,7 @@ namespace gpos
 			};
 
 			// memory pool
-			IMemoryPool *m_pmp;
+			IMemoryPool *const m_pmp;
 			
 			// size
 			ULONG m_ulSize;
@@ -112,11 +112,14 @@ namespace gpos
 
 			// each hash chain is an array of hashmap elements
 			typedef CDynamicPtrArray<CHashMapElem, CleanupDelete> DrgHashChain;
-			DrgHashChain **m_ppdrgchain;
+			DrgHashChain **const m_ppdrgchain;
 
 			// array for keys
+			// We use CleanupNULL because the keys are owned by the hash table
 			typedef CDynamicPtrArray<K, CleanupNULL> DrgKeys;
-			DrgKeys *m_pdrgKeys;
+			DrgKeys *const m_pdrgKeys;
+
+			DrgPi *const m_pdrgPiFilledBuckets;
 
 			// private copy ctor
 			CHashMap(const CHashMap<K, T, pfnHash, pfnEq, pfnDestroyK, pfnDestroyT> &);

--- a/libgpos/include/gpos/common/CHashMap.h
+++ b/libgpos/include/gpos/common/CHashMap.h
@@ -109,10 +109,14 @@ namespace gpos
 		
 			// number of entries
 			ULONG m_ulEntries;
-		
+
 			// each hash chain is an array of hashmap elements
 			typedef CDynamicPtrArray<CHashMapElem, CleanupDelete> DrgHashChain;
 			DrgHashChain **m_ppdrgchain;
+
+			// array for keys
+			typedef CDynamicPtrArray<K, CleanupNULL> DrgKeys;
+			DrgKeys *m_pdrgKeys;
 
 			// private copy ctor
 			CHashMap(const CHashMap<K, T, pfnHash, pfnEq, pfnDestroyK, pfnDestroyT> &);

--- a/libgpos/include/gpos/common/CHashMap.inl
+++ b/libgpos/include/gpos/common/CHashMap.inl
@@ -123,6 +123,7 @@ namespace gpos
 		
 		m_ppdrgchain = GPOS_NEW_ARRAY(m_pmp, DrgHashChain*, m_ulSize);
 		(void) clib::PvMemSet(m_ppdrgchain, 0, m_ulSize * sizeof(DrgHashChain*));
+		m_pdrgKeys = GPOS_NEW(m_pmp) DrgKeys(m_pmp);
 	}
 
 
@@ -145,6 +146,7 @@ namespace gpos
 		Clear();
 		
 		GPOS_DELETE_ARRAY(m_ppdrgchain);
+		m_pdrgKeys->Release();
 	}
 
 
@@ -204,11 +206,13 @@ namespace gpos
 		{
 			*ppdrgchain = GPOS_NEW(m_pmp) DrgHashChain(m_pmp);
 		}
-		
+
 		CHashMapElem *phme = GPOS_NEW(m_pmp) CHashMapElem(pk, pt, true /*fOwn*/);
 		(*ppdrgchain)->Append(phme);
-		
+
 		m_ulEntries++;
+
+		m_pdrgKeys->Append(pk);
 		return true;
 	}
 	

--- a/libgpos/include/gpos/common/CHashMapIter.h
+++ b/libgpos/include/gpos/common/CHashMapIter.h
@@ -45,9 +45,9 @@ namespace gpos
 			// current hashchain
 			ULONG m_ulChain;
 
-			// current cursor
-			ULONG m_ulElement;
-			
+			// current key
+			ULONG m_ulKey;
+
 			// is initialized?
 			BOOL m_fInit;
 

--- a/libgpos/include/gpos/common/CHashMapIter.inl
+++ b/libgpos/include/gpos/common/CHashMapIter.inl
@@ -34,7 +34,7 @@ namespace gpos
 		: 
 		m_ptm(ptm),
 		m_ulChain(0),
-		m_ulElement((ULONG)-1)
+		m_ulKey(0)
 	{
 		GPOS_ASSERT(NULL != ptm);
 	}
@@ -45,8 +45,7 @@ namespace gpos
 	//		CHashMapIter::FAdvance
 	//
 	//	@doc:
-	//		Advance cursor; increment element position -- if not existent, try
-	//		to find next existing hash chain;
+	//		Get the next existent hash chain
 	//
 	//---------------------------------------------------------------------------
 	template <class K, class T, 
@@ -57,24 +56,12 @@ namespace gpos
 	BOOL
 	CHashMapIter<K, T,pfnHash, pfnEq, pfnDestroyK, pfnDestroyT>::FAdvance()
 	{
-		// bump counter
-		m_ulElement++;
-
-		// if position is not valid, find next valid element
-		while (m_ulChain < m_ptm->m_ulSize)
+		if (m_ulKey < m_ptm->m_pdrgKeys->UlLength())
 		{
-			typename TMap::DrgHashChain *pdrgchain;
-			pdrgchain = m_ptm->m_ppdrgchain[m_ulChain];
-			
-			if (NULL != pdrgchain && m_ulElement < pdrgchain->UlLength())
-			{
-				return true;
-			}
-
-			m_ulElement = 0;
-			m_ulChain++;
+			m_ulKey++;
+			return true;
 		}
-		
+
 		return false;
 	}
 
@@ -94,16 +81,11 @@ namespace gpos
 	const typename CHashMap<K, T, pfnHash, pfnEq, pfnDestroyK, pfnDestroyT>::CHashMapElem *
 	CHashMapIter<K, T, pfnHash, pfnEq, pfnDestroyK, pfnDestroyT>::Phme() const
 	{
-		typename TMap::DrgHashChain *pdrgchain;
-		pdrgchain = m_ptm->m_ppdrgchain[m_ulChain];
-		GPOS_ASSERT(NULL != pdrgchain);
-			
-		if (m_ulElement < pdrgchain->UlLength())
-		{
-			return (*pdrgchain)[m_ulElement];
-		}
-		
-		return NULL;
+		typename TMap::CHashMapElem *phme = NULL;
+		K *k = (*(m_ptm->m_pdrgKeys))[m_ulKey-1];
+		m_ptm->Lookup(k, &phme);
+
+		return phme;
 	}
 
 


### PR DESCRIPTION
Currently, the HashMapIter implementation scans through all hash map
buckets to get the next existing hash chain. This degrades performance
significantly.

This commit improves the iterator implementation by maintaining a
dynamic key array which holds the existing keys in HashMap. The
iteration is done using this array.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>