### PR TITLE
Improve Match Part Constraints logic

### DIFF
--- a/libgpopt/src/operators/CPhysicalPartitionSelector.cpp
+++ b/libgpopt/src/operators/CPhysicalPartitionSelector.cpp
@@ -178,7 +178,7 @@ CPhysicalPartitionSelector::FMatchPartCnstr
 		return NULL == m_ppartcnstrmap && NULL == ppartcnstrmap;
 	}
 
-	return FSubsetPartCnstr(m_ppartcnstrmap, ppartcnstrmap) &&
+	return m_ppartcnstrmap->UlEntries() == ppartcnstrmap->UlEntries() &&
 			FSubsetPartCnstr(ppartcnstrmap, m_ppartcnstrmap);
 }
 


### PR DESCRIPTION
We do not need to call FSubsetPartCnstr() twice to check for equality.
Two part constraints can are equal if their lengths match and
one is subset of the other.

Signed-off-by: Omer Arap <oarap@pivotal.io>