### PR TITLE
Improve FEqual() in CCTEReq

### DIFF
--- a/libgpopt/include/gpopt/base/CCTEReq.h
+++ b/libgpopt/include/gpopt/base/CCTEReq.h
@@ -170,7 +170,7 @@ namespace gpopt
 					const
 			{
 				GPOS_ASSERT(NULL != pcter);
-				return this->FSubset(pcter) && pcter->FSubset(this);
+				return (m_phmcter->UlEntries() == pcter->m_phmcter->UlEntries()) && this->FSubset(pcter);
 			}
 
 			// check if current requirement is a subset of the given one


### PR DESCRIPTION
We do not need to call FSubset() twice to check for equality.
Two CTE requirements will be considered equal if their lengths match and
one is subset of the other.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>