### PR TITLE
Remove relation mdid from indices

### DIFF
--- a/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Frames-Query.xml
+++ b/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Frames-Query.xml
@@ -614,7 +614,7 @@ select * from x where x.i in (select last_value(y.i) over(partition by x.i order
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -693,7 +693,7 @@ select * from x where x.i in (select last_value(y.i) over(partition by x.i order
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Query.xml
+++ b/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Query.xml
@@ -627,7 +627,7 @@ select * from x where x.i in (select row_number() over(partition by x.i order by
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -696,7 +696,7 @@ select * from x where x.i in (select row_number() over(partition by x.i order by
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Query.xml
+++ b/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Query.xml
@@ -627,7 +627,7 @@ select * from x where x.i in (select row_number() over(partition by x.i) from y)
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -684,7 +684,7 @@ select * from x where x.i in (select row_number() over(partition by x.i) from y)
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/indexjoin/positive_04.mdp
+++ b/data/dxl/indexjoin/positive_04.mdp
@@ -3538,7 +3538,7 @@
           <dxl:OpClass Mdid="0.3018.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.33052642.1.0" Name="store_sales_pkey" RelationMdid="0.33052616.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.33052642.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -8553,7 +8553,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33052182.1.0" Name="store_returns_pkey" RelationMdid="0.33052156.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26">
+      <dxl:Index Mdid="0.33052182.1.0" Name="store_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -13337,7 +13337,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABldv" LintValue="756671276"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.33051952.1.0" Name="item_pkey" RelationMdid="0.33051926.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.33051952.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/metadata/md.xml
+++ b/data/dxl/metadata/md.xml
@@ -100,12 +100,12 @@
       <dxl:Triggers/>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" RelationMdid="0.1234.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" KeyColumns="1" IncludedColumns="0,1">
       <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
        </dxl:OpClasses>       
     </dxl:Index>
-    <dxl:Index Mdid="0.2347.1.1" Name="T_a" RelationMdid="0.1234.1.1" IsClustered="false" KeyColumns="0" IncludedColumns="0,1">
+    <dxl:Index Mdid="0.2347.1.1" Name="T_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1">
       <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
        </dxl:OpClasses>  
@@ -1139,7 +1139,7 @@
       </dxl:PartConstraint>                                                                                                                                                                
     </dxl:Relation> 
     
-    <dxl:Index Mdid="0.13144342.1.0" Name="idx_p1_j_1_prt_p11" RelationMdid="0.5369655.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1"> 
+    <dxl:Index Mdid="0.13144342.1.0" Name="idx_p1_j_1_prt_p11" IsClustered="false" KeyColumns="1" IncludedColumns="0,1">
        <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
        </dxl:OpClasses>  
@@ -1169,7 +1169,7 @@
        </dxl:PartConstraint>                                                                                                                                         
      </dxl:Index>
      
-     <dxl:Index Mdid="0.13144285.1.0" Name="idx_p1_i_1_prt_p11" RelationMdid="0.5369655.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1">
+     <dxl:Index Mdid="0.13144285.1.0" Name="idx_p1_i_1_prt_p11" IsClustered="false" KeyColumns="0" IncludedColumns="0,1">
        <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
        </dxl:OpClasses>   
@@ -2831,13 +2831,13 @@
        <dxl:SumAgg Mdid="0.0.0.0"/>                                                                                                                                                  
        <dxl:CountAgg Mdid="0.2147.1.0"/>                                                                                                 
      </dxl:Type>                                                                                                                       
-     <dxl:Index Mdid="0.197454.1.1" Name="foo_ab" RelationMdid="0.197339.1.0" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4">
+     <dxl:Index Mdid="0.197454.1.1" Name="foo_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4">
       <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
           <dxl:OpClass Mdid="0.434.1.0"/>
        </dxl:OpClasses>        
     </dxl:Index> 
-     <dxl:Index Mdid="0.197514.1.1" Name="foo_bitmap_c" RelationMdid="0.197339.1.0" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4">
+     <dxl:Index Mdid="0.197514.1.1" Name="foo_bitmap_c" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4">
        <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
        </dxl:OpClasses>         
@@ -3659,7 +3659,7 @@
        <dxl:Triggers/>                                                                                                                                                   
        <dxl:CheckConstraints/>                                                                                                                                           
      </dxl:Relation>
-     <dxl:Index Mdid="0.27324.1.0" Name="p_ind" RelationMdid="0.27118.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+     <dxl:Index Mdid="0.27324.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
       <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
        </dxl:OpClasses>   

--- a/data/dxl/minidump/AssertMaxOneRow.mdp
+++ b/data/dxl/minidump/AssertMaxOneRow.mdp
@@ -743,13 +743,13 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
           <dxl:OpClass Mdid="0.3033.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" RelationMdid="0.1259.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" RelationMdid="0.1259.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BTreeIndex-Against-InList.mdp
+++ b/data/dxl/minidump/BTreeIndex-Against-InList.mdp
@@ -247,7 +247,7 @@ SELECT * FROM test WHERE a in (1, 47);
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.41665.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.41665.1.1.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.41692.1.0" Name="test_index" RelationMdid="0.41665.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.41692.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1976.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -30,7 +30,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.4524693.1.0" Name="test_index" RelationMdid="0.4524666.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.4524693.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1976.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapBoolAnd.mdp
+++ b/data/dxl/minidump/BitmapBoolAnd.mdp
@@ -193,12 +193,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -206,14 +206,14 @@
       <dxl:ColumnStatistics Mdid="1.145159.1.1.10" Name="gp_segment_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.3" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.5" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.4" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
+++ b/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
@@ -194,22 +194,22 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
+++ b/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
@@ -36,7 +36,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" RelationMdid="0.1632545.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -257,7 +257,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" RelationMdid="0.1632545.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
+++ b/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
@@ -37,7 +37,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" RelationMdid="0.1632545.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -258,7 +258,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" RelationMdid="0.1632545.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
+++ b/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
@@ -23,7 +23,7 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
       <dxl:TraceFlags Value="102004,102005,102006,102007,102024,102025,102121,103001,103016"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.21849037.1.0" Name="idx_t_1" RelationMdid="0.21849009.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.21849037.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3017.1.0"/>
         </dxl:OpClasses>
@@ -243,12 +243,12 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
           <dxl:UpperBound Closed="true" TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.21849058.1.0" Name="idx_t_2" RelationMdid="0.21849009.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.21849058.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3017.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.21849079.1.0" Name="idx_t_3" RelationMdid="0.21849009.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.21849079.1.0" Name="idx_t_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapBoolOr.mdp
+++ b/data/dxl/minidump/BitmapBoolOr.mdp
@@ -213,12 +213,12 @@ explain select * from r where a = 1 or b = 2;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -226,14 +226,14 @@ explain select * from r where a = 1 or b = 2;
       <dxl:ColumnStatistics Mdid="1.145159.1.1.10" Name="gp_segment_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.3" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.5" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.4" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" RelationMdid="0.145159.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndex-Against-InList.mdp
+++ b/data/dxl/minidump/BitmapIndex-Against-InList.mdp
@@ -15,7 +15,7 @@ SELECT * FROM bitmap_test WHERE a in (1, 47);
       <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.4513675.1.0" Name="bitmap_index" RelationMdid="0.4513648.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.4513675.1.0" Name="bitmap_index" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
@@ -283,7 +283,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.29237539.1.1.7" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29237539.1.1.6" Name="c7" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.29237567.1.0" Name="idx_t_2" RelationMdid="0.29237539.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.29237567.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
@@ -187,7 +187,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2;
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.10" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.3" Name="c4" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.2" Name="c3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.29842205.1.0" Name="idx_t_2" RelationMdid="0.29842149.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.29842205.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
@@ -46,7 +46,7 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31264085.1.0" Name="idx_t_1" RelationMdid="0.31264029.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.31264085.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -141,7 +141,7 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31264106.1.0" Name="idx_t_2" RelationMdid="0.31264029.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.31264106.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
           <dxl:OpClass Mdid="0.3022.1.0"/>

--- a/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
@@ -263,7 +263,7 @@ select * from x, y where x.i > y.j and y.k = 10;
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.10" Name="gp_segment_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.3" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.52975773.1.0" Name="y_idx" RelationMdid="0.52975747.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.52975773.1.0" Name="y_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -329,7 +329,7 @@ select * from x, y where x.i > y.j and y.k = 10;
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.10" Name="gp_segment_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.3" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.53062705.1.0" Name="y_idx_1_prt_1" RelationMdid="0.53062540.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.53062705.1.0" Name="y_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -860,7 +860,7 @@ ORDER BY 1 asc ;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" RelationMdid="0.16166659.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1980.1.0"/>
           <dxl:OpClass Mdid="0.1980.1.0"/>

--- a/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
+++ b/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
@@ -611,7 +611,7 @@ inferred from the second operator (c4 = 'f')
           <dxl:OpClass Mdid="0.3017.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.22226547.1.0" Name="idx_t_1" RelationMdid="0.22226519.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.22226547.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3017.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/data/dxl/minidump/BitmapIndexScan.mdp
@@ -187,7 +187,7 @@ see sql/BitmapIndexScan.sql
       <dxl:ColumnStatistics Mdid="1.24702.1.1.12" Name="dataowner" Width="0.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.24702.1.1.5" Name="created_by" Width="0.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.24702.1.1.4" Name="creation_date" Width="4.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.24762.1.0" Name="inner_table_idx" RelationMdid="0.24732.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.24762.1.0" Name="inner_table_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1988.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
+++ b/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
@@ -712,7 +712,7 @@ c4 = 'f'
         <dxl:Commutator Mdid="0.85.1.0"/>
         <dxl:InverseOp Mdid="0.91.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.22226400.1.0" Name="idx_t_1" RelationMdid="0.22226372.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.22226400.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3017.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
+++ b/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
@@ -236,7 +236,7 @@ explain select * from indexonao where a = 21;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99997"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.22227385.1.0" Name="idx_onao" RelationMdid="0.22227328.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+      <dxl:Index Mdid="0.22227385.1.0" Name="idx_onao" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapTableScan-AO.mdp
+++ b/data/dxl/minidump/BitmapTableScan-AO.mdp
@@ -512,7 +512,7 @@ explain select * from t_ao where c2 = 'HEAP';
         <dxl:SumAgg Mdid="0.2111.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.21846783.1.0" Name="idx_t_ao_3" RelationMdid="0.21846751.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.21846783.1.0" Name="idx_t_ao_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3035.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
+++ b/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
@@ -214,7 +214,7 @@ explain select * from xfoo where j = 1 and k = 2;
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.51565282.1.0" Name="idx_jk" RelationMdid="0.51565256.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.51565282.1.0" Name="idx_jk" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
           <dxl:OpClass Mdid="0.3027.1.0"/>

--- a/data/dxl/minidump/BitmapTableScan-Basic.mdp
+++ b/data/dxl/minidump/BitmapTableScan-Basic.mdp
@@ -8,7 +8,7 @@
       <dxl:TraceFlags Value="101001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" RelationMdid="0.9459819.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
+++ b/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
@@ -255,7 +255,7 @@ SELECT * FROM my_tq_agg_small tq WHERE 110 >= tq.ets;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31763881.1.0" Name="my_idx" RelationMdid="0.31763855.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.31763881.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -201,7 +201,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.2435227.1.1.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.2435227.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.2435371.1.0" Name="pp_1_prt_1_idx" RelationMdid="0.2435227.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.2435371.1.0" Name="pp_1_prt_1_idx" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1976.1.0"/>
         </dxl:OpClasses>
@@ -218,7 +218,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.2435390.1.0" Name="pp_rest_1_idx" RelationMdid="0.2435227.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="2,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.2435390.1.0" Name="pp_rest_1_idx" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="2,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1976.1.0"/>
           <dxl:OpClass Mdid="0.1976.1.0"/>

--- a/data/dxl/minidump/CTE-12.mdp
+++ b/data/dxl/minidump/CTE-12.mdp
@@ -1987,7 +1987,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAAB1pXRQ==" LintValue="795648812"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.3061052.1.0" Name="country_pkey" RelationMdid="0.3060954.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21">
+      <dxl:Index Mdid="0.3061052.1.0" Name="country_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -5830,7 +5830,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.26188.1.0" Name="item_pkey" RelationMdid="0.25160.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.26188.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -164,12 +164,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2698.1.0" Name="pg_tablespace_spcname_index" RelationMdid="0.1213.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2698.1.0" Name="pg_tablespace_spcname_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2672.1.0" Name="pg_database_oid_index" RelationMdid="0.1262.1.0" IsClustered="false" KeyColumns="12" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
+      <dxl:Index Mdid="0.2672.1.0" Name="pg_database_oid_index" IsClustered="false" KeyColumns="12" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
@@ -338,12 +338,12 @@
       <dxl:GPDBFunc Mdid="0.1597.1.0" Name="pg_encoding_to_char" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.19.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.2697.1.0" Name="pg_tablespace_oid_index" RelationMdid="0.1213.1.0" IsClustered="false" KeyColumns="8" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2697.1.0" Name="pg_tablespace_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2671.1.0" Name="pg_database_datname_index" RelationMdid="0.1262.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
+      <dxl:Index Mdid="0.2671.1.0" Name="pg_database_datname_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/CoerceToDomain.mdp
+++ b/data/dxl/minidump/CoerceToDomain.mdp
@@ -957,12 +957,12 @@ SELECT * FROM information_schema.tables;
         <dxl:Commutator Mdid="0.607.1.0"/>
         <dxl:InverseOp Mdid="0.608.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" RelationMdid="0.1259.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" RelationMdid="0.1259.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
@@ -1630,12 +1630,12 @@ SELECT * FROM information_schema.tables;
           <dxl:UpperBound Closed="true" TypeMdid="0.26.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" RelationMdid="0.2615.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" RelationMdid="0.2615.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -46,12 +46,12 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
       <dxl:TraceFlags Value="102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" RelationMdid="0.29191849.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" RelationMdid="0.29191993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.0.0.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -479,7 +479,7 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" RelationMdid="0.29191945.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -46,12 +46,12 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
       <dxl:TraceFlags Value="102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" RelationMdid="0.29191849.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" RelationMdid="0.29191993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.0.0.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -478,7 +478,7 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" RelationMdid="0.29191945.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
+++ b/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
@@ -275,7 +275,7 @@ where a=1 and b>0;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.2155361.1.1.5" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.2155361.1.1.4" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.2155640.1.0" Name="sc_part_idx_b_1_prt_extra" RelationMdid="0.2155361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.2155640.1.0" Name="sc_part_idx_b_1_prt_extra" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DirectDispatch-IndexScan.mdp
+++ b/data/dxl/minidump/DirectDispatch-IndexScan.mdp
@@ -366,12 +366,12 @@ where a=1 and b=0;
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962926.1.0" Name="sc_idx_b" RelationMdid="0.1962900.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1962926.1.0" Name="sc_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.1975983.1.0" Name="sc_idx_bc" RelationMdid="0.1962900.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1975983.1.0" Name="sc_idx_bc" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/minidump/DynamicBitmapBoolOp.mdp
+++ b/data/dxl/minidump/DynamicBitmapBoolOp.mdp
@@ -17,7 +17,7 @@
       <dxl:TraceFlags Value="102006,102024,102025,103001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.672579.1.0" Name="p_b_1_prt_1" RelationMdid="0.671910.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.672579.1.0" Name="p_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -135,7 +135,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.672348.1.0" Name="p_a_1_prt_1" RelationMdid="0.671910.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.672348.1.0" Name="p_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -318,7 +318,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.671910.1.1.5" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.671910.1.1.4" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.672810.1.0" Name="p_c_1_prt_1" RelationMdid="0.671910.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.672810.1.0" Name="p_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -373,7 +373,7 @@ see sql/DynamicBitmapIndexScan.sql
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.16959.1.1.1" Name="flex_value_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16959.1.1.0" Name="flex_value_set_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.17270.1.0" Name="inner_table_idx_1_prt_other" RelationMdid="0.16959.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.17270.1.0" Name="inner_table_idx_1_prt_other" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3032.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -8,7 +8,7 @@
       <dxl:TraceFlags Value="101001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" RelationMdid="0.9459819.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
+++ b/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
@@ -115,7 +115,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.816512.1.1.3" Name="t" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.816512.1.1.2" Name="j" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.816754.1.0" Name="bm_test_idx_part" RelationMdid="0.816512.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" IsPartial="true" KeyColumns="0" IncludedColumns="0,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.816754.1.0" Name="bm_test_idx_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" IsPartial="true" KeyColumns="0" IncludedColumns="0,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -178,7 +178,7 @@ WHERE
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1096283.1.0" Name="date_dim_1_prt_p1_1_pkey" RelationMdid="0.1096216.1.0" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1096283.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
           <dxl:OpClass Mdid="0.3027.1.0"/>

--- a/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
@@ -190,7 +190,7 @@
         <dxl:Commutator Mdid="0.523.1.0"/>
         <dxl:InverseOp Mdid="0.97.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" RelationMdid="0.296682.1.0" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
@@ -190,7 +190,7 @@
         <dxl:Commutator Mdid="0.523.1.0"/>
         <dxl:InverseOp Mdid="0.97.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" RelationMdid="0.296682.1.0" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
       <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -287,7 +287,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.274813.1.0" Name="p_1_prt_3_ind_bc" RelationMdid="0.266602.1.1" IsClustered="false" IsPartial="true" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.274813.1.0" Name="p_1_prt_3_ind_bc" IsClustered="false" IsPartial="true" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
       <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
           <dxl:OpClass Mdid="0.3027.1.0"/>
@@ -491,7 +491,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.267021.1.0" Name="p_def_ind_c" RelationMdid="0.266602.1.1" IsClustered="false" IsPartial="true" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.267021.1.0" Name="p_def_ind_c" IsClustered="false" IsPartial="true" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -167,7 +167,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.274855.1.1.3" Name="ctid" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.274855.1.1.2" Name="c" Width="8.000000"/>
-      <dxl:Index Mdid="0.275094.1.0" Name="ppp_1_prt_extra_ind_c" RelationMdid="0.274855.1.1" IsClustered="false" IsPartial="true" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.275094.1.0" Name="ppp_1_prt_extra_ind_c" IsClustered="false" IsPartial="true" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
@@ -267,7 +267,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.567110.1.0" Name="testbug_char5_tag1_1_prt_part201203" RelationMdid="0.566955.1.0" IsClustered="false" KeyColumns="3" IncludedColumns="0,1,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.567110.1.0" Name="testbug_char5_tag1_1_prt_part201203" IsClustered="false" KeyColumns="3" IncludedColumns="0,1,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.426.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -186,7 +186,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" RelationMdid="0.318877.1.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -86,7 +86,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.3" Name="1.27119.15.1.3" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.2" Name="1.27119.15.1.2" Width="8.000000"/>
-      <dxl:Index Mdid="0.2732323.15.0" Name="p2_ind" RelationMdid="0.27119.15.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.2732323.15.0" Name="p2_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
          <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -186,7 +186,7 @@
       <dxl:ColumnStatistics Mdid="1.27119.15.1.8" Name="1.27119.15.1.8" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.0" Name="1.27119.15.1.0" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.1" Name="1.27119.15.1.1" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.15.1" Name="p_ind" RelationMdid="0.27119.15.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27323.15.1" Name="p_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -84,7 +84,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2732323.25.0" Name="p2_ind" RelationMdid="0.27119.25.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.2732323.25.0" Name="p2_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -104,7 +104,7 @@
       <dxl:ColumnStatistics Mdid="1.27119.25.1.8" Name="1.27119.25.1.8" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.25.1.0" Name="1.27119.25.1.0" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.25.1.1" Name="1.27119.25.1.1" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.25.0" Name="p_ind" RelationMdid="0.27119.25.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27323.25.0" Name="p_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -86,7 +86,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" RelationMdid="0.161992.1.0" IsClustered="false" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -86,7 +86,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" RelationMdid="0.161992.1.0" IsClustered="false" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
@@ -84,7 +84,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.29165.1.0" Name="p_ind" RelationMdid="0.28421.1.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.29165.1.0" Name="p_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -162,7 +162,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" RelationMdid="0.318877.1.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
@@ -31,7 +31,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.1637610.1.1.7" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.1637610.1.1.6" Name="c7" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.1637960.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p1" RelationMdid="0.1637610.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1637960.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p1" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -165,7 +165,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1637979.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p2" RelationMdid="0.1637610.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1637979.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -86,7 +86,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.27119.1.1.5" Name="xmax" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.1.1.4" Name="cmin" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.1.0" Name="p_ind" RelationMdid="0.27119.1.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27323.1.0" Name="p_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -103,7 +103,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.2732323.1.0" Name="p2_ind" RelationMdid="0.27119.1.1" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.2732323.1.0" Name="p2_ind" IsClustered="false" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -136,7 +136,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.7" Name="cmax" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.6" Name="xmax" Width="8.000000"/>
-      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" RelationMdid="0.310650.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
         </dxl:OpClasses>
@@ -215,7 +215,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" RelationMdid="0.310650.1.1" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
           <dxl:OpClass Mdid="0.3027.1.0"/>

--- a/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -99,7 +99,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.7" Name="cmax" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.6" Name="xmax" Width="8.000000"/>
-      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" RelationMdid="0.310650.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
         </dxl:OpClasses>
@@ -199,7 +199,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" RelationMdid="0.310650.1.1" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.434.1.0"/>
           <dxl:OpClass Mdid="0.3027.1.0"/>

--- a/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -139,7 +139,7 @@
       </dxl:GPDBFunc>
       <dxl:ColumnStatistics Mdid="1.27118.1.1.7" Name="tableoid" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27118.1.1.6" Name="cmax" Width="8.000000"/>
-      <dxl:Index Mdid="0.27322.1.0" Name="p_ind" RelationMdid="0.27118.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27322.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -154,7 +154,7 @@
         <dxl:Commutator Mdid="0.521.1.0"/>
         <dxl:InverseOp Mdid="0.525.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1122360.1.0" Name="t2_pfirst_ind" RelationMdid="0.1122228.1.0" IsClustered="false" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1122360.1.0" Name="t2_pfirst_ind" IsClustered="false" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
+++ b/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
@@ -657,7 +657,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABzk3Mw==" LintValue="921330540"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.607634.1.0" Name="p_idx_1_prt_1" RelationMdid="0.607198.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.607634.1.0" Name="p_idx_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.2003.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Gb-on-keys.mdp
+++ b/data/dxl/minidump/Gb-on-keys.mdp
@@ -55,7 +55,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.1154027.1.1.5" Name="cmin" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.1154027.1.1.4" Name="xmin" Width="8.000000"/>
-      <dxl:Index Mdid="0.1154050.1.0" Name="keys_pkey" RelationMdid="0.1154027.1.0" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1154050.1.0" Name="keys_pkey" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -3358,7 +3358,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="18000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.672881.1.0" Name="item_pkey" RelationMdid="0.672855.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.672881.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -7880,7 +7880,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:OpClass Mdid="0.3032.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.673571.1.0" Name="store_sales_pkey" RelationMdid="0.673545.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.673571.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -442,7 +442,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42822830.1.0" Name="dbs_index1_1_prt_1" RelationMdid="0.42822392.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.42822830.1.0" Name="dbs_index1_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/InEqualityJoin.mdp
+++ b/data/dxl/minidump/InEqualityJoin.mdp
@@ -2353,7 +2353,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.26529.1.0" Name="web_sales_pkey" RelationMdid="0.25732.1.0" IsClustered="false" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.26529.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
+++ b/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
@@ -168,7 +168,7 @@ select * from x, y where (x.i > y.j);
       <dxl:ColumnStatistics Mdid="1.54648535.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.54648430.1.1.7" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.54648430.1.1.6" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.54648640.1.0" Name="x_idx_2" RelationMdid="0.54648430.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.54648640.1.0" Name="x_idx_2" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -300,7 +300,7 @@ select * from x, y where (x.i > y.j);
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.54648659.1.0" Name="y_idx_2" RelationMdid="0.54648535.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.54648659.1.0" Name="y_idx_2" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
+++ b/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
@@ -374,7 +374,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.16033549.1.1.7" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.16033549.1.1.6" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.16033719.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" RelationMdid="0.16033575.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16033719.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -402,7 +402,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.16033738.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" RelationMdid="0.16033575.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16033738.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
+++ b/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
@@ -270,7 +270,7 @@ ORDER BY 1 asc ;
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16032679.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" RelationMdid="0.16032574.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16032679.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -408,7 +408,7 @@ ORDER BY 1 asc ;
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16032698.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_3" RelationMdid="0.16032574.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16032698.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_3" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -68,7 +68,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" RelationMdid="0.9393858.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -68,7 +68,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" RelationMdid="0.9393858.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
@@ -229,7 +229,7 @@
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.7" Name="tableoid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.6" Name="cmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" RelationMdid="0.9385666.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -68,7 +68,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" RelationMdid="0.9393858.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -229,7 +229,7 @@
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.7" Name="tableoid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.6" Name="cmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" RelationMdid="0.9385666.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-IndexOnMasterOnlyTable.mdp
+++ b/data/dxl/minidump/IndexApply-IndexOnMasterOnlyTable.mdp
@@ -481,7 +481,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" RelationMdid="0.1259.1.0" IsClustered="false" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
@@ -966,7 +966,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" RelationMdid="0.1259.1.0" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1086.1.0"/>
           <dxl:OpClass Mdid="0.1089.1.0"/>

--- a/data/dxl/minidump/IndexApply-InnerSelect-Basic.mdp
+++ b/data/dxl/minidump/IndexApply-InnerSelect-Basic.mdp
@@ -362,7 +362,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
           <dxl:OpClass Mdid="0.3040.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.32518895.1.0" Name="idx_t_2" RelationMdid="0.32518867.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.32518895.1.0" Name="idx_t_2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1994.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
+++ b/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
@@ -340,7 +340,7 @@ WHERE tt.event_ts >= tq.ets AND
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.32989821.1.1.5" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989821.1.1.4" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.32989991.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" RelationMdid="0.32989847.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.32989991.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -362,7 +362,7 @@ WHERE tt.event_ts >= tq.ets AND
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.10" Name="tableoid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.3" Name="ask_price" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.2" Name="bid_price" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.32990010.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" RelationMdid="0.32989847.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.32990010.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
+++ b/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
@@ -301,7 +301,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32553517.1.0" Name="idx_t_2_1_prt_p1" RelationMdid="0.32553346.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.32553517.1.0" Name="idx_t_2_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1994.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -312,7 +312,7 @@ Table X (int i, int j) is distributed by i, column j has index
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -344,7 +344,7 @@ Table X (int i, int j) is distributed by i, column j has index
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -56,7 +56,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.7" Name="tableoid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.6" Name="cmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881168.1.0" Name="idx_z_p_j_1_prt_z_p1" RelationMdid="0.41880987.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.41881168.1.0" Name="idx_z_p_j_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -179,7 +179,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.4" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.5" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.4" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" RelationMdid="0.41880825.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -333,7 +333,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.6" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.2" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" RelationMdid="0.41880987.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
+++ b/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
@@ -482,7 +482,7 @@ select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
           <dxl:UpperBound Closed="true" TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAAJGVjY2JjODdlNGI1Y2UyZmUyODMwOGZkOWYyYTdiYWYz" LintValue="162161524"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.26855161.1.0" Name="y_idx_1_prt_def" RelationMdid="0.26854909.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.26855161.1.0" Name="y_idx_1_prt_def" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1994.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -861,7 +861,7 @@ ORDER BY 1 asc ;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" RelationMdid="0.16166659.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1980.1.0"/>
           <dxl:OpClass Mdid="0.1980.1.0"/>

--- a/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -312,7 +312,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -333,7 +333,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" RelationMdid="0.16422594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
+++ b/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
@@ -272,7 +272,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="8.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" RelationMdid="0.40972.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply1.mdp
+++ b/data/dxl/minidump/IndexApply1.mdp
@@ -271,7 +271,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="8.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" RelationMdid="0.40972.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply2.mdp
+++ b/data/dxl/minidump/IndexApply2.mdp
@@ -264,7 +264,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="8.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" RelationMdid="0.40972.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply3.mdp
+++ b/data/dxl/minidump/IndexApply3.mdp
@@ -271,7 +271,7 @@
         <dxl:OpFunc Mdid="0.177.1.0"/>
         <dxl:Commutator Mdid="0.551.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" RelationMdid="0.40972.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexApply4.mdp
+++ b/data/dxl/minidump/IndexApply4.mdp
@@ -271,7 +271,7 @@
         <dxl:OpFunc Mdid="0.177.1.0"/>
         <dxl:Commutator Mdid="0.551.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" RelationMdid="0.40972.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -119,7 +119,7 @@
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.8" Name="gp_segment_id" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.1" Name="b" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.0" Name="a" Width="8.000000"/>
-      <dxl:Index Mdid="0.1119939.1.0" Name="t_a" RelationMdid="0.1119916.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1119939.1.0" Name="t_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexScan-AOTable.mdp
+++ b/data/dxl/minidump/IndexScan-AOTable.mdp
@@ -46,7 +46,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.507751.1.0" Name="ao_j" RelationMdid="0.507724.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.507751.1.0" Name="ao_j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexScan-BoolFalse.mdp
+++ b/data/dxl/minidump/IndexScan-BoolFalse.mdp
@@ -53,7 +53,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.296558.1.0" Name="s_b" RelationMdid="0.296532.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexScan-BoolTrue.mdp
+++ b/data/dxl/minidump/IndexScan-BoolTrue.mdp
@@ -53,7 +53,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.296558.1.0" Name="s_b" RelationMdid="0.296532.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexScan-DroppedColumns.mdp
+++ b/data/dxl/minidump/IndexScan-DroppedColumns.mdp
@@ -66,7 +66,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.567205.1.0" Name="r_c" RelationMdid="0.567182.1.0" IsClustered="false" KeyColumns="2" IncludedColumns="0,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.567205.1.0" Name="r_c" IsClustered="false" KeyColumns="2" IncludedColumns="0,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/IndexScan-Relabel.mdp
+++ b/data/dxl/minidump/IndexScan-Relabel.mdp
@@ -613,7 +613,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.603018.1.0" Name="r_idx" RelationMdid="0.602992.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.603018.1.0" Name="r_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.2003.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -61,7 +61,7 @@ OR
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
@@ -720,12 +720,12 @@ OR
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -129,7 +129,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.642410.1.0" Name="web_sales_pkey" RelationMdid="0.641613.1.0" IsClustered="false" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.642410.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -2994,7 +2994,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.642441.1.0" Name="web_site_pkey" RelationMdid="0.641665.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.642441.1.0" Name="web_site_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/JoinNDVRemain.mdp
+++ b/data/dxl/minidump/JoinNDVRemain.mdp
@@ -885,7 +885,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.525049.1.0" Name="store_pkey" RelationMdid="0.516672.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.525049.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -1749,7 +1749,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAADjk5OSAgICAgICA=" LintValue="825230246"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.518353.1.0" Name="customer_address_pkey" RelationMdid="0.508415.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.518353.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -980,17 +980,17 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.26.1.0" IsNull="false" IsByValue="true" Value="1664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Negative-IndexApply1.mdp
+++ b/data/dxl/minidump/Negative-IndexApply1.mdp
@@ -393,12 +393,12 @@ select * from z,tt where tt.i=5 and z.i=6 ;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.38103594.1.1.7" Name="tableoid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.38103594.1.1.6" Name="cmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41880312.1.0" Name="idx_z_i" RelationMdid="0.16414402.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.41880312.1.0" Name="idx_z_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.41872120.1.0" Name="idx_tt_i" RelationMdid="0.38103594.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.41872120.1.0" Name="idx_tt_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Negative-IndexApply2.mdp
+++ b/data/dxl/minidump/Negative-IndexApply2.mdp
@@ -137,7 +137,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.4" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.5" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.4" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" RelationMdid="0.41880825.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -291,7 +291,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.6" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.3" Name="xmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.2" Name="ctid" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" RelationMdid="0.41880987.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/data/dxl/minidump/Nested-Setops-2.mdp
@@ -176,7 +176,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1637480.1.0" Name="index_1637480" RelationMdid="0.1637457.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.1637480.1.0" Name="index_1637480" IsClustered="false" KeyColumns="1" IncludedColumns="1">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/NoSortPlan.mdp
+++ b/data/dxl/minidump/NoSortPlan.mdp
@@ -137,7 +137,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>        
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.3373430.1.0" Name="idx_yj" RelationMdid="0.3373378.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.3373430.1.0" Name="idx_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -173,7 +173,7 @@
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" RelationMdid="0.310291.1.0" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -190,7 +190,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" RelationMdid="0.310291.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -870,7 +870,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.8685870.1.0" Name="idx1" RelationMdid="0.8685596.1.0" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.8685870.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IsPartial="true" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1988.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -798,7 +798,7 @@
       <dxl:ColumnStatistics Mdid="1.810130.1.1.4" Name="hd_vehicle_count" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.810176.1.1.5" Name="xmin" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.810176.1.1.4" Name="ctid" Width="8.000000"/>
-      <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" RelationMdid="0.802906.1.0" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
           <dxl:OpClass Mdid="0.3027.1.0"/>
@@ -1134,7 +1134,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.818378.1.0" Name="household_demographics_pkey" RelationMdid="0.810130.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.818378.1.0" Name="household_demographics_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -190,7 +190,7 @@
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" RelationMdid="0.310291.1.0" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -207,7 +207,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" RelationMdid="0.310291.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>        

--- a/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -248,7 +248,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
       <dxl:GPDBFunc Mdid="0.6084.1.0" Name="gp_partition_selection" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.26.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1695490.1.0" Name="pt2_idx_1_prt_1" RelationMdid="0.1695223.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1695490.1.0" Name="pt2_idx_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Rollup.mdp
+++ b/data/dxl/minidump/Rollup.mdp
@@ -68,12 +68,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.67041.1.0" Name="index_67041" RelationMdid="0.67018.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.67041.1.0" Name="index_67041" IsClustered="false" KeyColumns="1" IncludedColumns="1">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.66697.1.0" Name="index_66697" RelationMdid="0.66674.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.66697.1.0" Name="index_66697" IsClustered="false" KeyColumns="1" IncludedColumns="1">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -328,12 +328,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2690.1.0" Name="pg_proc_oid_index" RelationMdid="0.1255.1.0" IsClustered="false" KeyColumns="24" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
+      <dxl:Index Mdid="0.2690.1.0" Name="pg_proc_oid_index" IsClustered="false" KeyColumns="24" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" RelationMdid="0.2615.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>
@@ -506,14 +506,14 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2691.1.0" Name="pg_proc_proname_args_nsp_index" RelationMdid="0.1255.1.0" IsClustered="false" KeyColumns="0,12,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
+      <dxl:Index Mdid="0.2691.1.0" Name="pg_proc_proname_args_nsp_index" IsClustered="false" KeyColumns="0,12,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
           <dxl:OpClass Mdid="0.1991.1.0"/>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" RelationMdid="0.2615.1.0" IsClustered="false" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1089.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/SelectOnCastedCol.mdp
+++ b/data/dxl/minidump/SelectOnCastedCol.mdp
@@ -967,7 +967,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.17091.1.0" Name="customer_address_pkey" RelationMdid="0.17068.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.17091.1.0" Name="customer_address_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -90,7 +90,7 @@ AND
        <dxl:ResultType Mdid="0.20.1.0"/>                                                  
        <dxl:IntermediateResultType Mdid="0.20.1.0"/>                                      
      </dxl:GPDBAgg>
-	 <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+	 <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
@@ -420,12 +420,12 @@ AND
          <dxl:OpClass Mdid="0.3028.1.0"/>                                                              
        </dxl:OpClasses>                                                                                
      </dxl:GPDBScalarOp>
-	 <dxl:Index Mdid="0.3307.1.0" Name="pg_foreign_data_wrapper_name_index" RelationMdid="0.2898.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+	 <dxl:Index Mdid="0.3307.1.0" Name="pg_foreign_data_wrapper_name_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.3306.1.0" Name="pg_foreign_data_wrapper_oid_index" RelationMdid="0.2898.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.3306.1.0" Name="pg_foreign_data_wrapper_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
@@ -621,12 +621,12 @@ AND
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" RelationMdid="0.1260.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -101,7 +101,7 @@
       <dxl:ColumnStatistics Mdid="1.58436.1.1.2" Name="ctid" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.58375.1.1.3" Name="xmin" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.58375.1.1.2" Name="ctid" Width="8.000000"/>
-      <dxl:Index Mdid="0.58417.1.0" Name="r_b" RelationMdid="0.58375.1.0" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.58417.1.0" Name="r_b" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -297,7 +297,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="20"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.58398.1.0" Name="r_a" RelationMdid="0.58375.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.58398.1.0" Name="r_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -8,7 +8,7 @@
       <dxl:TraceFlags Value="101013,103001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.32912.1.0" Name="date_dim_pkey" RelationMdid="0.32889.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.32912.1.0" Name="date_dim_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -66,7 +66,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.33600.1.0" Name="index_33600" RelationMdid="0.33577.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.33600.1.0" Name="index_33600" IsClustered="false" KeyColumns="1" IncludedColumns="1">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -27,7 +27,7 @@ select  i_item_id
       <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -3104,7 +3104,7 @@ select  i_item_id
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42129547.1.0" Name="inventory_idx02_1_prt_p1" RelationMdid="0.42110028.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42129547.1.0" Name="inventory_idx02_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -3196,7 +3196,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42120598.1.0" Name="catalog_sales_idx02_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120598.1.0" Name="catalog_sales_idx02_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -3303,12 +3303,12 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42129813.1.0" Name="item_idx04" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129813.1.0" Name="item_idx04" IsClustered="false" IndexType="B-tree" KeyColumns="9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.42120465.1.0" Name="catalog_sales_idx01_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120465.1.0" Name="catalog_sales_idx01_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -4844,7 +4844,7 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAAAAgBjAKwm" DoubleValue="99.990000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42112159.1.0" Name="date_dim_1_prt_p1_1_pkey" RelationMdid="0.42102149.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.42112159.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -4892,7 +4892,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42125595.1.0" Name="date_dim_idx02_1_prt_p1_1" RelationMdid="0.42102149.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.42125595.1.0" Name="date_dim_idx02_1_prt_p1_1" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -4939,7 +4939,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42120731.1.0" Name="catalog_sales_idx03_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="5" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120731.1.0" Name="catalog_sales_idx03_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="5" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -5016,7 +5016,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129433.1.0" Name="inventory_idx01_1_prt_p1" RelationMdid="0.42110028.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42129433.1.0" Name="inventory_idx01_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -5081,7 +5081,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.42120997.1.0" Name="catalog_sales_idx05_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120997.1.0" Name="catalog_sales_idx05_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="15" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -5170,7 +5170,7 @@ select  i_item_id
           <dxl:OpClass Mdid="0.3018.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42120864.1.0" Name="catalog_sales_idx04_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120864.1.0" Name="catalog_sales_idx04_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -7254,7 +7254,7 @@ select  i_item_id
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.42110028.1.1.7" Name="xmax" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.42110028.1.1.6" Name="cmin" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.42121263.1.0" Name="catalog_sales_idx07_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="13" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121263.1.0" Name="catalog_sales_idx07_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="13" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -7332,7 +7332,7 @@ select  i_item_id
         </dxl:PartConstraint>
       </dxl:Index>
       <dxl:RelationStatistics Mdid="2.42110250.1.1" Name="item" Rows="18000.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.42121130.1.0" Name="catalog_sales_idx06_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121130.1.0" Name="catalog_sales_idx06_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1980.1.0"/>
         </dxl:OpClasses>
@@ -7409,7 +7409,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129832.1.0" Name="item_idx05" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129832.1.0" Name="item_idx05" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -7619,7 +7619,7 @@ select  i_item_id
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.42101810.1.1" Name="catalog_sales" Rows="14745100288.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.42121396.1.0" Name="catalog_sales_idx08_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121396.1.0" Name="catalog_sales_idx08_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -7909,7 +7909,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42118452.1.0" Name="inventory_1_prt_p1_pkey" RelationMdid="0.42110028.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42118452.1.0" Name="inventory_1_prt_p1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.0.0.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -8189,7 +8189,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42121776.1.0" Name="date_dim_idx01_1_prt_p1_1" RelationMdid="0.42102149.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.42121776.1.0" Name="date_dim_idx01_1_prt_p1_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10096,7 +10096,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42121529.1.0" Name="catalog_sales_idx09_1_prt_p1" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121529.1.0" Name="catalog_sales_idx09_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10173,7 +10173,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129851.1.0" Name="item_idx06" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129851.1.0" Name="item_idx06" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.426.1.0"/>
         </dxl:OpClasses>
@@ -13218,7 +13218,7 @@ select  i_item_id
           </dxl:Or>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42118607.1.0" Name="item_pkey" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42118607.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -16305,7 +16305,7 @@ select  i_item_id
           <dxl:OpClass Mdid="0.3032.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42129756.1.0" Name="item_idx01" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="7" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129756.1.0" Name="item_idx01" IsClustered="false" IndexType="B-tree" KeyColumns="7" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -18806,12 +18806,12 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42129775.1.0" Name="item_idx02" RelationMdid="0.42110250.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="12" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129775.1.0" Name="item_idx02" IsClustered="false" IndexType="B-tree" KeyColumns="12" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.426.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.42111849.1.0" Name="catalog_sales_1_prt_p1_pkey" RelationMdid="0.42101810.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42111849.1.0" Name="catalog_sales_1_prt_p1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.0.0.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -20246,7 +20246,7 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42129661.1.0" Name="inventory_idx03_1_prt_p1" RelationMdid="0.42110028.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42129661.1.0" Name="inventory_idx03_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -55,12 +55,12 @@ with results as
       <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.8404352.1.0" Name="store_pkey" RelationMdid="0.8403408.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.8404352.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.8404104.1.0" Name="date_dim_pkey" RelationMdid="0.8402992.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.8404104.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -6451,7 +6451,7 @@ with results as
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.8404414.1.0" Name="store_sales_pkey" RelationMdid="0.8403512.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.8404414.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1980.1.0"/>

--- a/data/dxl/minidump/UnionAll.mdp
+++ b/data/dxl/minidump/UnionAll.mdp
@@ -91,7 +91,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.17952.1.0" Name="index_17952" RelationMdid="0.17929.1.1" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.17952.1.0" Name="index_17952" IsClustered="false" KeyColumns="1" IncludedColumns="1">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -149,7 +149,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.471042.1.0" Name="sale_pkey" RelationMdid="0.471019.1.0" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.471042.1.0" Name="sale_pkey" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/data/dxl/minidump/UnnestSQJoins.mdp
@@ -119,13 +119,13 @@ WHERE
         <dxl:Commutator Mdid="0.410.1.0"/>
         <dxl:InverseOp Mdid="0.411.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2654.1.0" Name="pg_amop_opr_opc_index" RelationMdid="0.2602.1.0" IsClustered="false" KeyColumns="4,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.2654.1.0" Name="pg_amop_opr_opc_index" IsClustered="false" KeyColumns="4,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2652.1.0" Name="pg_am_oid_index" RelationMdid="0.2601.1.0" IsClustered="false" KeyColumns="26" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.2652.1.0" Name="pg_am_oid_index" IsClustered="false" KeyColumns="26" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -489,26 +489,26 @@ WHERE
         <dxl:Commutator Mdid="0.1869.1.0"/>
         <dxl:InverseOp Mdid="0.1862.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2653.1.0" Name="pg_amop_opc_strat_index" RelationMdid="0.2602.1.0" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.2653.1.0" Name="pg_amop_opc_strat_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
           <dxl:OpClass Mdid="0.1989.1.0"/>
           <dxl:OpClass Mdid="0.1976.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2651.1.0" Name="pg_am_name_index" RelationMdid="0.2601.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.2651.1.0" Name="pg_am_name_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1986.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.2686.1.0" Name="pg_opclass_am_name_nsp_index" RelationMdid="0.2616.1.0" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2686.1.0" Name="pg_opclass_am_name_nsp_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
           <dxl:OpClass Mdid="0.1986.1.0"/>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>
       </dxl:Index> 
-       <dxl:Index Mdid="0.2687.1.0" Name="pg_opclass_oid_index" RelationMdid="0.2616.1.0" IsClustered="false" KeyColumns="8" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+       <dxl:Index Mdid="0.2687.1.0" Name="pg_opclass_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1989.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -277,7 +277,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" RelationMdid="0.1259.1.0" IsClustered="false" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
@@ -534,7 +534,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" RelationMdid="0.1259.1.0" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -95,7 +95,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.284658.1.0" Name="r_pkey" RelationMdid="0.284632.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.284658.1.0" Name="r_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/minidump/retail_28.mdp
+++ b/data/dxl/minidump/retail_28.mdp
@@ -2138,7 +2138,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADTU4OTk1NTc3Mg==" LintValue="759579644"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.4449193.1.0" Name="order_lineitems_cust_id_1_prt_default_part" RelationMdid="0.4435137.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.4449193.1.0" Name="order_lineitems_cust_id_1_prt_default_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/parse_tests/q26-Metadata.xml
+++ b/data/dxl/parse_tests/q26-Metadata.xml
@@ -38,7 +38,7 @@
       <dxl:Triggers/>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" RelationMdid="0.1234.1.1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="1">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="1">
       <dxl:OpClasses/>
     </dxl:Index>
     <dxl:Relation Mdid="0.1258.5.1" Name="S" IsTemporary="true" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="0;0,1" PartitionColumns="1" NumberLeafPartitions="0">
@@ -58,7 +58,7 @@
       <dxl:Triggers/>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" RelationMdid="0.802906.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
       <dxl:OpClasses>
         <dxl:OpClass Mdid="0.3027.1.0"/>
         <dxl:OpClass Mdid="0.3027.1.0"/>
@@ -202,7 +202,7 @@
         <dxl:Ident ColId="2" ColName="B" TypeMdid="0.23.1.0"/>
       </dxl:Comparison>
     </dxl:CheckConstraint>
-    <dxl:Index Mdid="0.17027.1.0" Name="r_ind" RelationMdid="0.17004.1.0" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+    <dxl:Index Mdid="0.17027.1.0" Name="r_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
       <dxl:OpClasses/>
       <dxl:PartConstraint DefaultPartition="0" Unbounded="false">
         <dxl:And>

--- a/data/dxl/tpcds-partitioned/tpcds_query22a.mdp
+++ b/data/dxl/tpcds-partitioned/tpcds_query22a.mdp
@@ -1928,7 +1928,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.3336185.1.0" Name="warehouse_pkey" RelationMdid="0.3336159.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20"/>
+      <dxl:Index Mdid="0.3336185.1.0" Name="warehouse_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20"/>
       <dxl:Relation Mdid="0.3336159.1.0" Name="warehouse" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="0;20,14">
         <dxl:Columns>
           <dxl:Column Name="w_warehouse_sk" Attno="1" Mdid="0.23.1.0" Nullable="false">
@@ -2043,7 +2043,7 @@
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.3336415.1.0" Name="item_pkey" RelationMdid="0.3336389.1.0" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28"/>
+      <dxl:Index Mdid="0.3336415.1.0" Name="item_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28"/>
       <dxl:Relation Mdid="0.3336389.1.0" Name="item" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="0;28,22">
         <dxl:Columns>
           <dxl:Column Name="i_item_sk" Attno="1" Mdid="0.23.1.0" Nullable="false">
@@ -3428,7 +3428,7 @@
       <dxl:GPDBFunc Mdid="0.6084.1.0" Name="gp_partition_selection" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.26.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.3324385.1.0" Name="date_dim_1_prt_p1_1_pkey" RelationMdid="0.3324312.1.0" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.3324385.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:PartConstraint DefaultPartition="" Unbounded="false">
           <dxl:And>
             <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">

--- a/data/dxl/tpcds/tpcds_query1.mdp
+++ b/data/dxl/tpcds/tpcds_query1.mdp
@@ -2323,7 +2323,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10257,7 +10257,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920754"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query10.mdp
+++ b/data/dxl/tpcds/tpcds_query10.mdp
@@ -4780,7 +4780,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -19905,7 +19905,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2099"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -23829,7 +23829,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -27165,7 +27165,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -32458,7 +32458,7 @@
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDCast Mdid="3.1015.1.0;1009.1.0" Name="array_coerce" BinaryCoercible="false" SourceTypeId="0.1015.1.0" DestinationTypeId="0.1009.1.0" CastFuncId="0.384.1.0"/>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query12.mdp
+++ b/data/dxl/tpcds/tpcds_query12.mdp
@@ -12317,7 +12317,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14169,7 +14169,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query13.mdp
+++ b/data/dxl/tpcds/tpcds_query13.mdp
@@ -2270,7 +2270,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -4774,7 +4774,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10261,7 +10261,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13180,7 +13180,7 @@
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:RelationStatistics Mdid="2.1961407.1.1" Name="store" Rows="12.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13300,7 +13300,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query14.mdp
+++ b/data/dxl/tpcds/tpcds_query14.mdp
@@ -21973,7 +21973,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query14a.mdp
+++ b/data/dxl/tpcds/tpcds_query14a.mdp
@@ -21958,7 +21958,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query14b.mdp
+++ b/data/dxl/tpcds/tpcds_query14b.mdp
@@ -21932,7 +21932,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query15.mdp
+++ b/data/dxl/tpcds/tpcds_query15.mdp
@@ -11306,7 +11306,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920673"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query16.mdp
+++ b/data/dxl/tpcds/tpcds_query16.mdp
@@ -12686,7 +12686,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2452735"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961479.1.0" Name="call_center_pkey" RelationMdid="0.1961453.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.1961479.1.0" Name="call_center_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -15192,7 +15192,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="159989"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -18400,7 +18400,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961893.1.0" Name="catalog_returns_pkey" RelationMdid="0.1961867.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,16" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33">
+      <dxl:Index Mdid="0.1961893.1.0" Name="catalog_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,16" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -18565,7 +18565,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -20414,7 +20414,7 @@
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDCast Mdid="3.1015.1.0;1009.1.0" Name="array_coerce" BinaryCoercible="false" SourceTypeId="0.1015.1.0" DestinationTypeId="0.1009.1.0" CastFuncId="0.384.1.0"/>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query17.mdp
+++ b/data/dxl/tpcds/tpcds_query17.mdp
@@ -19728,7 +19728,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query18.mdp
+++ b/data/dxl/tpcds/tpcds_query18.mdp
@@ -7520,7 +7520,7 @@
       <dxl:GPDBFunc Mdid="0.1703.1.0" Name="numeric" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13625,7 +13625,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920778"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -19572,13 +19572,13 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAAGFVua25vd24gICAgICAgICAgICAg" LintValue="536871860"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" RelationMdid="0.1961499.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
       <dxl:MDCast Mdid="3.23.1.0;1700.1.0" Name="numeric" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.1700.1.0" CastFuncId="0.1740.1.0"/>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query18a.mdp
+++ b/data/dxl/tpcds/tpcds_query18a.mdp
@@ -7520,7 +7520,7 @@
       <dxl:GPDBFunc Mdid="0.1703.1.0" Name="numeric" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13625,7 +13625,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920778"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -19582,13 +19582,13 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAAGFVua25vd24gICAgICAgICAgICAg" LintValue="536871860"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" RelationMdid="0.1961499.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
       <dxl:MDCast Mdid="3.23.1.0;1700.1.0" Name="numeric" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.1700.1.0" CastFuncId="0.1740.1.0"/>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query19.mdp
+++ b/data/dxl/tpcds/tpcds_query19.mdp
@@ -13366,7 +13366,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -15574,7 +15574,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query2.mdp
+++ b/data/dxl/tpcds/tpcds_query2.mdp
@@ -15346,7 +15346,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgEAAgACAJAhbAc=" DoubleValue="28592.190000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query20.mdp
+++ b/data/dxl/tpcds/tpcds_query20.mdp
@@ -10012,7 +10012,7 @@
           <dxl:OpClass Mdid="0.3022.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14169,7 +14169,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query21.mdp
+++ b/data/dxl/tpcds/tpcds_query21.mdp
@@ -5256,7 +5256,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -7418,7 +7418,7 @@
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
       <dxl:RelationStatistics Mdid="2.1961131.1.1" Name="warehouse" Rows="5.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query22.mdp
+++ b/data/dxl/tpcds/tpcds_query22.mdp
@@ -5203,7 +5203,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query22a.mdp
+++ b/data/dxl/tpcds/tpcds_query22a.mdp
@@ -5207,7 +5207,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query23.mdp
+++ b/data/dxl/tpcds/tpcds_query23.mdp
@@ -23947,7 +23947,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query24.mdp
+++ b/data/dxl/tpcds/tpcds_query24.mdp
@@ -4067,7 +4067,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query25.mdp
+++ b/data/dxl/tpcds/tpcds_query25.mdp
@@ -19705,7 +19705,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query26.mdp
+++ b/data/dxl/tpcds/tpcds_query26.mdp
@@ -6974,7 +6974,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11508,7 +11508,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920778"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11740,7 +11740,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.1961755.1.0" Name="promotion_pkey" RelationMdid="0.1961729.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25">
+      <dxl:Index Mdid="0.1961755.1.0" Name="promotion_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query27.mdp
+++ b/data/dxl/tpcds/tpcds_query27.mdp
@@ -2242,7 +2242,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -5527,7 +5527,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10635,7 +10635,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query27a.mdp
+++ b/data/dxl/tpcds/tpcds_query27a.mdp
@@ -2229,7 +2229,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -5514,7 +5514,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10622,7 +10622,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query28.mdp
+++ b/data/dxl/tpcds/tpcds_query28.mdp
@@ -1937,7 +1937,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/tpcds/tpcds_query29.mdp
+++ b/data/dxl/tpcds/tpcds_query29.mdp
@@ -19705,7 +19705,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query3.mdp
+++ b/data/dxl/tpcds/tpcds_query3.mdp
@@ -9639,7 +9639,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11490,7 +11490,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query30.mdp
+++ b/data/dxl/tpcds/tpcds_query30.mdp
@@ -9613,7 +9613,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920673"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13624,7 +13624,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99998"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query31.mdp
+++ b/data/dxl/tpcds/tpcds_query31.mdp
@@ -16218,7 +16218,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query32.mdp
+++ b/data/dxl/tpcds/tpcds_query32.mdp
@@ -9992,7 +9992,7 @@
           <dxl:OpClass Mdid="0.3022.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14277,13 +14277,13 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query33.mdp
+++ b/data/dxl/tpcds/tpcds_query33.mdp
@@ -23056,7 +23056,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -27558,7 +27558,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -31435,7 +31435,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query34.mdp
+++ b/data/dxl/tpcds/tpcds_query34.mdp
@@ -2471,7 +2471,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10664,7 +10664,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14736,7 +14736,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query35.mdp
+++ b/data/dxl/tpcds/tpcds_query35.mdp
@@ -4768,7 +4768,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -19900,7 +19900,7 @@
         <dxl:ResultType Mdid="0.23.1.0"/>
         <dxl:IntermediateResultType Mdid="0.23.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -23824,7 +23824,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -27077,7 +27077,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/tpcds/tpcds_query36.mdp
+++ b/data/dxl/tpcds/tpcds_query36.mdp
@@ -2009,7 +2009,7 @@
           <dxl:OpClass Mdid="0.3028.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10184,7 +10184,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query36a.mdp
+++ b/data/dxl/tpcds/tpcds_query36a.mdp
@@ -2021,7 +2021,7 @@
           <dxl:OpClass Mdid="0.3028.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10196,7 +10196,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query37.mdp
+++ b/data/dxl/tpcds/tpcds_query37.mdp
@@ -6524,7 +6524,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961847.1.0" Name="inventory_pkey" RelationMdid="0.1961821.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.1961847.1.0" Name="inventory_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.0.0.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -10115,7 +10115,7 @@
           <dxl:OpClass Mdid="0.3022.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14592,7 +14592,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query38.mdp
+++ b/data/dxl/tpcds/tpcds_query38.mdp
@@ -22031,7 +22031,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query39.mdp
+++ b/data/dxl/tpcds/tpcds_query39.mdp
@@ -5210,7 +5210,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query4.mdp
+++ b/data/dxl/tpcds/tpcds_query4.mdp
@@ -2386,7 +2386,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -14909,7 +14909,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAABVk=" LintValue="160899628"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -17907,7 +17907,7 @@
           <dxl:OpClass Mdid="0.3040.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/tpcds/tpcds_query40.mdp
+++ b/data/dxl/tpcds/tpcds_query40.mdp
@@ -15434,7 +15434,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="159989"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -19597,7 +19597,7 @@
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
       <dxl:RelationStatistics Mdid="2.1961131.1.1" Name="warehouse" Rows="5.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query41.mdp
+++ b/data/dxl/tpcds/tpcds_query41.mdp
@@ -3493,7 +3493,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query42.mdp
+++ b/data/dxl/tpcds/tpcds_query42.mdp
@@ -9651,7 +9651,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11502,7 +11502,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query43.mdp
+++ b/data/dxl/tpcds/tpcds_query43.mdp
@@ -2011,7 +2011,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -8314,7 +8314,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query44.mdp
+++ b/data/dxl/tpcds/tpcds_query44.mdp
@@ -1943,7 +1943,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/tpcds/tpcds_query45.mdp
+++ b/data/dxl/tpcds/tpcds_query45.mdp
@@ -15513,7 +15513,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -17713,7 +17713,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query46.mdp
+++ b/data/dxl/tpcds/tpcds_query46.mdp
@@ -2451,7 +2451,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11754,7 +11754,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -16096,7 +16096,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query47.mdp
+++ b/data/dxl/tpcds/tpcds_query47.mdp
@@ -2067,7 +2067,7 @@
           <dxl:OpClass Mdid="0.3040.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -10339,7 +10339,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12235,7 +12235,7 @@
           <dxl:OpClass Mdid="0.3040.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query48.mdp
+++ b/data/dxl/tpcds/tpcds_query48.mdp
@@ -2270,7 +2270,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -4588,7 +4588,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -9997,7 +9997,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12913,7 +12913,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query50.mdp
+++ b/data/dxl/tpcds/tpcds_query50.mdp
@@ -12884,7 +12884,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query51.mdp
+++ b/data/dxl/tpcds/tpcds_query51.mdp
@@ -4151,7 +4151,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -12230,7 +12230,7 @@
           <dxl:OpClass Mdid="0.3022.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -15285,7 +15285,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query51a.mdp
+++ b/data/dxl/tpcds/tpcds_query51a.mdp
@@ -4151,7 +4151,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -12242,7 +12242,7 @@
           <dxl:OpClass Mdid="0.3022.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -15297,7 +15297,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query52.mdp
+++ b/data/dxl/tpcds/tpcds_query52.mdp
@@ -9639,7 +9639,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11490,7 +11490,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query53.mdp
+++ b/data/dxl/tpcds/tpcds_query53.mdp
@@ -10162,7 +10162,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12038,7 +12038,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query55.mdp
+++ b/data/dxl/tpcds/tpcds_query55.mdp
@@ -9639,7 +9639,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11490,7 +11490,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query56.mdp
+++ b/data/dxl/tpcds/tpcds_query56.mdp
@@ -23053,7 +23053,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -27555,7 +27555,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -31432,7 +31432,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query57.mdp
+++ b/data/dxl/tpcds/tpcds_query57.mdp
@@ -10365,7 +10365,7 @@
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query58.mdp
+++ b/data/dxl/tpcds/tpcds_query58.mdp
@@ -21930,7 +21930,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgEAAgABACgcqBY=" DoubleValue="17208.580000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query59.mdp
+++ b/data/dxl/tpcds/tpcds_query59.mdp
@@ -8316,7 +8316,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query6.mdp
+++ b/data/dxl/tpcds/tpcds_query6.mdp
@@ -12892,7 +12892,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920673"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -15095,7 +15095,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query60.mdp
+++ b/data/dxl/tpcds/tpcds_query60.mdp
@@ -23065,7 +23065,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -27567,7 +27567,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -31444,7 +31444,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query61.mdp
+++ b/data/dxl/tpcds/tpcds_query61.mdp
@@ -2426,7 +2426,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14432,7 +14432,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14656,7 +14656,7 @@
           <dxl:OpClass Mdid="0.3032.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961755.1.0" Name="promotion_pkey" RelationMdid="0.1961729.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25">
+      <dxl:Index Mdid="0.1961755.1.0" Name="promotion_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -17040,7 +17040,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -20545,7 +20545,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query62.mdp
+++ b/data/dxl/tpcds/tpcds_query62.mdp
@@ -11333,7 +11333,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="20"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query63.mdp
+++ b/data/dxl/tpcds/tpcds_query63.mdp
@@ -10162,7 +10162,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12038,7 +12038,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query65.mdp
+++ b/data/dxl/tpcds/tpcds_query65.mdp
@@ -10175,7 +10175,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query66.mdp
+++ b/data/dxl/tpcds/tpcds_query66.mdp
@@ -11014,7 +11014,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAADjY1MSAgICAgICA=" LintValue="319816502"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961203.1.0" Name="ship_mode_pkey" RelationMdid="0.1961177.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.1961203.1.0" Name="ship_mode_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -16422,7 +16422,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -19239,7 +19239,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" RelationMdid="0.1961223.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
+      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query67.mdp
+++ b/data/dxl/tpcds/tpcds_query67.mdp
@@ -10181,7 +10181,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query67a.mdp
+++ b/data/dxl/tpcds/tpcds_query67a.mdp
@@ -10181,7 +10181,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query68.mdp
+++ b/data/dxl/tpcds/tpcds_query68.mdp
@@ -2461,7 +2461,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11764,7 +11764,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -16106,7 +16106,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query69.mdp
+++ b/data/dxl/tpcds/tpcds_query69.mdp
@@ -4777,7 +4777,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -19927,7 +19927,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2099"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -23851,7 +23851,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -27171,7 +27171,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -32448,7 +32448,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query7.mdp
+++ b/data/dxl/tpcds/tpcds_query7.mdp
@@ -5729,7 +5729,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11198,7 +11198,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11299,7 +11299,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.1961755.1.0" Name="promotion_pkey" RelationMdid="0.1961729.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25">
+      <dxl:Index Mdid="0.1961755.1.0" Name="promotion_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query70.mdp
+++ b/data/dxl/tpcds/tpcds_query70.mdp
@@ -8363,7 +8363,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query70a.mdp
+++ b/data/dxl/tpcds/tpcds_query70a.mdp
@@ -8361,7 +8361,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query71.mdp
+++ b/data/dxl/tpcds/tpcds_query71.mdp
@@ -22465,7 +22465,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -26621,12 +26621,12 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" RelationMdid="0.1961223.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
+      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query72.mdp
+++ b/data/dxl/tpcds/tpcds_query72.mdp
@@ -8822,7 +8822,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -17167,7 +17167,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -23964,7 +23964,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query73.mdp
+++ b/data/dxl/tpcds/tpcds_query73.mdp
@@ -2483,7 +2483,7 @@
           <dxl:OpClass Mdid="0.3028.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10649,7 +10649,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14709,7 +14709,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query74.mdp
+++ b/data/dxl/tpcds/tpcds_query74.mdp
@@ -17093,7 +17093,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920673"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -22950,7 +22950,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99998"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" RelationMdid="0.1961499.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query76.mdp
+++ b/data/dxl/tpcds/tpcds_query76.mdp
@@ -4195,7 +4195,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -18983,7 +18983,7 @@
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -26201,7 +26201,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" RelationMdid="0.1962005.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1962031.1.0" Name="catalog_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/tpcds/tpcds_query79.mdp
+++ b/data/dxl/tpcds/tpcds_query79.mdp
@@ -2491,7 +2491,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -10634,7 +10634,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14674,7 +14674,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query8.mdp
+++ b/data/dxl/tpcds/tpcds_query8.mdp
@@ -11514,7 +11514,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAABVk=" LintValue="160899628"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -15753,7 +15753,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99998"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" RelationMdid="0.1961499.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.1961525.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -15878,7 +15878,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query81.mdp
+++ b/data/dxl/tpcds/tpcds_query81.mdp
@@ -11666,7 +11666,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2452903"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -15734,7 +15734,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="49998"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query82.mdp
+++ b/data/dxl/tpcds/tpcds_query82.mdp
@@ -7045,7 +7045,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2452642"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961847.1.0" Name="inventory_pkey" RelationMdid="0.1961821.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.1961847.1.0" Name="inventory_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.0.0.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -9805,7 +9805,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11977,7 +11977,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query83.mdp
+++ b/data/dxl/tpcds/tpcds_query83.mdp
@@ -18189,7 +18189,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1920754"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query84.mdp
+++ b/data/dxl/tpcds/tpcds_query84.mdp
@@ -6042,7 +6042,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961341.1.0" Name="income_band_pkey" RelationMdid="0.1961315.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1961341.1.0" Name="income_band_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11781,7 +11781,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99998"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query85.mdp
+++ b/data/dxl/tpcds/tpcds_query85.mdp
@@ -7313,7 +7313,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14258,7 +14258,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -16395,7 +16395,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -21467,7 +21467,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query86.mdp
+++ b/data/dxl/tpcds/tpcds_query86.mdp
@@ -12278,7 +12278,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query86a.mdp
+++ b/data/dxl/tpcds/tpcds_query86a.mdp
@@ -12290,7 +12290,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query87.mdp
+++ b/data/dxl/tpcds/tpcds_query87.mdp
@@ -22031,7 +22031,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query88.mdp
+++ b/data/dxl/tpcds/tpcds_query88.mdp
@@ -2242,7 +2242,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -6378,7 +6378,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" RelationMdid="0.1961223.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
+      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -8722,7 +8722,7 @@
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:RelationStatistics Mdid="2.1961407.1.1" Name="store" Rows="12.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query89.mdp
+++ b/data/dxl/tpcds/tpcds_query89.mdp
@@ -10188,7 +10188,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12060,7 +12060,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query9.mdp
+++ b/data/dxl/tpcds/tpcds_query9.mdp
@@ -207,7 +207,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961295.1.0" Name="reason_pkey" RelationMdid="0.1961269.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1961295.1.0" Name="reason_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -1957,7 +1957,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" RelationMdid="0.1962051.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.1962077.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>

--- a/data/dxl/tpcds/tpcds_query90.mdp
+++ b/data/dxl/tpcds/tpcds_query90.mdp
@@ -3441,7 +3441,7 @@
       <dxl:GPDBFunc Mdid="0.1703.1.0" Name="numeric" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1961709.1.0" Name="web_page_pkey" RelationMdid="0.1961683.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20">
+      <dxl:Index Mdid="0.1961709.1.0" Name="web_page_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -9405,7 +9405,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" RelationMdid="0.1961223.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
+      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12214,7 +12214,7 @@
       <dxl:GPDBFunc Mdid="0.1781.1.0" Name="numeric" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query91.mdp
+++ b/data/dxl/tpcds/tpcds_query91.mdp
@@ -5057,7 +5057,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" RelationMdid="0.1961039.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.1961065.1.0" Name="customer_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -12655,7 +12655,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2452903"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -16997,12 +16997,12 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="6"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
       </dxl:Index>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query92.mdp
+++ b/data/dxl/tpcds/tpcds_query92.mdp
@@ -10505,7 +10505,7 @@
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -12437,7 +12437,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -14295,7 +14295,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query93.mdp
+++ b/data/dxl/tpcds/tpcds_query93.mdp
@@ -106,7 +106,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961295.1.0" Name="reason_pkey" RelationMdid="0.1961269.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1961295.1.0" Name="reason_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query94.mdp
+++ b/data/dxl/tpcds/tpcds_query94.mdp
@@ -2516,7 +2516,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1961939.1.0" Name="web_returns_pkey" RelationMdid="0.1961913.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="2,13" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
+      <dxl:Index Mdid="0.1961939.1.0" Name="web_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,13" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -6943,7 +6943,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961571.1.0" Name="web_site_pkey" RelationMdid="0.1961545.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.1961571.1.0" Name="web_site_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13699,7 +13699,7 @@
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -15631,7 +15631,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -20587,7 +20587,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query95.mdp
+++ b/data/dxl/tpcds/tpcds_query95.mdp
@@ -6937,7 +6937,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961571.1.0" Name="web_site_pkey" RelationMdid="0.1961545.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.1961571.1.0" Name="web_site_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -13693,7 +13693,7 @@
         <dxl:ResultType Mdid="0.1700.1.0"/>
         <dxl:IntermediateResultType Mdid="0.1700.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" RelationMdid="0.1961959.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.1961985.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
           <dxl:OpClass Mdid="0.1978.1.0"/>
@@ -15625,7 +15625,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="5"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -20569,7 +20569,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" RelationMdid="0.1960993.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.1961019.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query96.mdp
+++ b/data/dxl/tpcds/tpcds_query96.mdp
@@ -2242,7 +2242,7 @@
           <dxl:OpClass Mdid="0.3028.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" RelationMdid="0.1961407.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.1961433.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -6368,7 +6368,7 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" RelationMdid="0.1961223.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
+      <dxl:Index Mdid="0.1961249.1.0" Name="time_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -8712,7 +8712,7 @@
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:RelationStatistics Mdid="2.1961407.1.1" Name="store" Rows="12.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" RelationMdid="0.1961637.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.1961663.1.0" Name="household_demographics_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query97.mdp
+++ b/data/dxl/tpcds/tpcds_query97.mdp
@@ -12707,7 +12707,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query98.mdp
+++ b/data/dxl/tpcds/tpcds_query98.mdp
@@ -9702,7 +9702,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="50000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>
@@ -11554,7 +11554,7 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" RelationMdid="0.1961361.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.1961387.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/data/dxl/tpcds/tpcds_query99.mdp
+++ b/data/dxl/tpcds/tpcds_query99.mdp
@@ -8855,7 +8855,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEltcG9ydGFudCBpc3N1ZXMgbGl2" LintValue="671269806"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" RelationMdid="0.1961085.1.0" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.1961111.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1978.1.0"/>
         </dxl:OpClasses>

--- a/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
+++ b/libgpopt/include/gpopt/metadata/CIndexDescriptor.h
@@ -41,9 +41,6 @@ namespace gpopt
 			// mdid of the index
 			IMDId *m_pmdidIndex;
 
-			// mdid of the table
-			IMDId *m_pmdidTable;
-
 			// name of index
 			CName m_name;
 
@@ -66,7 +63,6 @@ namespace gpopt
 				(
 				IMemoryPool *pmp,
 				IMDId *pmdidIndex,
-				IMDId *pmdidTable,
 				const CName &name,
 				DrgPcoldesc *pdrgcoldescKeyCols,
 				DrgPcoldesc *pdrgcoldescIncludedCols,
@@ -87,12 +83,6 @@ namespace gpopt
 			IMDId *Pmdid() const
 			{
 				return m_pmdidIndex;
-			}
-
-			// table mdid
-			IMDId *PmdidTable() const
-			{
-				return m_pmdidTable;
 			}
 
 			// index name

--- a/libgpopt/src/metadata/CIndexDescriptor.cpp
+++ b/libgpopt/src/metadata/CIndexDescriptor.cpp
@@ -30,7 +30,6 @@ CIndexDescriptor::CIndexDescriptor
 	(
 	IMemoryPool *pmp,
 	IMDId *pmdidIndex,
-	IMDId *pmdidTable,
 	const CName &name,
 	DrgPcoldesc *pdrgcoldescKeyCols,
 	DrgPcoldesc *pdrgcoldescIncludedCols,
@@ -38,7 +37,6 @@ CIndexDescriptor::CIndexDescriptor
 	)
 	:
 	m_pmdidIndex(pmdidIndex),
-	m_pmdidTable(pmdidTable),
 	m_name(pmp, name),
 	m_pdrgpcoldescKeyCols(pdrgcoldescKeyCols),
 	m_pdrgpcoldescIncludedCols(pdrgcoldescIncludedCols),
@@ -46,7 +44,6 @@ CIndexDescriptor::CIndexDescriptor
 {
 	GPOS_ASSERT(NULL != pmp);
 	GPOS_ASSERT(pmdidIndex->FValid());
-	GPOS_ASSERT(pmdidTable->FValid());
 	GPOS_ASSERT(NULL != pdrgcoldescKeyCols);
 	GPOS_ASSERT(NULL != pdrgcoldescIncludedCols);
 }
@@ -62,7 +59,6 @@ CIndexDescriptor::CIndexDescriptor
 CIndexDescriptor::~CIndexDescriptor()
 {
 	m_pmdidIndex->Release();
-	m_pmdidTable->Release();
 
 	m_pdrgpcoldescKeyCols->Release();
 	m_pdrgpcoldescIncludedCols->Release();
@@ -121,7 +117,6 @@ CIndexDescriptor::Pindexdesc
 	DrgPcoldesc *pdrgpcoldesc = ptabdesc->Pdrgpcoldesc();
 
 	pmdindex->Pmdid()->AddRef();
-	pmdindex->PmdidRel()->AddRef();
 
 	// array of index column descriptors
 	DrgPcoldesc *pdrgcoldescKey = GPOS_NEW(pmp) DrgPcoldesc(pmp);
@@ -148,7 +143,6 @@ CIndexDescriptor::Pindexdesc
 											(
 											pmp,
 											pmdindex->Pmdid(),
-											pmdindex->PmdidRel(),
 											CName(&strIndexName),
 											pdrgcoldescKey,
 											pdrgcoldescIncluded,

--- a/libnaucrates/include/naucrates/md/CMDIndexGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDIndexGPDB.h
@@ -45,9 +45,6 @@ namespace gpmd
 						
 			// table name
 			CMDName *m_pmdname;
-			
-			// mdid of indexed relation
-			IMDId *m_pmdidRel;
 
 			// is the index clustered
 			BOOL m_fClustered;
@@ -87,7 +84,6 @@ namespace gpmd
 				IMemoryPool *pmp, 
 				IMDId *pmdid, 
 				CMDName *pmdname,
-				IMDId *pmdidRel, 
 				BOOL fClustered, 
 				EmdindexType emdindt,
 				IMDId *pmdidItemType,
@@ -110,10 +106,6 @@ namespace gpmd
 			virtual 
 			CMDName Mdname() const;
 
-			// mdid of indexed relation
-			virtual
-			IMDId *PmdidRel() const;
-			
 			// is the index clustered
 			virtual
 			BOOL FClustered() const;

--- a/libnaucrates/include/naucrates/md/IMDIndex.h
+++ b/libnaucrates/include/naucrates/md/IMDIndex.h
@@ -45,18 +45,14 @@ namespace gpmd
 				EmdindBitmap,	// bitmap
 				EmdindSentinel
 			};
-			
+
 			// object type
 			virtual
 			Emdtype Emdt() const
 			{
 				return EmdtInd;
 			}
-		
-			// mdid of indexed relation
-			virtual
-			IMDId *PmdidRel() const = 0;
-						
+
 			// is the index clustered
 			virtual
 			BOOL FClustered() const = 0;

--- a/libnaucrates/src/md/CMDIndexGPDB.cpp
+++ b/libnaucrates/src/md/CMDIndexGPDB.cpp
@@ -36,7 +36,6 @@ CMDIndexGPDB::CMDIndexGPDB
 	IMemoryPool *pmp, 
 	IMDId *pmdid, 
 	CMDName *pmdname,
-	IMDId *pmdidRel, 
 	BOOL fClustered, 
 	IMDIndex::EmdindexType emdindt,
 	IMDId *pmdidItemType,
@@ -50,7 +49,6 @@ CMDIndexGPDB::CMDIndexGPDB
 	m_pmp(pmp),
 	m_pmdid(pmdid),
 	m_pmdname(pmdname),
-	m_pmdidRel(pmdidRel),
 	m_fClustered(fClustered),
 	m_emdindt(emdindt),
 	m_pmdidItemType(pmdidItemType),
@@ -61,7 +59,6 @@ CMDIndexGPDB::CMDIndexGPDB
 	m_pmdpartcnstr(pmdpartcnstr)
 {
 	GPOS_ASSERT(pmdid->FValid());
-	GPOS_ASSERT(pmdidRel->FValid());
 	GPOS_ASSERT(IMDIndex::EmdindSentinel > emdindt);
 	GPOS_ASSERT(NULL != pdrgpulKeyCols);
 	GPOS_ASSERT(0 < pdrgpulKeyCols->UlSafeLength());
@@ -86,7 +83,6 @@ CMDIndexGPDB::~CMDIndexGPDB()
 	GPOS_DELETE(m_pmdname);
 	GPOS_DELETE(m_pstr);
 	m_pmdid->Release();
-	m_pmdidRel->Release();
 	CRefCount::SafeRelease(m_pmdidItemType);
 	m_pdrgpulKeyCols->Release();
 	m_pdrgpulIncludedCols->Release();
@@ -120,20 +116,6 @@ CMDName
 CMDIndexGPDB::Mdname() const
 {
 	return *m_pmdname;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CMDIndexGPDB::PmdidRel
-//
-//	@doc:
-//		Returns the metadata id of the indexed relation
-//
-//---------------------------------------------------------------------------
-IMDId *
-CMDIndexGPDB::PmdidRel() const
-{
-	return m_pmdidRel;
 }
 
 //---------------------------------------------------------------------------
@@ -335,7 +317,6 @@ CMDIndexGPDB::Serialize
 	
 	m_pmdid->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenMdid));
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenName), m_pmdname->Pstr());
-	m_pmdidRel->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenRelationMdid));
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenIndexClustered), m_fClustered);
 	
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenIndexType), PstrIndexType(m_emdindt));

--- a/libnaucrates/src/md/CMDIndexGPDB.cpp
+++ b/libnaucrates/src/md/CMDIndexGPDB.cpp
@@ -393,11 +393,7 @@ CMDIndexGPDB::DebugPrint
 	
 	os << "Index name: " << (Mdname()).Pstr()->Wsz() << std::endl;
 	os << "Index type: " << PstrIndexType(m_emdindt)->Wsz() << std::endl;
-		
-	os << "Indexed relation id: ";
-	PmdidRel()->OsPrint(os);
-	os << std::endl;
-	
+
 	os << "Index keys: ";
 	for (ULONG ul = 0; ul < UlKeys(); ul++)
 	{

--- a/libnaucrates/src/parser/CParseHandlerMDIndex.cpp
+++ b/libnaucrates/src/parser/CParseHandlerMDIndex.cpp
@@ -42,7 +42,6 @@ CParseHandlerMDIndex::CParseHandlerMDIndex
 	CParseHandlerMetadataObject(pmp, pphm, pphRoot),
 	m_pmdid(NULL),
 	m_pmdname(NULL),
-	m_pmdidRel(NULL),
 	m_fClustered(false),
 	m_emdindt(IMDIndex::EmdindSentinel),
 	m_pmdidItemType(NULL),
@@ -120,9 +119,6 @@ CParseHandlerMDIndex::StartElement
 	// create a copy of the string in the CMDName constructor
 	m_pmdname = GPOS_NEW(m_pmp) CMDName(m_pmp, pstrColName);
 	GPOS_DELETE(pstrColName);
-
-	// parse mdid of indexed relation
-	m_pmdidRel = CDXLOperatorFactory::PmdidFromAttrs(m_pphm->Pmm(), attrs, EdxltokenRelationMdid, EdxltokenIndex);
 
 	// parse index clustering, key columns and included columns information
 	m_fClustered = CDXLOperatorFactory::FValueFromAttrs(m_pphm->Pmm(), attrs, EdxltokenIndexClustered, EdxltokenIndex);
@@ -212,8 +208,7 @@ CParseHandlerMDIndex::EndElement
 							(
 							m_pmp, 
 							m_pmdid, 
-							m_pmdname, 
-							m_pmdidRel, 
+							m_pmdname,
 							m_fClustered, 
 							m_emdindt,
 							m_pmdidItemType,


### PR DESCRIPTION
While working on https://github.com/greenplum-db/gporca/pull/160 we found that the abstraction in ORCA contains "the relation of an index". We don't use this information anywhere, instead, we get indices from "table descriptors", not the other way around. And retaining this dead abstraction actually introduces undue complexity for https://github.com/greenplum-db/gporca/pull/160 and https://github.com/greenplum-db/gpdb/pull/2163 . We are removing all mentions of "relation of an index".