### PR TITLE
Do not record time needed to access metadata when profiling is disabled

### DIFF
--- a/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -603,9 +603,12 @@ CMDAccessor::Pimdobj
 			pmdobjNew = gpdxl::CDXLUtils::PimdobjParseDXL(pmp, a_pstr.Pt(), NULL /* XSD path */);
 			GPOS_ASSERT(NULL != pmdobjNew);
 
-			// add fetch time in msec
-			CDouble dFetch(timerFetch.UlElapsedUS() / CDouble(GPOS_USEC_IN_MSEC));
-			m_dFetchTime = CDouble(m_dFetchTime.DVal() + dFetch.DVal());
+			if (GPOS_FTRACE(EopttracePrintOptStats))
+			{
+				// add fetch time in msec
+				CDouble dFetch(timerFetch.UlElapsedUS() / CDouble(GPOS_USEC_IN_MSEC));
+				m_dFetchTime = CDouble(m_dFetchTime.DVal() + dFetch.DVal());
+			}
 
 			// For CTAS mdid, we avoid adding the corresponding object to the MD cache
 			// since those objects have a fixed id, and if caching is enabled and those

--- a/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -668,9 +668,12 @@ CMDAccessor::Pimdobj
 	pimdobj = pmdaccelem->Pimdobj();
 	GPOS_ASSERT(NULL != pimdobj);
 	
-	// add lookup time in msec
-	CDouble dLookup(timerLookup.UlElapsedUS() / CDouble(GPOS_USEC_IN_MSEC));
-	m_dLookupTime = CDouble(m_dLookupTime.DVal() + dLookup.DVal());
+	if (GPOS_FTRACE(EopttracePrintOptStats))
+	{
+		// add lookup time in msec
+		CDouble dLookup(timerLookup.UlElapsedUS() / CDouble(GPOS_USEC_IN_MSEC));
+		m_dLookupTime = CDouble(m_dLookupTime.DVal() + dLookup.DVal());
+	}
 
 	return pimdobj;
 }


### PR DESCRIPTION
We were unnecessarily recording md access time when it is not required. This issue is now resolved.