### PR TITLE
Retain the subplan while translating CorrelatedNLJ [#144468913]

### DIFF
--- a/data/dxl/minidump/CorrelatedNLJ-PartSelector-Subplan.mdp
+++ b/data/dxl/minidump/CorrelatedNLJ-PartSelector-Subplan.mdp
@@ -1,0 +1,11213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<--
+CREATE TABLE foo ( a character varying(1) NOT NULL, b bigint NOT NULL, c bigint NOT NULL,d smallint NOT NULL,e smallint NOT NULL,f smallint NOT NULL,g date NOT NULL,h character varying(1) NOT NULL,i integer NOT NULL,j timestamp without time zone NOT NULL,k character varying(1) NOT NULL,l character varying(1) NOT NULL,m timestamp without time zone NOT NULL,n smallint,o integer NOT NULL,p character varying(1),q character varying(30),r character varying(30),s character varying(30),t character varying(10),u character varying(10),v character varying(30),w character varying(1),x character varying(30),y character varying(30),z character varying(30),aa character varying(10),bb character varying(10),cc character varying(30),dd character varying(1),ee character varying(30),ff character varying(30),gg character varying(30),hh character varying(10),ii character varying(10),jj character varying(30),kk integer,ll character varying(50),mm integer,nn character varying(50),oo integer,pp character varying(50),qq integer,rr numeric(15,2),ss bigint,tt bigint)
+WITH (appendonly=true, compresslevel=3, compresstype=zlib) DISTRIBUTED BY (o) PARTITION BY LIST(tt) ( DEFAULT PARTITION dat  WITH (tablename='foo_1_prt_dat', orientation=row, appendonly=true, compresstype=zlib, compresslevel=3 ));
+
+CREATE TABLE bar (a integer,b character varying(1),c character varying(30),d character varying(30),e smallint,f integer,g character varying(1),h character varying(30),i character varying(30),j character varying(30),k character varying(10),l character varying(10),m character varying(30),n integer,o numeric(15,2),p date,q timestamp without time zone,r character varying(10),s character varying(6),t character varying(6),u character varying(10),v smallint,w timestamp without time zone)
+WITH (appendonly=true, compresstype=zlib, compresslevel=3) DISTRIBUTED BY (f);
+
+explain select b, c, d, e, g, i, j, m, n, o, kk, mm, oo, ss, tt, t, u, v, s FROM foo WHERE j > (select max(q) from bar) and l::int = 2;
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
+      <dxl:TraceFlags Value="101001,102120,103001,103014,103015,103022,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.19" Name="t" Width="2.000000" NullFreq="0.000000" NdvRemain="2273.000000" FreqRemain="0.110873" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.876270" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTA=" LintValue="161088044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTA=" LintValue="161088044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000521" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2MTEzOA==" LintValue="491193212"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2MTEzOA==" LintValue="491193212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000405" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2NjYxNg==" LintValue="1038009148"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2NjYxNg==" LintValue="1038009148"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2ODQzMw==" LintValue="223765308"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2ODQzMw==" LintValue="223765308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000492" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3NDcxNw==" LintValue="752804732"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3NDcxNw==" LintValue="752804732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000724" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3NzM5Mg==" LintValue="785269628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3NzM5Mg==" LintValue="785269628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000463" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDMyMw==" LintValue="240018294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDMyMw==" LintValue="240018294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000463" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDUyNA==" LintValue="240550774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDUyNA==" LintValue="240550774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MTg2Ng==" LintValue="526828342"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MTg2Ng==" LintValue="526828342"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000608" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4NjEyNg==" LintValue="1044824950"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4NjEyNg==" LintValue="1044824950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000608" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE5NTA2MQ==" LintValue="1044783926"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE5NTA2MQ==" LintValue="1044783926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDA1MQ==" LintValue="264643388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDA1MQ==" LintValue="264643388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ0Nzc0NQ==" LintValue="770614132"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ0Nzc0NQ==" LintValue="770614132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000492" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ1MTM4Mw==" LintValue="536765300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ1MTM4Mw==" LintValue="536765300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABzQ1OQ==" LintValue="911942444"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABzQ1OQ==" LintValue="911942444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000463" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjU0MTYyNA==" LintValue="478053172"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjU0MTYyNA==" LintValue="478053172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000637" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYwMjI4Ng==" LintValue="485409588"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYwMjI4Ng==" LintValue="485409588"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYxODgyNA==" LintValue="256279348"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYxODgyNA==" LintValue="256279348"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000521" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYxODgyOQ==" LintValue="256320308"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYxODgyOQ==" LintValue="256320308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000753" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjY4ODg0Ng==" LintValue="264684342"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjY4ODg0Ng==" LintValue="264684342"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000695" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY4OTMz" LintValue="786850670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY4OTMz" LintValue="786850670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjY5MjYyNQ==" LintValue="528393014"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjY5MjYyNQ==" LintValue="528393014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjc3MjkzOQ==" LintValue="475472764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjc3MjkzOQ==" LintValue="475472764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000550" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjc3Nzc0Nw==" LintValue="770630516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjc3Nzc0Nw==" LintValue="770630516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000405" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACDkyNjU=" LintValue="83796772"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACDkyNjU=" LintValue="83796772"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.18" Name="s" Width="3.000000" NullFreq="0.000000" NdvRemain="2171.000000" FreqRemain="0.185783" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.753554" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTA=" LintValue="161088044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTA=" LintValue="161088044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003967" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjAwMDQ1OQ==" LintValue="264708924"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjAwMDQ1OQ==" LintValue="264708924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjAwOTMxNQ==" LintValue="517907324"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjAwOTMxNQ==" LintValue="517907324"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003996" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE1MDUyMw==" LintValue="223765364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE1MDUyMw==" LintValue="223765364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2MTEzOA==" LintValue="491193212"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2MTEzOA==" LintValue="491193212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001708" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2NjYxNg==" LintValue="1038009148"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2NjYxNg==" LintValue="1038009148"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002143" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2OTgxMQ==" LintValue="501621564"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE2OTgxMQ==" LintValue="501621564"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003011" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3MTAyNw==" LintValue="474407732"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3MTAyNw==" LintValue="474407732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3NzM5Mg==" LintValue="785269628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE3NzM5Mg==" LintValue="785269628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006602" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDMyMw==" LintValue="240018294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDMyMw==" LintValue="240018294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDczMg==" LintValue="241058686"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MDczMg==" LintValue="241058686"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008571" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MTY3MQ==" LintValue="526263102"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MTY3MQ==" LintValue="526263102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003417" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MTgzNQ==" LintValue="510042942"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MTgzNQ==" LintValue="510042942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001564" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MzAzNw==" LintValue="239526718"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4MzAzNw==" LintValue="239526718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001911" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4NDc2OQ==" LintValue="794764150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4NDc2OQ==" LintValue="794764150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001390" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4NzkxNw==" LintValue="786883454"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4NzkxNw==" LintValue="786883454"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002548" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4ODgxMw==" LintValue="249979710"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4ODgxMw==" LintValue="249979710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4ODg0NQ==" LintValue="266773302"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE4ODg0NQ==" LintValue="266773302"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001245" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE5MDczNQ==" LintValue="257860478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE5MDczNQ==" LintValue="257860478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE5NTA2MQ==" LintValue="1044783926"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjE5NTA2MQ==" LintValue="1044783926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001708" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjM5NDEyMA==" LintValue="794166134"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjM5NDEyMA==" LintValue="794166134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002316" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ0Nzc0NQ==" LintValue="770614132"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ0Nzc0NQ==" LintValue="770614132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ1MTM4Mw==" LintValue="536765300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjQ1MTM4Mw==" LintValue="536765300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYwMjE0OQ==" LintValue="535241588"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjYwMjE0OQ==" LintValue="535241588"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjc3Nzc0Nw==" LintValue="770630516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACjc3Nzc0Nw==" LintValue="770630516"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.11" Name="l" Width="5.000000" NullFreq="0.042131" NdvRemain="6930.000000" FreqRemain="0.918025" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTAwMDAw" LintValue="759563046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTAwMDAw" LintValue="759563046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001100" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTAxOTA0" LintValue="1030128486"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTAxOTA0" LintValue="1030128486"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001071" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTA0NjY4" LintValue="215941926"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTA0NjY4" LintValue="215941926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001419" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzNzc1" LintValue="752788334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzNzc1" LintValue="752788334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002780" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3MzA4" LintValue="223282022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3MzA4" LintValue="223282022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001187" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQwODgw" LintValue="761660198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQwODgw" LintValue="761660198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001245" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ4MjMx" LintValue="802038574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ4MjMx" LintValue="802038574"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ4NTk5" LintValue="760685422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ4NTk5" LintValue="760685422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ4Njgz" LintValue="761160486"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ4Njgz" LintValue="761160486"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYxMzQ4" LintValue="1062142822"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYxMzQ4" LintValue="1062142822"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003533" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001100" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1NzE5" LintValue="509551470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1NzE5" LintValue="509551470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcxMDgz" LintValue="1028023078"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcxMDgz" LintValue="1028023078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001390" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0MzIx" LintValue="265167718"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0MzIx" LintValue="265167718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001448" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTMy" LintValue="265700206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTMy" LintValue="265700206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NjUz" LintValue="241066798"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NjUz" LintValue="241066798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001100" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTg3NzAw" LintValue="224265060"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTg3NzAw" LintValue="224265060"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001564" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTg4MjEz" LintValue="760111916"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTg4MjEz" LintValue="760111916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001071" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTg4MzM5" LintValue="768549740"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTg4MzM5" LintValue="768549740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001390" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTkxMjU3" LintValue="1028580140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTkxMjU3" LintValue="1028580140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTkyMzMx" LintValue="1020142444"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTkyMzMx" LintValue="1020142444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001506" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTk5OTc0" LintValue="1038517100"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTk5OTc0" LintValue="1038517100"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.10" Name="k" Width="2.000000" NullFreq="0.042131" NdvRemain="357.000000" FreqRemain="0.289967" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.069813" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030896" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025742" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023744" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021254" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020993" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021283" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018532" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017692" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE4" LintValue="882049836"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE4" LintValue="882049836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.048994" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016621" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015173" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012191" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011785" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011930" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI1" LintValue="873636644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI1" LintValue="873636644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040944" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.041610" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040481" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036687" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033010" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032286" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027566" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.3" Name="d" Width="2.000000" NullFreq="0.000000" NdvRemain="593.000000" FreqRemain="0.124019" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.812277" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001737" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001737" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEF4ZWw=" LintValue="289506092"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEF4ZWw=" LintValue="289506092"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003330" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002432" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001650" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACERpcms=" LintValue="612459364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACERpcms=" LintValue="612459364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004430" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001911" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEhhbnM=" LintValue="60973924"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEhhbnM=" LintValue="60973924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001882" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUhlaWtl" LintValue="850961260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUhlaWtl" LintValue="850961260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003562" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002461" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002403" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002027" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkthcmwtSGVpbno=" LintValue="11223910"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkthcmwtSGVpbno=" LintValue="11223910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002201" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001737" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004517" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002577" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001650" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJvbGFuZA==" LintValue="286819190"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJvbGFuZA==" LintValue="286819190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002519" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001882" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVN0ZXZl" LintValue="764191590"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVN0ZXZl" LintValue="764191590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005936" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001998" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAB1V3ZQ==" LintValue="659596140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAB1V3ZQ==" LintValue="659596140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002519" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003243" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.2" Name="c" Width="20.000000" NullFreq="0.000000" NdvRemain="6346.000000" FreqRemain="0.857536" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.003648" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkFncmFyZGllbnN0IEJhZGVuIEdtYkg=" LintValue="328532836"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkFncmFyZGllbnN0IEJhZGVuIEdtYkg=" LintValue="328532836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIUFvbiBWZXJzLi1NLiBEZXV0c2NobGFuZCBHbWJI" LintValue="293929958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIUFvbiBWZXJzLi1NLiBEZXV0c2NobGFuZCBHbWJI" LintValue="293929958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003677" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH0JBRy1Ib2hlbmxvaGUtUmFpZmZlaXNlbiBlRw==" LintValue="43836204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH0JBRy1Ib2hlbmxvaGUtUmFpZmZlaXNlbiBlRw==" LintValue="43836204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004951" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUJlcmxpbmVyIFZvbGtzYmFuayBlRw==" LintValue="571269950"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUJlcmxpbmVyIFZvbGtzYmFuayBlRw==" LintValue="571269950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEEZpc2NoZXIgR21iSA==" LintValue="319095798"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEEZpc2NoZXIgR21iSA==" LintValue="319095798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003735" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHEZyYW5rZnVydGVyIFZvbGtzYmFuayBlRw==" LintValue="36496318"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHEZyYW5rZnVydGVyIFZvbGtzYmFuayBlRw==" LintValue="36496318"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIUZ1bmsgVmVyc2ljaGVydW5nc21ha2xlciBHbWJI" LintValue="322241524"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIUZ1bmsgVmVyc2ljaGVydW5nc21ha2xlciBHbWJI" LintValue="322241524"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004691" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUdFTk8tRmluYW56U2VydmljZSBlRw==" LintValue="288678716"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUdFTk8tRmluYW56U2VydmljZSBlRw==" LintValue="288678716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003967" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHElBSyBTaXR0ICYgT3ZlcmxhY2sgR21iSA==" LintValue="865403878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHElBSyBTaXR0ICYgT3ZlcmxhY2sgR21iSA==" LintValue="865403878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005762" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkvDtnJzY2huZXIrR2VybGluZyBHYlI=" LintValue="839271414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkvDtnJzY2huZXIrR2VybGluZyBHYlI=" LintValue="839271414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003938" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH09TS0FSIFNDSFVOQ0sgR21iSCAmIENvLiBLRw==" LintValue="730653630"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH09TS0FSIFNDSFVOQ0sgR21iSCAmIENvLiBLRw==" LintValue="730653630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006255" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVIrViBMZWJlbnN2ZXJzaWNoZXJ1bmcgQUc=" LintValue="967107388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVIrViBMZWJlbnN2ZXJzaWNoZXJ1bmcgQUc=" LintValue="967107388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005357" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlZCIEdyb25hdS1BaGF1cyBlRw==" LintValue="941155260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlZCIEdyb25hdS1BaGF1cyBlRw==" LintValue="941155260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZCIFBhZGVyYm9ybi1Iw7Z4dGVyLURldG1vbGQgZUc=" LintValue="589095854"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZCIFBhZGVyYm9ybi1Iw7Z4dGVyLURldG1vbGQgZUc=" LintValue="589095854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004372" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZSIEJhbmsgU2Nod8OkYi5IYWxsLUNyYWlsc2guZUc=" LintValue="975496108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZSIEJhbmsgU2Nod8OkYi5IYWxsLUNyYWlsc2guZUc=" LintValue="975496108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003648" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlZSLUJhbmsgZUc=" LintValue="822928188"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlZSLUJhbmsgZUc=" LintValue="822928188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003533" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZlcmVpbmlndGUgVm9sa3NiYW5rIGVH" LintValue="34399020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZlcmVpbmlndGUgVm9sa3NiYW5rIGVH" LintValue="34399020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004141" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFZvbGtzYmFuayBIZWxsd2VnIGVH" LintValue="312271806"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFZvbGtzYmFuayBIZWxsd2VnIGVH" LintValue="312271806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004720" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVZvbGtzYmFuayBMYWhyIGVH" LintValue="590930750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVZvbGtzYmFuayBMYWhyIGVH" LintValue="590930750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004488" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003706" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZvbGtzYmFuayBSaGVpbkFockVpZmVsIGVH" LintValue="825025342"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZvbGtzYmFuayBSaGVpbkFockVpZmVsIGVH" LintValue="825025342"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003475" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBTdHV0dGdhcnQgZUc=" LintValue="154723246"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBTdHV0dGdhcnQgZUc=" LintValue="154723246"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011930" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003764" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAImRlYXMgRGV1dHNjaGUgQXNzLi1NYWtsZXIgR21iSA==" LintValue="859112436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAImRlYXMgRGV1dHNjaGUgQXNzLi1NYWtsZXIgR21iSA==" LintValue="859112436"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBScalarOp Mdid="0.2064.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.1114.1.0"/>
+        <dxl:RightType Mdid="0.1114.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.2057.1.0"/>
+        <dxl:Commutator Mdid="0.2062.1.0"/>
+        <dxl:InverseOp Mdid="0.2063.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.434.1.0"/>
+          <dxl:OpClass Mdid="0.3041.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.237712.1.0" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Type Mdid="0.21.1.0" Name="int2" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="2" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.94.1.0"/>
+        <dxl:InequalityOp Mdid="0.519.1.0"/>
+        <dxl:LessThanOp Mdid="0.95.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.522.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.520.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.524.1.0"/>
+        <dxl:ComparisonOp Mdid="0.350.1.0"/>
+        <dxl:ArrayType Mdid="0.1005.1.0"/>
+        <dxl:MinAgg Mdid="0.2133.1.0"/>
+        <dxl:MaxAgg Mdid="0.2117.1.0"/>
+        <dxl:AvgAgg Mdid="0.2102.1.0"/>
+        <dxl:SumAgg Mdid="0.2109.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.237712.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Hash" DistributionColumns="5" Keys="25,23" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1043.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.21.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="f" Attno="6" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="g" Attno="7" Mdid="0.1043.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="h" Attno="8" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="i" Attno="9" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="j" Attno="10" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="k" Attno="11" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l" Attno="12" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m" Attno="13" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="n" Attno="14" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="o" Attno="15" Mdid="0.1700.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="p" Attno="16" Mdid="0.1082.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="q" Attno="17" Mdid="0.1114.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="r" Attno="18" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="s" Attno="19" Mdid="0.1043.1.0" Nullable="true" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="t" Attno="20" Mdid="0.1043.1.0" Nullable="true" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="u" Attno="21" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="v" Attno="22" Mdid="0.21.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="w" Attno="23" Mdid="0.1114.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.43" Name="rr" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.152044" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACAIAAAA=" DoubleValue="0.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACAIAAAA=" DoubleValue="0.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033306" DistinctValues="1819.880358">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACAIAAAA=" DoubleValue="0.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAANAOwT" DoubleValue="13.510000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000690" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAANAOwT" DoubleValue="13.510000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAANAOwT" DoubleValue="13.510000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001750" DistinctValues="95.641381">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAANAOwT" DoubleValue="13.510000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000885" DistinctValues="48.299732">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOACgj" DoubleValue="14.900000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOACgj" DoubleValue="14.900000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOACgj" DoubleValue="14.900000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002342" DistinctValues="127.852232">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOACgj" DoubleValue="14.900000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAQAFgb" DoubleValue="16.700000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAQAFgb" DoubleValue="16.700000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAQAFgb" DoubleValue="16.700000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018855" DistinctValues="1029.210468">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAQAFgb" DoubleValue="16.700000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002731" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012974" DistinctValues="708.159307">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAApAEAG" DoubleValue="41.160000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011147" DistinctValues="609.082949">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAApAEAG" DoubleValue="41.160000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006704" DistinctValues="366.332498">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAyAA==" DoubleValue="50.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAyAA==" DoubleValue="50.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAyAA==" DoubleValue="50.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017205" DistinctValues="940.106291">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAyAA==" DoubleValue="50.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AFAU" DoubleValue="58.520000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000563" DistinctValues="30.744145">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AFAU" DoubleValue="58.520000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002842" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003224" DistinctValues="176.080102">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001931" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018501" DistinctValues="1010.364392">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012769" DistinctValues="697.333101">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABIAJgI" DoubleValue="72.220000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABIAJgI" DoubleValue="72.220000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABdAFQk" DoubleValue="93.930000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032628" DistinctValues="1783.781569">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABdAFQk" DoubleValue="93.930000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAB4AA==" DoubleValue="120.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000717" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAB4AA==" DoubleValue="120.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAB4AA==" DoubleValue="120.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002428" DistinctValues="132.740170">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAB4AA==" DoubleValue="120.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAB5ALgk" DoubleValue="121.940000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAB5ALgk" DoubleValue="121.940000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACZAHge" DoubleValue="153.780000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACZAHge" DoubleValue="153.780000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAC6AJAa" DoubleValue="186.680000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAC6AJAa" DoubleValue="186.680000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADeABwM" DoubleValue="222.310000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADeABwM" DoubleValue="222.310000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAABAaAP" DoubleValue="257.400000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025671" DistinctValues="1403.454012">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAABAaAP" DoubleValue="257.400000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAbAcgZ" DoubleValue="283.660000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000717" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAbAcgZ" DoubleValue="283.660000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAbAcgZ" DoubleValue="283.660000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009385" DistinctValues="513.067727">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAbAcgZ" DoubleValue="283.660000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAlASgK" DoubleValue="293.260000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007405" DistinctValues="404.594689">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAlASgK" DoubleValue="293.260000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003862" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007383" DistinctValues="403.394111">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020269" DistinctValues="1107.532939">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABFAaQG" DoubleValue="325.170000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030857" DistinctValues="1686.945974">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABFAaQG" DoubleValue="325.170000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000717" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004199" DistinctValues="229.575766">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABsAegc" DoubleValue="364.740000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABsAegc" DoubleValue="364.740000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACZAcQJ" DoubleValue="409.250000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACZAcQJ" DoubleValue="409.250000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOAYAl" DoubleValue="462.960000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009019" DistinctValues="493.092714">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOAYAl" DoubleValue="462.960000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026037" DistinctValues="1423.429025">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAARAmwH" DoubleValue="529.190000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018907" DistinctValues="1033.638825">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAARAmwH" DoubleValue="529.190000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA3AtgO" DoubleValue="567.380000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA3AtgO" DoubleValue="567.380000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA3AtgO" DoubleValue="567.380000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016149" DistinctValues="882.882914">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA3AtgO" DoubleValue="567.380000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006401" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005191" DistinctValues="283.657036">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002759" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029865" DistinctValues="1631.864703">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACzAkQW" DoubleValue="691.570000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACzAkQW" DoubleValue="691.570000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABdA/gR" DoubleValue="861.460000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004233" DistinctValues="231.392337">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABdA/gR" DoubleValue="861.460000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000910" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030824" DistinctValues="1685.129402">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACcBCwa" DoubleValue="1180.670000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000969" DistinctValues="52.918801">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACcBCwa" DoubleValue="1180.670000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003007" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027194" DistinctValues="1485.121120">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002883" DistinctValues="157.469707">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000910" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004010" DistinctValues="219.012110">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYBw==" DoubleValue="1880.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000614" DistinctValues="33.553568">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYBw==" DoubleValue="1880.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABgCQ==" DoubleValue="2400.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABgCQ==" DoubleValue="2400.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABgCQ==" DoubleValue="2400.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034443" DistinctValues="1882.968171">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABgCQ==" DoubleValue="2400.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgIAAQADAC0GiBM=" DoubleValue="31581.500000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035056" DistinctValues="1917.521739">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgIAAQADAC0GiBM=" DoubleValue="31581.500000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAQAhAMQi" DoubleValue="338900.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.42" Name="qq" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.859488" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000798" DistinctValues="16.899077">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001710" DistinctValues="36.231330">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1396"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4389"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000005" DistinctValues="0.096843">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000025" DistinctValues="0.520530">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4440"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000005" DistinctValues="0.096843">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4448"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000800" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4448"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4448"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000065" DistinctValues="1.367905">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4448"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4561"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001462" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4561"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4561"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000050" DistinctValues="1.065271">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000993" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4649"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4649"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019759" DistinctValues="418.651626">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4649"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000296" DistinctValues="6.270574">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000000" DistinctValues="0.006423">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39753"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39754"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003049" DistinctValues="65.141463">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="60037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="60037"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="60037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016022" DistinctValues="342.292163">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="60037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="166616"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="166616"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="166616"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003202" DistinctValues="68.410900">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="166616"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="187917"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="187917"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="187917"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000438" DistinctValues="9.349051">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="187917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="190828"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002404" DistinctValues="51.456637">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="190828"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252134"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252135"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252135"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000000" DistinctValues="0.005036">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252135"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252141"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000966" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252141"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252141"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020307" DistinctValues="434.734131">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="252141"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770088"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000000" DistinctValues="0.004197">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770093"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000029" DistinctValues="0.621186">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770093"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001848" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.231145">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770588"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001655" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770588"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770588"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000686" DistinctValues="14.597859">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="770588"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001793" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008034" DistinctValues="170.934535">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003523" DistinctValues="74.953890">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008365" DistinctValues="177.969648">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000170" DistinctValues="3.614851">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001846" DistinctValues="39.276886">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="899219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022711" DistinctValues="490.200000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="899219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="899629"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.35" Name="jj" Width="10.000000" NullFreq="0.000000" NdvRemain="2944.000000" FreqRemain="0.783617" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.006401" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkJhZCBOZXVlbmFoci1BaHJ3ZWlsZXI=" LintValue="27411262"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkJhZCBOZXVlbmFoci1BaHJ3ZWlsZXI=" LintValue="27411262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016278" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008746" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006842" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADURhcm1zdGFkdA==" LintValue="942048118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADURhcm1zdGFkdA==" LintValue="942048118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006566" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0TDvHNzZWxkb3Jm" LintValue="613991398"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0TDvHNzZWxkb3Jm" LintValue="613991398"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011974" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004690" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEZyZWlidXJnIGltIEJyZWlzZ2F1" LintValue="840868860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEZyZWlidXJnIGltIEJyZWlzZ2F1" LintValue="840868860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009546" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dpZcOfZW4=" LintValue="281658366"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dpZcOfZW4=" LintValue="281658366"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020885" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006704" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkthc3NlbA==" LintValue="809861996"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkthc3NlbA==" LintValue="809861996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012884" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006180" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF0xhbmRhdSBpbiBkZXIgUGZhbHo=" LintValue="406012774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF0xhbmRhdSBpbiBkZXIgUGZhbHo=" LintValue="406012774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haW56" LintValue="280707940"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haW56" LintValue="280707940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008304" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013381" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007201" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEE9iZXJ0c2hhdXNlbg==" LintValue="845005694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEE9iZXJ0c2hhdXNlbg==" LintValue="845005694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005849" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBhZGVyYm9ybg==" LintValue="764527478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBhZGVyYm9ybg==" LintValue="764527478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004249" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNwZXllcg==" LintValue="166347644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNwZXllcg==" LintValue="166347644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016471" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005270" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlR1dHRsaW5nZW4=" LintValue="305775484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlR1dHRsaW5nZW4=" LintValue="305775484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011946" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.34" Name="ii" Width="5.000000" NullFreq="0.000000" NdvRemain="3672.000000" FreqRemain="0.864233" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.006483" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwODky" LintValue="778453806"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwODky" LintValue="778453806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007973" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTIwMDk3" LintValue="776397614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTIwMDk3" LintValue="776397614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005325" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzMDk4" LintValue="793183022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzMDk4" LintValue="793183022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009187" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM1Mzk0" LintValue="525239150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM1Mzk0" LintValue="525239150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003973" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3MjM1" LintValue="231645998"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3MjM1" LintValue="231645998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003973" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzMTI5" LintValue="784802662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzMTI5" LintValue="784802662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003697" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzMTc1" LintValue="801547118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzMTc1" LintValue="801547118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006401" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzNDc0" LintValue="802587438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzNDc0" LintValue="802587438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003642" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU1NTQz" LintValue="525755238"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU1NTQz" LintValue="525755238"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004938" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYwMzEz" LintValue="776889198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYwMzEz" LintValue="776889198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzMTc5" LintValue="801579886"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzMTc5" LintValue="801579886"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzNjU0" LintValue="794723118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzNjU0" LintValue="794723118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY0Mjgz" LintValue="206463782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY0Mjgz" LintValue="206463782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004773" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005518" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MjA1" LintValue="508470054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MjA1" LintValue="508470054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004249" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY3MzQ2" LintValue="256820070"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY3MzQ2" LintValue="256820070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007835" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY4MTY1" LintValue="801547110"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY4MTY1" LintValue="801547110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcwMTc0" LintValue="784761710"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcwMTc0" LintValue="784761710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003531" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc1MDE1" LintValue="524722990"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc1MDE1" LintValue="524722990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006208" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2ODI5" LintValue="535241510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2ODI5" LintValue="535241510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005270" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc4NTMy" LintValue="802571118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc4NTMy" LintValue="802571118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003559" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc5MDk4" LintValue="1028064046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc5MDk4" LintValue="1028064046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007201" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTgwOTky" LintValue="795231084"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTgwOTky" LintValue="795231084"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.27" Name="bb" Width="5.000000" NullFreq="0.000000" NdvRemain="4144.000000" FreqRemain="0.863957" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.003752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwNjIz" LintValue="752771878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwNjIz" LintValue="752771878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005877" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwODky" LintValue="778453806"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwODky" LintValue="778453806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007311" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTIwMDk3" LintValue="776397614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTIwMDk3" LintValue="776397614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005932" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTIwNDU5" LintValue="760685358"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTIwNDU5" LintValue="760685358"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005325" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzMDk4" LintValue="793183022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzMDk4" LintValue="793183022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008608" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM1Mzk0" LintValue="525239150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM1Mzk0" LintValue="525239150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003559" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3MjM1" LintValue="231645998"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3MjM1" LintValue="231645998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUyMTQ2" LintValue="1061602150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUyMTQ2" LintValue="1061602150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006346" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzNDc0" LintValue="802587438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzNDc0" LintValue="802587438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003669" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU1NTQz" LintValue="525755238"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU1NTQz" LintValue="525755238"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYwMzEz" LintValue="776889198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYwMzEz" LintValue="776889198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzMTc5" LintValue="801579886"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzMTc5" LintValue="801579886"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003780" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzNjU0" LintValue="794723118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTYzNjU0" LintValue="794723118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005987" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY0Mjgz" LintValue="206463782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY0Mjgz" LintValue="206463782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009242" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MjA1" LintValue="508470054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MjA1" LintValue="508470054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY3MzQ2" LintValue="256820070"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY3MzQ2" LintValue="256820070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007422" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY4MTY1" LintValue="801547110"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY4MTY1" LintValue="801547110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005849" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcwMTc0" LintValue="784761710"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcwMTc0" LintValue="784761710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007394" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003449" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc1MDE1" LintValue="524722990"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc1MDE1" LintValue="524722990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005987" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2ODI5" LintValue="535241510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2ODI5" LintValue="535241510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004194" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005049" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc4NTMy" LintValue="802571118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc4NTMy" LintValue="802571118"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.26" Name="aa" Width="2.000000" NullFreq="0.000000" NdvRemain="263.000000" FreqRemain="0.305800" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.020168" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.106632" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028472" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021547" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014981" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014595" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019174" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019864" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022127" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016967" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.060724" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016885" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013601" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013988" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012388" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011174" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI1" LintValue="873636644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI1" LintValue="873636644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039977" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040998" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.041025" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029548" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035894" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019782" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.19" Name="t" Width="2.000000" NullFreq="0.038652" NdvRemain="366.000000" FreqRemain="0.292556" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.082878" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029548" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026844" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025051" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020940" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021078" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021658" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018236" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017740" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017271" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE4" LintValue="882049836"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE4" LintValue="882049836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015478" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.045440" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015174" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013960" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013739" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011698" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012056" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011615" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI1" LintValue="873636644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI1" LintValue="873636644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040667" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039342" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036473" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037604" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034569" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032666" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027065" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.18" Name="s" Width="13.000000" NullFreq="0.038652" NdvRemain="31641.000000" FreqRemain="0.839044" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.002428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009822" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEJlcmdzdHIu" LintValue="357942054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEJlcmdzdHIu" LintValue="357942054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUJlcmxpbmVyIFN0ci4=" LintValue="928891700"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUJlcmxpbmVyIFN0ci4=" LintValue="928891700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUJpcmtlbndlZw==" LintValue="57205614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUJpcmtlbndlZw==" LintValue="57205614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001517" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JydW5uZW5zdHIu" LintValue="400933668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JydW5uZW5zdHIu" LintValue="400933668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADERvcmZzdHIu" LintValue="911590308"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADERvcmZzdHIu" LintValue="911590308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003835" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0Zhc2FuZW5zdHIu" LintValue="399885110"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0Zhc2FuZW5zdHIu" LintValue="399885110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001573" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUZyaWVkcmljaHN0ci4=" LintValue="98943908"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUZyaWVkcmljaHN0ci4=" LintValue="98943908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003669" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdhcnRlbnN0ci4=" LintValue="654164790"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdhcnRlbnN0ci4=" LintValue="654164790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002400" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdvZXRoZXN0ci4=" LintValue="887997238"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdvZXRoZXN0ci4=" LintValue="887997238"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024472" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002097" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUluZHVzdHJpZXN0ci4=" LintValue="634241844"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUluZHVzdHJpZXN0ci4=" LintValue="634241844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001655" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEphaG5zdHIu" LintValue="885375796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEphaG5zdHIu" LintValue="885375796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002897" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUtpcmNoc3RyLg==" LintValue="936231732"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUtpcmNoc3RyLg==" LintValue="936231732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002180" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxhbmdlIFN0ci4=" LintValue="903725878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxhbmdlIFN0ci4=" LintValue="903725878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003531" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxpbmRlbnN0ci4=" LintValue="349553460"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxpbmRlbnN0ci4=" LintValue="349553460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026210" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAElJhaWZmZWlzZW5zdHIu" LintValue="383632166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAElJhaWZmZWlzZW5zdHIu" LintValue="383632166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003035" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFJpbmdzdHIu" LintValue="99992502"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFJpbmdzdHIu" LintValue="99992502"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002897" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaHVsc3RyLg==" LintValue="880133044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaHVsc3RyLg==" LintValue="880133044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1RhbHN0ci4=" LintValue="399360932"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1RhbHN0ci4=" LintValue="399360932"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdhbGRzdHIu" LintValue="132498228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdhbGRzdHIu" LintValue="132498228"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.10" Name="k" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUE=" LintValue="160703020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUE=" LintValue="160703020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUM=" LintValue="160719404"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUM=" LintValue="160719404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.999034" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUU=" LintValue="160735788"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUU=" LintValue="160735788"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.3" Name="d" Width="2.000000" NullFreq="0.000000" NdvRemain="12.615385" FreqRemain="0.005543" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.006925" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005794" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="2.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.045688" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003200" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="2.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036694" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000792" DistinctValues="1.582418">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003200" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000594" DistinctValues="1.186813">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.053082" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="29"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.256442" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="3.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.046626" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036887" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.084423" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012829" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="35"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000308" DistinctValues="0.222222">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007449" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016333" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="39"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="40"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000616" DistinctValues="0.444444">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003476" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000462" DistinctValues="0.333333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002621" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="47"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020030" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="3.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024996" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000277" DistinctValues="0.553846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007201" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001109" DistinctValues="2.215385">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.265050" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="3.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023009" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000292" DistinctValues="0.210526">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000219" DistinctValues="0.157895">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002345" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000875" DistinctValues="0.631579">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008553" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.029616" DistinctValues="1113.515908">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000018" DistinctValues="0.668912">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001379" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10030"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000133" DistinctValues="5.016842">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10030"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10075"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000828" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10075"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10075"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007612" DistinctValues="286.182953">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10075"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="12642"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020366" DistinctValues="766.817562">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="12642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002787" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017013" DistinctValues="640.567053">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="61446"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007976" DistinctValues="300.296033">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="61446"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="70050"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="70050"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="70050"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029404" DistinctValues="1107.088582">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="70050"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="160532"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022755" DistinctValues="856.755655">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="160532"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="167831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="167831"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="167831"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014624" DistinctValues="550.628960">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="167831"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="172522"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011796" DistinctValues="443.825771">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="172522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="177736"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001186" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="177736"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="177736"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009344" DistinctValues="351.553593">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="177736"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="181866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="181866"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="181866"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016239" DistinctValues="611.005252">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="181866"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="189044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014000" DistinctValues="527.106692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="189044"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="197696"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="197696"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="197696"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023380" DistinctValues="880.277923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="197696"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="212145"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="212145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="252147"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="252147"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="301565"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011272" DistinctValues="424.110260">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="301565"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="312521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="312521"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="312521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002981" DistinctValues="112.143795">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="312521"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="315418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000855" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="315418"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="315418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023127" DistinctValues="870.130560">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="315418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="337896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023759" DistinctValues="894.558428">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="337896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013620" DistinctValues="512.826188">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="361536"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="361536"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="405152"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="405152"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="441727"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="441727"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="476648"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003837" DistinctValues="144.481661">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="476648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033542" DistinctValues="1262.902955">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="510449"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="510449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="554955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="554955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="602343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031378" DistinctValues="1181.415345">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="602343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="641037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="641037"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="641037"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006002" DistinctValues="225.969271">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="641037"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="648438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="648438"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="693729"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="693729"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="729135"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013265" DistinctValues="499.429464">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="729135"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000883" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024115" DistinctValues="907.955152">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="769435"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002465" DistinctValues="92.680026">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="769435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012654" DistinctValues="475.772463">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017548" DistinctValues="659.782805">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="774489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004712" DistinctValues="177.149321">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="781930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002646" DistinctValues="99.564433">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="781930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="783948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="783948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="783948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025993" DistinctValues="977.981261">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="783948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="803770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="803770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="803770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008740" DistinctValues="328.838922">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="803770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="810435"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002879" DistinctValues="108.262866">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="810435"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="813684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000855" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="813684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="813684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005747" DistinctValues="216.059224">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="813684"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017720" DistinctValues="666.238145">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000717" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840162"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011033" DistinctValues="414.824381">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="852611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028948" DistinctValues="1089.179721">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="852611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000717" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000186" DistinctValues="6.997389">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003835" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008245" DistinctValues="310.207505">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037379" DistinctValues="1408.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899240"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899781"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.11" Name="l" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000331" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033107" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.139546" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030955" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.522375" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.136732" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.136953" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.2146.1.0"/>
+        <dxl:MaxAgg Mdid="0.2130.1.0"/>
+        <dxl:AvgAgg Mdid="0.2103.1.0"/>
+        <dxl:SumAgg Mdid="0.2114.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.25" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.24" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.17" Name="r" Width="5.000000" NullFreq="0.000000" NdvRemain="2864.000000" FreqRemain="0.530679" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.389721" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMDQ0OTg=" LintValue="268370734"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMDQ0OTg=" LintValue="268370734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003127" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMTE2MTI=" LintValue="1022772014"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMTE2MTI=" LintValue="1022772014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002896" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMTY3MDI=" LintValue="485901158"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMTY3MDI=" LintValue="485901158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002838" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjI2NDM=" LintValue="1039557414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjI2NDM=" LintValue="1039557414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004314" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjM0MTU=" LintValue="754885422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjM0MTU=" LintValue="754885422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002230" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjQ4OTc=" LintValue="248439598"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjQ4OTc=" LintValue="248439598"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003793" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjU3NDk=" LintValue="502735718"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjU3NDk=" LintValue="502735718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003069" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjYzMjc=" LintValue="476504934"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjYzMjc=" LintValue="476504934"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003011" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjY4MjM=" LintValue="474899238"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMjY4MjM=" LintValue="474899238"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002288" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzAxMjc=" LintValue="762241894"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzAxMjc=" LintValue="762241894"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004112" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzE5Mjg=" LintValue="1028588390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzE5Mjg=" LintValue="1028588390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002606" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzQ5ODI=" LintValue="265175910"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzQ5ODI=" LintValue="265175910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002230" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzg3NzA=" LintValue="745931630"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWMzg3NzA=" LintValue="745931630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002693" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNDU4MTM=" LintValue="533619502"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNDU4MTM=" LintValue="533619502"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002722" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNTc2Nzc=" LintValue="259449646"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNTc2Nzc=" LintValue="259449646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002345" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNTgzOTY=" LintValue="753320814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNTgzOTY=" LintValue="753320814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003243" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNjE2ODc=" LintValue="1022812966"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNjE2ODc=" LintValue="1022812966"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003301" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNjE2ODg=" LintValue="1022821158"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNjE2ODg=" LintValue="1022821158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002606" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNjE4MDQ=" LintValue="1053721382"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWNjE4MDQ=" LintValue="1053721382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009903" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzAzMkQ=" LintValue="392725350"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzAzMkQ=" LintValue="392725350"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004430" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzAzNEk=" LintValue="384377702"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzAzNEk=" LintValue="384377702"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002548" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzA0MUg=" LintValue="401670958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzA0MUg=" LintValue="401670958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002230" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzMyNUE=" LintValue="384312110"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzMyNUE=" LintValue="384312110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003706" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzM1M0E=" LintValue="393225070"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1hWRzM1M0E=" LintValue="393225070"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.9" Name="j" Width="13.000000" NullFreq="0.042131" NdvRemain="27757.000000" FreqRemain="0.864312" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEJhY2hzdHIu" LintValue="398836516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEJhY2hzdHIu" LintValue="398836516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007500" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003706" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEJlcmdzdHIu" LintValue="357942054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEJlcmdzdHIu" LintValue="357942054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001853" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUJlcmxpbmVyIFN0ci4=" LintValue="928891700"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUJlcmxpbmVyIFN0ci4=" LintValue="928891700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001708" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkRpZXNlbHN0ci4=" LintValue="905823028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkRpZXNlbHN0ci4=" LintValue="905823028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009382" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADERvcmZzdHIu" LintValue="911590308"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADERvcmZzdHIu" LintValue="911590308"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004314" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdhcnRlbnN0ci4=" LintValue="654164790"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdhcnRlbnN0ci4=" LintValue="654164790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002085" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdvZXRoZXN0ci4=" LintValue="887997238"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkdvZXRoZXN0ci4=" LintValue="887997238"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020211" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkhlc3NlbnJpbmc=" LintValue="866444262"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkhlc3NlbnJpbmc=" LintValue="866444262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005589" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUluZHVzdHJpZXN0ci4=" LintValue="634241844"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUluZHVzdHJpZXN0ci4=" LintValue="634241844"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEphaG5zdHIu" LintValue="885375796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEphaG5zdHIu" LintValue="885375796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002201" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUtpcmNoc3RyLg==" LintValue="936231732"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUtpcmNoc3RyLg==" LintValue="936231732"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001650" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxhbmdlIFN0ci4=" LintValue="903725878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxhbmdlIFN0ci4=" LintValue="903725878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003069" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxpbmRlbnN0ci4=" LintValue="349553460"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkxpbmRlbnN0ci4=" LintValue="349553460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001477" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002809" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC05ldXN0ci4=" LintValue="1055245094"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC05ldXN0ci4=" LintValue="1055245094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003417" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002461" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAElJhaWZmZWlzZW5zdHIu" LintValue="383632166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAElJhaWZmZWlzZW5zdHIu" LintValue="383632166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002925" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFJpbmdzdHIu" LintValue="99992502"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFJpbmdzdHIu" LintValue="99992502"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003880" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003446" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaHVsc3RyLg==" LintValue="880133044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaHVsc3RyLg==" LintValue="880133044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdhbGRzdHIu" LintValue="132498228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdhbGRzdHIu" LintValue="132498228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001650" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADldpZXNlbnN0ci4=" LintValue="887997236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADldpZXNlbnN0ci4=" LintValue="887997236"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.8" Name="i" Width="5.000000" NullFreq="0.042131" NdvRemain="3750.000000" FreqRemain="0.481511" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.347937" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008455" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004865" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005212" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004343" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkRpZXRlcg==" LintValue="8012606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkRpZXRlcg==" LintValue="8012606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005183" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004546" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dlcmhhcmQ=" LintValue="481854438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dlcmhhcmQ=" LintValue="481854438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004430" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004980" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004980" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003735" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEthcmw=" LintValue="77693796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEthcmw=" LintValue="77693796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006197" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005675" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01hbmZyZWQ=" LintValue="55608108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01hbmZyZWQ=" LintValue="55608108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004488" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004807" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcnRpbg==" LintValue="594395948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcnRpbg==" LintValue="594395948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009063" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007181" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003533" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldHJh" LintValue="1019749158"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldHJh" LintValue="1019749158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003446" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNhYmluZQ==" LintValue="573088628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNhYmluZQ==" LintValue="573088628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005299" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009990" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003533" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAB1V3ZQ==" LintValue="659596140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAB1V3ZQ==" LintValue="659596140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003388" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005183" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005907" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.1" Name="b" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.162704" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025800" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000116" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.260924" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.550282" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="14527"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024809" DistinctValues="707.952853">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="14527"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="68933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001477" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="68933"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="68933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003222" DistinctValues="91.932634">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="68933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002027" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75998"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75998"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008955" DistinctValues="255.537590">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75998"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95636"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95636"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="114735"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001037" DistinctValues="29.582198">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="114735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="116041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001650" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="116041"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="116041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000789" DistinctValues="22.515088">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="116041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="117035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="117035"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="117035"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035159" DistinctValues="1003.325790">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="117035"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="161330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030864" DistinctValues="881.583544">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="161330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="168611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="168611"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="168611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006121" DistinctValues="174.839533">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="168611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170055"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000010" DistinctValues="0.296103">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170055"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170057"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170057"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004502" DistinctValues="128.360686">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170057"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170924"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007618" DistinctValues="217.191611">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="170924"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="172391"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001129" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="172391"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="172391"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024854" DistinctValues="708.574677">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="172391"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="177177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001370" DistinctValues="39.096479">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="177177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="177392"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="177392"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="177392"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028350" DistinctValues="809.024340">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="177392"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="181841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002345" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="181841"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="181841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007264" DistinctValues="207.302258">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="181841"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="191711"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="191711"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="200363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="200363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="244444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="244444"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="294115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006357" DistinctValues="181.232700">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="294115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300183"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000158" DistinctValues="4.509911">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002201" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028481" DistinctValues="811.992981">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="300334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003533" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327521"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001988" DistinctValues="56.687486">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327521"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="329419"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="329419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="354244"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="354244"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="398718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027469" DistinctValues="784.621903">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="398718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429153"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429153"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429153"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009516" DistinctValues="271.801174">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429153"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439696"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439696"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="476039"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="476039"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531637"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="597048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003214" DistinctValues="91.635719">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="597048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="602286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="602286"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="602286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010148" DistinctValues="289.322552">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="602286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618824"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618824"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618824"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000003" DistinctValues="0.087472">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618824"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618829"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023619" DistinctValues="673.377334">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="618829"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="657320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026821" DistinctValues="765.395379">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="657320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="688846"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="688846"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="688846"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003215" DistinctValues="91.747419">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="688846"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="692625"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001303" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="692625"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="692625"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006948" DistinctValues="198.280279">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="692625"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="700792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="700792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001795" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001393" DistinctValues="39.708052">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="743436"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="744484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001477" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="744484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="744484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001650" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="744485"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="744485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035592" DistinctValues="1014.715025">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="744485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="771266"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004231" DistinctValues="120.724929">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="771266"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="772939"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001129" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="772939"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="772939"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012158" DistinctValues="346.948869">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="772939"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="777747"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="777747"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="777747"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020596" DistinctValues="587.749279">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="777747"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="785892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="785892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="840464"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011901" DistinctValues="339.948405">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="840464"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="859442"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="859442"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="859442"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025083" DistinctValues="716.474672">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="859442"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="899440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036985" DistinctValues="1057.423077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="899440"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="899781"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.16" Name="q" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000232" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AGCcxf/iH/8=" DoubleValue="-63082281600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AGCcxf/iH/8=" DoubleValue="-63082281600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038386" DistinctValues="0.999691">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AGCcxf/iH/8=" DoubleValue="-63082281600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EoSdhjX//8=" DoubleValue="-44974916613420.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EoSdhjX//8=" DoubleValue="-44974916613420.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EoSdhjX//8=" DoubleValue="-44974916613420.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000012" DistinctValues="0.000309">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EoSdhjX//8=" DoubleValue="-44974916613420.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="iJvfSMvo//8=" DoubleValue="-25515178091640.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="iJvfSMvo//8=" DoubleValue="-25515178091640.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="NJnYndEDAAA=" DoubleValue="4198831266100.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026098" DistinctValues="0.679678">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="NJnYndEDAAA=" DoubleValue="4198831266100.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4tT0FNQaAAA=" DoubleValue="29498186978530.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4tT0FNQaAAA=" DoubleValue="29498186978530.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4tT0FNQaAAA=" DoubleValue="29498186978530.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012300" DistinctValues="0.320322">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4tT0FNQaAAA=" DoubleValue="29498186978530.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lI6FK6wlAAA=" DoubleValue="41421394775700.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036295" DistinctValues="0.945235">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lI6FK6wlAAA=" DoubleValue="41421394775700.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zH36yxU+AAA=" DoubleValue="68263337426380.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zH36yxU+AAA=" DoubleValue="68263337426380.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zH36yxU+AAA=" DoubleValue="68263337426380.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002103" DistinctValues="0.054765">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zH36yxU+AAA=" DoubleValue="68263337426380.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wjzX4n8/AAA=" DoubleValue="69818499153090.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036933" DistinctValues="0.961841">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wjzX4n8/AAA=" DoubleValue="69818499153090.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="utQdSlNWAAA=" DoubleValue="94915725743290.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="utQdSlNWAAA=" DoubleValue="94915725743290.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="utQdSlNWAAA=" DoubleValue="94915725743290.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001465" DistinctValues="0.038159">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="utQdSlNWAAA=" DoubleValue="94915725743290.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nCoqHTtXAAA=" DoubleValue="95911403989660.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nCoqHTtXAAA=" DoubleValue="95911403989660.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SslwCEhxAAA=" DoubleValue="124554193193290.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SslwCEhxAAA=" DoubleValue="124554193193290.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OhjjmZyTAAA=" DoubleValue="162300805978170.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OhjjmZyTAAA=" DoubleValue="162300805978170.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="XIU9iC2yAAA=" DoubleValue="195908629005660.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005107" DistinctValues="0.133001">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="XIU9iC2yAAA=" DoubleValue="195908629005660.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Ds+iFQm2AAA=" DoubleValue="200150133952270.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Ds+iFQm2AAA=" DoubleValue="200150133952270.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Ds+iFQm2AAA=" DoubleValue="200150133952270.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033291" DistinctValues="0.866999">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Ds+iFQm2AAA=" DoubleValue="200150133952270.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Mq9LrC7PAAA=" DoubleValue="227799366086450.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002884" DistinctValues="0.075105">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Mq9LrC7PAAA=" DoubleValue="227799366086450.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pG1a+knRAAA=" DoubleValue="230115663048100.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pG1a+knRAAA=" DoubleValue="230115663048100.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pG1a+knRAAA=" DoubleValue="230115663048100.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000319" DistinctValues="0.008303">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pG1a+knRAAA=" DoubleValue="230115663048100.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nswXmYXRAAA=" DoubleValue="230371729329310.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nswXmYXRAAA=" DoubleValue="230371729329310.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nswXmYXRAAA=" DoubleValue="230371729329310.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035195" DistinctValues="0.916593">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nswXmYXRAAA=" DoubleValue="230371729329310.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QEjlZTvrAAA=" DoubleValue="258640345122880.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007875" DistinctValues="0.205080">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QEjlZTvrAAA=" DoubleValue="258640345122880.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="+IsZV1bwAAA=" DoubleValue="264253619145720.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="+IsZV1bwAAA=" DoubleValue="264253619145720.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="+IsZV1bwAAA=" DoubleValue="264253619145720.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022781" DistinctValues="0.593292">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="+IsZV1bwAAA=" DoubleValue="264253619145720.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pvqsSxv/AAA=" DoubleValue="280492698827430.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pvqsSxv/AAA=" DoubleValue="280492698827430.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pvqsSxv/AAA=" DoubleValue="280492698827430.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007742" DistinctValues="0.201627">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="pvqsSxv/AAA=" DoubleValue="280492698827430.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="YNrmOyAEAQA=" DoubleValue="286011467160160.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020754" DistinctValues="0.540502">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="YNrmOyAEAQA=" DoubleValue="286011467160160.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BqVJap4QAQA=" DoubleValue="299747550799110.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BqVJap4QAQA=" DoubleValue="299747550799110.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BqVJap4QAQA=" DoubleValue="299747550799110.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017644" DistinctValues="0.459498">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BqVJap4QAQA=" DoubleValue="299747550799110.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="kg13ST0bAQA=" DoubleValue="311425016204690.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001692" DistinctValues="0.044071">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="kg13ST0bAQA=" DoubleValue="311425016204690.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="mm4zpzscAQA=" DoubleValue="312517510524570.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="mm4zpzscAQA=" DoubleValue="312517510524570.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="mm4zpzscAQA=" DoubleValue="312517510524570.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009980" DistinctValues="0.259916">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="mm4zpzscAQA=" DoubleValue="312517510524570.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="NPf5zBciAQA=" DoubleValue="318960595236660.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="NPf5zBciAQA=" DoubleValue="318960595236660.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="NPf5zBciAQA=" DoubleValue="318960595236660.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026726" DistinctValues="0.696013">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="NPf5zBciAQA=" DoubleValue="318960595236660.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lujp9cgxAQA=" DoubleValue="336214165678230.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022598" DistinctValues="0.588527">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lujp9cgxAQA=" DoubleValue="336214165678230.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uo9WmR49AQA=" DoubleValue="348676607610810.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uo9WmR49AQA=" DoubleValue="348676607610810.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uo9WmR49AQA=" DoubleValue="348676607610810.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015800" DistinctValues="0.411473">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uo9WmR49AQA=" DoubleValue="348676607610810.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SoQkTQtFAQA=" DoubleValue="357389817906250.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SoQkTQtFAQA=" DoubleValue="357389817906250.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2ii3Vn5WAQA=" DoubleValue="376575597422810.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023670" DistinctValues="0.616444">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2ii3Vn5WAQA=" DoubleValue="376575597422810.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="hH+aCaJkAQA=" DoubleValue="392122085310340.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="hH+aCaJkAQA=" DoubleValue="392122085310340.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="hH+aCaJkAQA=" DoubleValue="392122085310340.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008668" DistinctValues="0.225739">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="hH+aCaJkAQA=" DoubleValue="392122085310340.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="VMK8jc9pAQA=" DoubleValue="397815133815380.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="VMK8jc9pAQA=" DoubleValue="397815133815380.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="VMK8jc9pAQA=" DoubleValue="397815133815380.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006060" DistinctValues="0.157818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="VMK8jc9pAQA=" DoubleValue="397815133815380.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bP9kPm5tAQA=" DoubleValue="401795237347180.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009647" DistinctValues="0.251238">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bP9kPm5tAQA=" DoubleValue="401795237347180.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="GvrbWYRxAQA=" DoubleValue="406288233921050.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000087" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="GvrbWYRxAQA=" DoubleValue="406288233921050.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="GvrbWYRxAQA=" DoubleValue="406288233921050.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003376" DistinctValues="0.087913">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="GvrbWYRxAQA=" DoubleValue="406288233921050.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="WtAlZ/JyAQA=" DoubleValue="407860414894170.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="WtAlZ/JyAQA=" DoubleValue="407860414894170.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="WtAlZ/JyAQA=" DoubleValue="407860414894170.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003285" DistinctValues="0.085546">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="WtAlZ/JyAQA=" DoubleValue="407860414894170.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7hMMmVZ0AQA=" DoubleValue="409390260425710.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7hMMmVZ0AQA=" DoubleValue="409390260425710.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7hMMmVZ0AQA=" DoubleValue="409390260425710.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022091" DistinctValues="0.575303">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7hMMmVZ0AQA=" DoubleValue="409390260425710.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gkAtDLJ9AQA=" DoubleValue="419678638653570.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034617" DistinctValues="0.901522">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gkAtDLJ9AQA=" DoubleValue="419678638653570.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EWQFW+OAQA=" DoubleValue="438082731001300.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EWQFW+OAQA=" DoubleValue="438082731001300.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EWQFW+OAQA=" DoubleValue="438082731001300.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003781" DistinctValues="0.098478">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1EWQFW+OAQA=" DoubleValue="438082731001300.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nj+cKUOQAQA=" DoubleValue="440093112024990.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016612" DistinctValues="0.432639">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nj+cKUOQAQA=" DoubleValue="440093112024990.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OHWRBc2XAQA=" DoubleValue="448381794219320.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OHWRBc2XAQA=" DoubleValue="448381794219320.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OHWRBc2XAQA=" DoubleValue="448381794219320.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019540" DistinctValues="0.508892">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OHWRBc2XAQA=" DoubleValue="448381794219320.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="3vB0BaugAQA=" DoubleValue="458131368112350.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="3vB0BaugAQA=" DoubleValue="458131368112350.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="3vB0BaugAQA=" DoubleValue="458131368112350.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002245" DistinctValues="0.058469">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="3vB0BaugAQA=" DoubleValue="458131368112350.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="so721K+hAQA=" DoubleValue="459251540987570.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026092" DistinctValues="0.679514">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="so721K+hAQA=" DoubleValue="459251540987570.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="vjehBqeqAQA=" DoubleValue="469109324199870.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="vjehBqeqAQA=" DoubleValue="469109324199870.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="vjehBqeqAQA=" DoubleValue="469109324199870.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012306" DistinctValues="0.320486">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="vjehBqeqAQA=" DoubleValue="469109324199870.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="HF91h+GuAQA=" DoubleValue="473758640201500.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="HF91h+GuAQA=" DoubleValue="473758640201500.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2iE8jcG9AQA=" DoubleValue="490113972576730.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2iE8jcG9AQA=" DoubleValue="490113972576730.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="M+xEiJrJAQA=" DoubleValue="503140525075507.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020365" DistinctValues="0.530359">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="M+xEiJrJAQA=" DoubleValue="503140525075507.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yqkr5FrTAQA=" DoubleValue="513862305294794.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yqkr5FrTAQA=" DoubleValue="513862305294794.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yqkr5FrTAQA=" DoubleValue="513862305294794.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018033" DistinctValues="0.469641">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yqkr5FrTAQA=" DoubleValue="513862305294794.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="JBKldP3bAQA=" DoubleValue="523356606894628.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="JBKldP3bAQA=" DoubleValue="523356606894628.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5z22sP3lAQA=" DoubleValue="534352730930663.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012916" DistinctValues="0.336359">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5z22sP3lAQA=" DoubleValue="534352730930663.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rWDeo4TpAQA=" DoubleValue="538230870925485.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rWDeo4TpAQA=" DoubleValue="538230870925485.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rWDeo4TpAQA=" DoubleValue="538230870925485.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025483" DistinctValues="0.663641">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rWDeo4TpAQA=" DoubleValue="538230870925485.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="fyd4K3rwAQA=" DoubleValue="545882482681727.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038398" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="fyd4K3rwAQA=" DoubleValue="545882482681727.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="B8RroK3wAQA=" DoubleValue="546103488136199.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.48" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.41" Name="pp" Width="1.000000" NullFreq="0.000000" NdvRemain="263.000000" FreqRemain="0.034238" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.947553" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0F3ZW5pdXM=" LintValue="126510062"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0F3ZW5pdXM=" LintValue="126510062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002483" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH0JBRy1Ib2hlbmxvaGUtUmFpZmZlaXNlbiBlRw==" LintValue="43836204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH0JBRy1Ib2hlbmxvaGUtUmFpZmZlaXNlbiBlRw==" LintValue="43836204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJhY2g=" LintValue="278987628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJhY2g=" LintValue="278987628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJhaG4=" LintValue="304202596"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJhaG4=" LintValue="304202596"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0V5cmlzY2g=" LintValue="676398078"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0V5cmlzY2g=" LintValue="676398078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIEZGTSBDaXR5IFdlc3QtS2xhdXMgU2NodXN0ZXI=" LintValue="727597884"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIEZGTSBDaXR5IFdlc3QtS2xhdXMgU2NodXN0ZXI=" LintValue="727597884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEZvbGxyaWNo" LintValue="563938302"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEZvbGxyaWNo" LintValue="563938302"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUdFTk8tRmluYW56U2VydmljZSBlRw==" LintValue="288678716"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUdFTk8tRmluYW56U2VydmljZSBlRw==" LintValue="288678716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUhhdXNz" LintValue="348808044"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUhhdXNz" LintValue="348808044"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkhvbW1lcmRpbmc=" LintValue="428401510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkhvbW1lcmRpbmc=" LintValue="428401510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGksmUiBHZW5lcmFsYWdlbnR1ciBHYlI=" LintValue="948847478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGksmUiBHZW5lcmFsYWdlbnR1ciBHYlI=" LintValue="948847478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIUtLTi1WZXJzaWNoZXJ1bmdzc2VydmljZSBHbWJI" LintValue="277152612"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIUtLTi1WZXJzaWNoZXJ1bmdzc2VydmljZSBHbWJI" LintValue="277152612"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0vDtmhsZXI=" LintValue="976896812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0vDtmhsZXI=" LintValue="976896812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUxhbmdl" LintValue="329294636"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUxhbmdl" LintValue="329294636"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk5pa2xhcw==" LintValue="822764334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk5pa2xhcw==" LintValue="822764334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1BpZXRzY2g=" LintValue="853345278"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1BpZXRzY2g=" LintValue="853345278"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBvY2hh" LintValue="705700710"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBvY2hh" LintValue="705700710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJpdHRlcg==" LintValue="281953086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJpdHRlcg==" LintValue="281953086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVNhY2hzZW5oYXVzZXI=" LintValue="576078830"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVNhY2hzZW5oYXVzZXI=" LintValue="576078830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaHVsemU=" LintValue="666149796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaHVsemU=" LintValue="666149796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaMO8dHo=" LintValue="391857060"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaMO8dHo=" LintValue="391857060"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000386" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdlVm8gT0hH" LintValue="134538086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdlVm8gT0hH" LintValue="134538086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF1dlcm5lciBHZWhyaW5nIGUuSy4=" LintValue="698991548"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF1dlcm5lciBHZWhyaW5nIGUuSy4=" LintValue="698991548"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIldpbGZlcnQgVmVyc2ljaGVydW5nc3Zlci4gR21iSA==" LintValue="279774198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIldpbGZlcnQgVmVyc2ljaGVydW5nc3Zlci4gR21iSA==" LintValue="279774198"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.40" Name="oo" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.947553" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006659" DistinctValues="53.696694">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="111211922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="111211922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="111211922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000839" DistinctValues="6.761890">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="111211922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="125216560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="125216560"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="125216560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001259" DistinctValues="10.155352">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="125216560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="146249442"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="146249442"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="146249442"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001024" DistinctValues="8.260388">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="146249442"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="163357640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="163357640"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="163357640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001387" DistinctValues="11.186551">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="163357640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186526252"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186526252"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186526252"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000447" DistinctValues="3.605791">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186526252"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="193994253"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="193994253"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="193994253"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000010" DistinctValues="0.068679">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="193994253"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="194315945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="194315945"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="194315945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000306" DistinctValues="2.151455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="194315945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204393400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204393400"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204393400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000293" DistinctValues="2.057574">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204393400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214031116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214031116"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214031116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="0.193957">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214031116"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214939614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214939614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214939614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000352" DistinctValues="2.474060">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="214939614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="226528156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="226528156"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="226528156"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000399" DistinctValues="2.807419">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="226528156"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239678157"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239678157"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239678157"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000598" DistinctValues="4.207257">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239678157"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="259385024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="259385024"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="259385024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000587" DistinctValues="4.127008">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="259385024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="278716007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="278716007"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="278716007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000051" DistinctValues="0.357644">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="278716007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="280391220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="280391220"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="280391220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000450" DistinctValues="3.166419">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="280391220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="295222786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="295222786"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="295222786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000595" DistinctValues="4.183318">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="295222786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="314817524"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000386" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="314817524"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="314817524"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001327" DistinctValues="9.331723">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="314817524"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="358527485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="358527485"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="358527485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000089" DistinctValues="0.627778">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="358527485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="361468007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="361468007"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="361468007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001062" DistinctValues="7.464407">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="361468007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="396431424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="396431424"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="396431424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000148" DistinctValues="1.040001">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="396431424"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="401302808"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="401302808"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="401302808"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004282" DistinctValues="30.108906">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="401302808"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="542333472"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="542333472"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="542333472"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000793" DistinctValues="5.574912">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="542333472"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="568446461"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="568446461"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="568446461"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000245" DistinctValues="1.724150">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="568446461"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="576522410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="576522410"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="576522410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011615" DistinctValues="98.666667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="576522410"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="601136210"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.33" Name="hh" Width="2.000000" NullFreq="0.000000" NdvRemain="241.000000" FreqRemain="0.305882" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.016912" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.105336" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027451" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEw" LintValue="881984300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022761" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEx" LintValue="881992492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015312" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEy" LintValue="882000684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015533" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjEz" LintValue="882008876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017436" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE0" LintValue="882017068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034707" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE1" LintValue="882025260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019588" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE2" LintValue="882033452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020499" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE3" LintValue="882041644"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017023" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjE5" LintValue="882058028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.061690" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018292" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIw" LintValue="873595684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013767" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIx" LintValue="873603876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012167" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIy" LintValue="873612068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012939" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjIz" LintValue="873620260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012498" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjI0" LintValue="873628452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039177" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012470" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjMw" LintValue="873595692"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABjMw" LintValue="873595692"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.043288" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.041605" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029383" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTY=" LintValue="161137196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035452" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTc=" LintValue="161145388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028831" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTg=" LintValue="161153580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020002" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTk=" LintValue="161161772"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.32" Name="gg" Width="13.000000" NullFreq="0.000000" NdvRemain="4188.000000" FreqRemain="0.738040" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.013353" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEFtIE1hcmt0" LintValue="282231724"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEFtIE1hcmt0" LintValue="282231724"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUFtIFNlbHRlbmJhY2g=" LintValue="11600750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUFtIFNlbHRlbmJhY2g=" LintValue="11600750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007256" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUF1Z3VzdGFhbmxhZ2U=" LintValue="43557756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUF1Z3VzdGFhbmxhZ2U=" LintValue="43557756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.046350" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005849" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEEJpc21hcmNrc3RyLg==" LintValue="903725988"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEEJpc21hcmNrc3RyLg==" LintValue="903725988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010787" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0LDtnJzZW5zdHIu" LintValue="635290532"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0LDtnJzZW5zdHIu" LintValue="635290532"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004718" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHURpZXRyaWNoLUJvbmhvZWZmZXItUGxhdHo=" LintValue="740508646"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHURpZXRyaWNoLUJvbmhvZWZmZXItUGxhdHo=" LintValue="740508646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004828" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0V1cm9wYXBsYXR6" LintValue="1058227062"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0V1cm9wYXBsYXR6" LintValue="1058227062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006759" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUZyaWVkcmljaHN0ci4=" LintValue="98943908"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUZyaWVkcmljaHN0ci4=" LintValue="98943908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.051040" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005739" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhlaWRlbmthbXBzd2Vn" LintValue="410313726"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhlaWRlbmthbXBzd2Vn" LintValue="410313726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008277" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhpbmRlbmJ1cmdzdHIu" LintValue="930988982"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhpbmRlbmJ1cmdzdHIu" LintValue="930988982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkjDvGdlbHN0ci4=" LintValue="670417716"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkjDvGdlbHN0ci4=" LintValue="670417716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005463" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEtyZXV6YmVyZ2VyIFJpbmc=" LintValue="52749286"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEtyZXV6YmVyZ2VyIFJpbmc=" LintValue="52749286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006842" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1hcmt0" LintValue="299008812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1hcmt0" LintValue="299008812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011477" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk1hcmt0cGxhdHo=" LintValue="211502068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk1hcmt0cGxhdHo=" LintValue="211502068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008222" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007256" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFBvc3RzdHIu" LintValue="793101222"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFBvc3RzdHIu" LintValue="793101222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007587" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFJpZXNzdHIu" LintValue="267764646"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFJpZXNzdHIu" LintValue="267764646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009077" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlNjaGlmZmVuYmVyZ2VyIFdlZw==" LintValue="163636078"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlNjaGlmZmVuYmVyZ2VyIFdlZw==" LintValue="163636078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008249" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004801" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGxvw59wbGF0eg==" LintValue="531317748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGxvw59wbGF0eg==" LintValue="531317748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006014" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADldhZmZlbnN0ci4=" LintValue="384156468"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADldhZmZlbnN0ci4=" LintValue="384156468"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.25" Name="z" Width="13.000000" NullFreq="0.000000" NdvRemain="5010.000000" FreqRemain="0.735088" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.015395" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005794" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEFkbWlyYWxpdMOkdHN0ci4=" LintValue="267764518"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEFkbWlyYWxpdMOkdHN0ci4=" LintValue="267764518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004580" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEFtIE1hcmt0" LintValue="282231724"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEFtIE1hcmt0" LintValue="282231724"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004938" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUFtIFNlbHRlbmJhY2g=" LintValue="11600750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUFtIFNlbHRlbmJhY2g=" LintValue="11600750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006870" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUF1Z3VzdGFhbmxhZ2U=" LintValue="43557756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUF1Z3VzdGFhbmxhZ2U=" LintValue="43557756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.044005" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0JhaG5ob2ZzdHIu" LintValue="885375782"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEEJpc21hcmNrc3RyLg==" LintValue="903725988"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEEJpc21hcmNrc3RyLg==" LintValue="903725988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010511" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0LDtnJzZW5zdHIu" LintValue="635290532"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0LDtnJzZW5zdHIu" LintValue="635290532"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004690" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0V1cm9wYXBsYXR6" LintValue="1058227062"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0V1cm9wYXBsYXR6" LintValue="1058227062"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007339" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUZyaWVkcmljaHN0ci4=" LintValue="98943908"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUZyaWVkcmljaHN0ci4=" LintValue="98943908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.050682" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUhhdXB0c3RyLg==" LintValue="491635510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005049" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhlaWRlbmthbXBzd2Vn" LintValue="410313726"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhlaWRlbmthbXBzd2Vn" LintValue="410313726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhpbmRlbmJ1cmdzdHIu" LintValue="930988982"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkhpbmRlbmJ1cmdzdHIu" LintValue="930988982"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005987" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkjDvGdlbHN0ci4=" LintValue="670417716"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkjDvGdlbHN0ci4=" LintValue="670417716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006014" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkthaXNlcnN0ci4=" LintValue="484295604"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkthaXNlcnN0ci4=" LintValue="484295604"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004525" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEthcmxzdHIu" LintValue="928367396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEthcmxzdHIu" LintValue="928367396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006401" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEtyZXV6YmVyZ2VyIFJpbmc=" LintValue="52749286"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEtyZXV6YmVyZ2VyIFJpbmc=" LintValue="52749286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006787" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1hcmt0" LintValue="299008812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1hcmt0" LintValue="299008812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012967" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk1hcmt0cGxhdHo=" LintValue="211502068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk1hcmt0cGxhdHo=" LintValue="211502068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007780" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU1hcmt0c3RyLg==" LintValue="502121270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006925" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFBvc3RzdHIu" LintValue="793101222"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFBvc3RzdHIu" LintValue="793101222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011615" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE1JhaWZmZWlzZW5wbGF0eg==" LintValue="738935670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlNjaGlmZmVuYmVyZ2VyIFdlZw==" LintValue="163636078"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlNjaGlmZmVuYmVyZ2VyIFdlZw==" LintValue="163636078"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008139" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFNjaGlsbGVyc3RyLg==" LintValue="1020642086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADldhZmZlbnN0ci4=" LintValue="384156468"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADldhZmZlbnN0ci4=" LintValue="384156468"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.24" Name="y" Width="1.000000" NullFreq="0.000000" NdvRemain="629.000000" FreqRemain="0.087569" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.868123" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002731" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001545" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkRpZXRlcg==" LintValue="8012606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkRpZXRlcg==" LintValue="8012606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001186" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RpZXRtYXI=" LintValue="841892862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RpZXRtYXI=" LintValue="841892862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUVyaWNo" LintValue="331154286"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUVyaWNo" LintValue="331154286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002069" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001573" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUdlb3Jn" LintValue="916513638"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUdlb3Jn" LintValue="916513638"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0fDvG50ZXI=" LintValue="190464942"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0fDvG50ZXI=" LintValue="190464942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEhhbnM=" LintValue="60973924"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEhhbnM=" LintValue="60973924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEplbnM=" LintValue="330457956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEplbnM=" LintValue="330457956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001904" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001462" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEthcmw=" LintValue="77693796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEthcmw=" LintValue="77693796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001904" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001876" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01hbmZyZWQ=" LintValue="55608108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01hbmZyZWQ=" LintValue="55608108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003862" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002318" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003835" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003173" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.17" Name="r" Width="6.000000" NullFreq="0.038652" NdvRemain="4810.000000" FreqRemain="0.571704" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.244248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008635" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005325" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJlcm5k" LintValue="852525862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005242" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkRpZXRlcg==" LintValue="8012606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkRpZXRlcg==" LintValue="8012606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005932" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dlcmhhcmQ=" LintValue="481854438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dlcmhhcmQ=" LintValue="481854438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005435" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkhlbG11dA==" LintValue="372933484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004194" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUhvcnN0" LintValue="617775916"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUhvcnN0" LintValue="617775916"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006870" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEthcmw=" LintValue="77693796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEthcmw=" LintValue="77693796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006263" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007532" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01hbmZyZWQ=" LintValue="55608108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01hbmZyZWQ=" LintValue="55608108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004083" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005242" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcnRpbg==" LintValue="594395948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcnRpbg==" LintValue="594395948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009767" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009187" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldHJh" LintValue="1019749158"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldHJh" LintValue="1019749158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004938" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009546" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAB1V3ZQ==" LintValue="659596140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAB1V3ZQ==" LintValue="659596140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004828" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006235" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006897" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.16" Name="q" Width="11.000000" NullFreq="0.038652" NdvRemain="41058.000000" FreqRemain="0.880290" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJhdWVy" LintValue="273302382"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJhdWVy" LintValue="273302382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlY2tlcg==" LintValue="842154876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlY2tlcg==" LintValue="842154876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002924" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0Zpc2NoZXI=" LintValue="943342526"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0Zpc2NoZXI=" LintValue="943342526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhcnRtYW5u" LintValue="134857574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhcnRtYW5u" LintValue="134857574"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhvZmZtYW5u" LintValue="564773862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhvZmZtYW5u" LintValue="564773862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001379" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsZWlu" LintValue="571065196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsZWlu" LintValue="571065196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001545" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEtvY2g=" LintValue="10027884"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEtvY2g=" LintValue="10027884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001600" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haWVy" LintValue="305808236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haWVy" LintValue="305808236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001793" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1leWVy" LintValue="846873452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1leWVy" LintValue="846873452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC011ZWxsZXI=" LintValue="327828270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC011ZWxsZXI=" LintValue="327828270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC03DvGxsZXI=" LintValue="993674030"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC03DvGxsZXI=" LintValue="993674030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023589" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001324" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaG1pZA==" LintValue="850953084"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaG1pZA==" LintValue="850953084"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004966" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pZHQ=" LintValue="539132900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pZHQ=" LintValue="539132900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pdHQ=" LintValue="606241764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pdHQ=" LintValue="606241764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003007" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaG5laWRlcg==" LintValue="540689326"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaG5laWRlcg==" LintValue="540689326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaHVseg==" LintValue="870007668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaHVseg==" LintValue="870007668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001573" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFNjaMOkZmVy" LintValue="271729470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFNjaMOkZmVy" LintValue="271729470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007615" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RlYW1CYW5rIEFH" LintValue="454878014"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RlYW1CYW5rIEFH" LintValue="454878014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZHVSBlLlYuLSBWZXJzb3JndW5nc2thc3Nl" LintValue="611361646"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZHVSBlLlYuLSBWZXJzb3JndW5nc2thc3Nl" LintValue="611361646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001876" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002180" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhZ25lcg==" LintValue="278020924"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhZ25lcg==" LintValue="278020924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002345" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVdlYmVy" LintValue="991052590"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVdlYmVy" LintValue="991052590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACFdvbGY=" LintValue="589087588"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACFdvbGY=" LintValue="589087588"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003780" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEm5vcmlzYmFuayBHbWJI" LintValue="867501046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEm5vcmlzYmFuayBHbWJI" LintValue="867501046"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.8" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="111121567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="124757819"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="124757819"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023589" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004414" DistinctValues="1996.823387">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="138051331"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="138051331"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="138051331"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032864" DistinctValues="14865.638152">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="138051331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="144618653"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="144618653"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="166876940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022396" DistinctValues="10131.399649">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="166876940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="175566260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="175566260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="175566260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014882" DistinctValues="6732.061890">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="175566260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="181340096"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008772" DistinctValues="3966.281085">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="181340096"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182926973"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000221" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182926973"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182926973"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000037" DistinctValues="16.563694">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182926973"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182933600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182933600"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182933600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000021" DistinctValues="9.567801">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182933600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000051" DistinctValues="22.842251">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182946567"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182946567"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182946567"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000022" DistinctValues="9.882729">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182946567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182950521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182950521"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182950521"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000014" DistinctValues="6.131091">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182950521"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182952974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000221" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182952974"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182952974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000075" DistinctValues="33.889712">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182952974"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966533"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966533"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966533"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007213" DistinctValues="3261.390562">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966533"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="184271389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="184271389"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="184271389"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021076" DistinctValues="9529.912613">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="184271389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="188084230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="188084230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="197209143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="197209143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="205252380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="205252380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="216412354"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="216412354"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="226425217"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006213" DistinctValues="2810.556087">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="226425217"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024193" DistinctValues="10943.354111">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="241719901"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="241719901"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="241719901"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006872" DistinctValues="3108.551341">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="241719901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="245176686"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="245176686"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="261681412"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="261681412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="274821612"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="274821612"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="289002464"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="289002464"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="302089868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020356" DistinctValues="9208.360010">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="302089868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="308350410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="308350410"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="308350410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016922" DistinctValues="7655.101528">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="308350410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="313554929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034289" DistinctValues="15511.352608">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="313554929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="351682892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="351682892"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="351682892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002989" DistinctValues="1352.108930">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="351682892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="355006468"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="355006468"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="368304700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012729" DistinctValues="5756.867074">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="368304700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371835261"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371835261"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371835261"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000021" DistinctValues="9.687284">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371835261"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371841202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371841202"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371841202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000010" DistinctValues="4.347130">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371841202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371843868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371843868"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371843868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000128" DistinctValues="57.799219">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371843868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371879315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371879315"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371879315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000035" DistinctValues="15.875340">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371879315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371889051"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371889051"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371889051"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024355" DistinctValues="11014.885491">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="371889051"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="378644240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="378644240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="392237143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013166" DistinctValues="5955.787392">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="392237143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="397197654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="397197654"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="397197654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024113" DistinctValues="10907.674146">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="397197654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="406282538"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009168" DistinctValues="4147.481257">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="406282538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="410985063"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="410985063"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="410985063"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028110" DistinctValues="12715.980281">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="410985063"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="425402781"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16864.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="425402781"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="450513954"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017156" DistinctValues="7760.709609">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="450513954"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020123" DistinctValues="9102.751929">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="488054643"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002845" DistinctValues="1286.853986">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="488054643"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="496592778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000386" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="496592778"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="496592778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034434" DistinctValues="15576.607552">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="496592778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="599941860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037278" DistinctValues="16863.461538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="599941860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="900001207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="900001207"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="900001207"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.035244" DistinctValues="1439.920442">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10017"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10017"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10017"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000021" DistinctValues="0.865597">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10017"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10023"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000011" DistinctValues="0.432798">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10026"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001986" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10026"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10026"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000007" DistinctValues="0.288532">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10026"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001462" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002143" DistinctValues="87.569553">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10635"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017751" DistinctValues="725.248407">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10635"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="30026"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="30026"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="30026"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008428" DistinctValues="344.353673">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="30026"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000476" DistinctValues="19.448671">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000772" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39753"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39754"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010770" DistinctValues="440.026172">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="39754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="51519"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008449" DistinctValues="345.652304">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="51519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="63155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="63155"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="63155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027452" DistinctValues="1123.043230">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="63155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001525" DistinctValues="62.381389">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="103061"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="103061"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="160436"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005911" DistinctValues="241.956878">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="160436"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="162219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="162219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="162219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031515" DistinctValues="1290.120045">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="162219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="171726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="171726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002373" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000004" DistinctValues="0.168987">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188948"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000662" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188950"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002704" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188951"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188951"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014636" DistinctValues="597.959738">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188951"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="196028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000800" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="196028"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="196028"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022786" DistinctValues="930.948198">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="196028"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="207046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="207046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="242614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016446" DistinctValues="673.237184">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="242614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="261690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="261690"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="261690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020980" DistinctValues="858.839739">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="261690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="286025"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="286025"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="323431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034715" DistinctValues="1421.100854">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="323431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000745" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002711" DistinctValues="110.976070">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="355225"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="355225"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="401224"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="401224"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="434525"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="434525"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="471413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008902" DistinctValues="364.401476">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="471413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000966" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028524" DistinctValues="1167.675447">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="480118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="508012"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="508012"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="550641"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="550641"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="602286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="602286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="652222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="652222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="698714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="698714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="730724"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="730724"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000810" DistinctValues="33.119537">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034634" DistinctValues="1416.842586">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770259"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000855" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001983" DistinctValues="81.114799">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780355"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780933"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005893" DistinctValues="241.222066">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="780933"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="785197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="785197"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="785197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031533" DistinctValues="1290.854857">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="785197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="808015"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011253" DistinctValues="460.368594">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="808015"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018547" DistinctValues="758.757751">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="820168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000524" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007625" DistinctValues="311.950578">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="840198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="848433"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028866" DistinctValues="1180.897694">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="848433"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000709" DistinctValues="29.008930">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="887757"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007851" DistinctValues="321.170299">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037426" DistinctValues="1533.076923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899418"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899629"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.0" Name="a" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.348187" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUE=" LintValue="160703020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUE=" LintValue="160703020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUI=" LintValue="160711212"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUI=" LintValue="160711212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.624190" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUs=" LintValue="160784940"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUs=" LintValue="160784940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001654" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABU4=" LintValue="160809516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABU4=" LintValue="160809516"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.9" Name="j" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000441" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AGCcxf/iH/8=" DoubleValue="-63082281600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AGCcxf/iH/8=" DoubleValue="-63082281600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AGCcxf/iH/8=" DoubleValue="-63082281600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="MONuObTv//8=" DoubleValue="-17917639990480.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="MONuObTv//8=" DoubleValue="-17917639990480.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Yjq7iyoVAAA=" DoubleValue="23272477112930.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="Yjq7iyoVAAA=" DoubleValue="23272477112930.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="MA38C8MuAAA=" DoubleValue="51415254568240.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016850" DistinctValues="0.438577">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="MA38C8MuAAA=" DoubleValue="51415254568240.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bv88k4w6AAA=" DoubleValue="64375440080750.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bv88k4w6AAA=" DoubleValue="64375440080750.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bv88k4w6AAA=" DoubleValue="64375440080750.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021569" DistinctValues="0.561423">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bv88k4w6AAA=" DoubleValue="64375440080750.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uHQVU6NJAAA=" DoubleValue="80965822411960.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uHQVU6NJAAA=" DoubleValue="80965822411960.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="IPWA1PBiAAA=" DoubleValue="108786496894240.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000414" DistinctValues="0.010775">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="IPWA1PBiAAA=" DoubleValue="108786496894240.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="eu7SPEdjAAA=" DoubleValue="109157614284410.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="eu7SPEdjAAA=" DoubleValue="109157614284410.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="eu7SPEdjAAA=" DoubleValue="109157614284410.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035339" DistinctValues="0.919825">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="eu7SPEdjAAA=" DoubleValue="109157614284410.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2FiC1xeAAAA=" DoubleValue="140839888247000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2FiC1xeAAAA=" DoubleValue="140839888247000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2FiC1xeAAAA=" DoubleValue="140839888247000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002666" DistinctValues="0.069401">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="2FiC1xeAAAA=" DoubleValue="140839888247000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RmORZ0SCAAA=" DoubleValue="143230306968390.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RmORZ0SCAAA=" DoubleValue="143230306968390.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="GEwpH9idAAA=" DoubleValue="173551561296920.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000803" DistinctValues="0.020904">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="GEwpH9idAAA=" DoubleValue="173551561296920.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RozaQhyeAAA=" DoubleValue="173844217891910.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RozaQhyeAAA=" DoubleValue="173844217891910.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RozaQhyeAAA=" DoubleValue="173844217891910.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037616" DistinctValues="0.979096">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RozaQhyeAAA=" DoubleValue="173844217891910.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="UE5oxJOqAAA=" DoubleValue="187551632084560.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021763" DistinctValues="0.566463">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="UE5oxJOqAAA=" DoubleValue="187551632084560.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="sFoxZKWqAAA=" DoubleValue="187627327281840.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="sFoxZKWqAAA=" DoubleValue="187627327281840.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="sFoxZKWqAAA=" DoubleValue="187627327281840.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016656" DistinctValues="0.433537">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="sFoxZKWqAAA=" DoubleValue="187627327281840.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="6gA/4bKqAAA=" DoubleValue="187685259903210.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010700" DistinctValues="0.278497">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="6gA/4bKqAAA=" DoubleValue="187685259903210.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5my3u7WrAAA=" DoubleValue="188797026790630.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5my3u7WrAAA=" DoubleValue="188797026790630.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5my3u7WrAAA=" DoubleValue="188797026790630.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000021" DistinctValues="0.000536">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5my3u7WrAAA=" DoubleValue="188797026790630.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oFE5O7arAAA=" DoubleValue="188799166009760.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oFE5O7arAAA=" DoubleValue="188799166009760.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oFE5O7arAAA=" DoubleValue="188799166009760.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027699" DistinctValues="0.720967">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oFE5O7arAAA=" DoubleValue="188799166009760.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lqihWFSuAAA=" DoubleValue="191677287475350.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lqihWFSuAAA=" DoubleValue="191677287475350.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bk0CziC8AAA=" DoubleValue="206849081232750.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015879" DistinctValues="0.413303">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="bk0CziC8AAA=" DoubleValue="206849081232750.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qAs3I6LHAAA=" DoubleValue="219499189439400.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qAs3I6LHAAA=" DoubleValue="219499189439400.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qAs3I6LHAAA=" DoubleValue="219499189439400.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022540" DistinctValues="0.586697">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qAs3I6LHAAA=" DoubleValue="219499189439400.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="HKDVIPfXAAA=" DoubleValue="237456407765020.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030424" DistinctValues="0.791910">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="HKDVIPfXAAA=" DoubleValue="237456407765020.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BIY7K87qAAA=" DoubleValue="258171209483780.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BIY7K87qAAA=" DoubleValue="258171209483780.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BIY7K87qAAA=" DoubleValue="258171209483780.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007995" DistinctValues="0.208090">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BIY7K87qAAA=" DoubleValue="258171209483780.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="/gaChcHvAAA=" DoubleValue="263614447617790.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027498" DistinctValues="0.715725">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="/gaChcHvAAA=" DoubleValue="263614447617790.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="FO8lbCIBAQA=" DoubleValue="282722331651860.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="FO8lbCIBAQA=" DoubleValue="282722331651860.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="FO8lbCIBAQA=" DoubleValue="282722331651860.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003090" DistinctValues="0.080417">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="FO8lbCIBAQA=" DoubleValue="282722331651860.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SiLAShYDAQA=" DoubleValue="284869254980170.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SiLAShYDAQA=" DoubleValue="284869254980170.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SiLAShYDAQA=" DoubleValue="284869254980170.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007832" DistinctValues="0.203858">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="SiLAShYDAQA=" DoubleValue="284869254980170.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OCMddQkIAQA=" DoubleValue="290311689282360.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="OCMddQkIAQA=" DoubleValue="290311689282360.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="VBd3t5MhAQA=" DoubleValue="318393298655060.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037609" DistinctValues="0.978902">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="VBd3t5MhAQA=" DoubleValue="318393298655060.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="EEZ+R8c5AQA=" DoubleValue="345003037443600.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="EEZ+R8c5AQA=" DoubleValue="345003037443600.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="EEZ+R8c5AQA=" DoubleValue="345003037443600.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000811" DistinctValues="0.021098">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="EEZ+R8c5AQA=" DoubleValue="345003037443600.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7KOqzkw6AQA=" DoubleValue="345576535925740.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020820" DistinctValues="0.541907">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7KOqzkw6AQA=" DoubleValue="345576535925740.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qiCjlAZGAQA=" DoubleValue="358469054177450.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qiCjlAZGAQA=" DoubleValue="358469054177450.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qiCjlAZGAQA=" DoubleValue="358469054177450.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012718" DistinctValues="0.331021">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qiCjlAZGAQA=" DoubleValue="358469054177450.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5q21MjBNAQA=" DoubleValue="366344381246950.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5q21MjBNAQA=" DoubleValue="366344381246950.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5q21MjBNAQA=" DoubleValue="366344381246950.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004882" DistinctValues="0.127071">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="5q21MjBNAQA=" DoubleValue="366344381246950.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="0qXcFPBPAQA=" DoubleValue="369367537460690.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="0qXcFPBPAQA=" DoubleValue="369367537460690.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="YDCNY55hAQA=" DoubleValue="388807879635040.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003846" DistinctValues="0.100102">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="YDCNY55hAQA=" DoubleValue="388807879635040.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4lUGF75jAQA=" DoubleValue="391143057937890.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4lUGF75jAQA=" DoubleValue="391143057937890.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4lUGF75jAQA=" DoubleValue="391143057937890.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032725" DistinctValues="0.851781">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="4lUGF75jAQA=" DoubleValue="391143057937890.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="cuLLg9B1AQA=" DoubleValue="411013401535090.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="cuLLg9B1AQA=" DoubleValue="411013401535090.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="cuLLg9B1AQA=" DoubleValue="411013401535090.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001849" DistinctValues="0.048117">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="cuLLg9B1AQA=" DoubleValue="411013401535090.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nM+b3NV2AQA=" DoubleValue="412135878021020.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017590" DistinctValues="0.457844">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="nM+b3NV2AQA=" DoubleValue="412135878021020.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7pRRleqBAQA=" DoubleValue="424319504192750.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7pRRleqBAQA=" DoubleValue="424319504192750.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7pRRleqBAQA=" DoubleValue="424319504192750.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010352" DistinctValues="0.269457">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7pRRleqBAQA=" DoubleValue="424319504192750.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rCLeF3CIAQA=" DoubleValue="431489994859180.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rCLeF3CIAQA=" DoubleValue="431489994859180.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rCLeF3CIAQA=" DoubleValue="431489994859180.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010477" DistinctValues="0.272698">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="rCLeF3CIAQA=" DoubleValue="431489994859180.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="0Eo3rwmPAQA=" DoubleValue="438746733824720.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001275" DistinctValues="0.033174">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="0Eo3rwmPAQA=" DoubleValue="438746733824720.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zPnCs6CPAQA=" DoubleValue="439395350149580.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zPnCs6CPAQA=" DoubleValue="439395350149580.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zPnCs6CPAQA=" DoubleValue="439395350149580.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037145" DistinctValues="0.966826">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zPnCs6CPAQA=" DoubleValue="439395350149580.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oIVN8NGgAQA=" DoubleValue="458298516932000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oIVN8NGgAQA=" DoubleValue="458298516932000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="0Fq9r223AQA=" DoubleValue="483156704451280.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007914" DistinctValues="0.205980">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="0Fq9r223AQA=" DoubleValue="483156704451280.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="fnLEBMC7AQA=" DoubleValue="487908364808830.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="fnLEBMC7AQA=" DoubleValue="487908364808830.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="fnLEBMC7AQA=" DoubleValue="487908364808830.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003022" DistinctValues="0.078666">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="fnLEBMC7AQA=" DoubleValue="487908364808830.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qPKNiWa9AQA=" DoubleValue="489723068805800.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qPKNiWa9AQA=" DoubleValue="489723068805800.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qPKNiWa9AQA=" DoubleValue="489723068805800.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018029" DistinctValues="0.469273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="qPKNiWa9AQA=" DoubleValue="489723068805800.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7WhvBz/HAQA=" DoubleValue="500548498319597.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7WhvBz/HAQA=" DoubleValue="500548498319597.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7WhvBz/HAQA=" DoubleValue="500548498319597.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009454" DistinctValues="0.246081">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7WhvBz/HAQA=" DoubleValue="500548498319597.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="HGDtvWjMAQA=" DoubleValue="506225211826204.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021424" DistinctValues="0.557638">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="HGDtvWjMAQA=" DoubleValue="506225211826204.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ncJVfaXXAQA=" DoubleValue="518580749058717.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ncJVfaXXAQA=" DoubleValue="518580749058717.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ncJVfaXXAQA=" DoubleValue="518580749058717.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016995" DistinctValues="0.442362">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ncJVfaXXAQA=" DoubleValue="518580749058717.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ti8djY/gAQA=" DoubleValue="528382129156022.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012888" DistinctValues="0.335465">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ti8djY/gAQA=" DoubleValue="528382129156022.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ckkGaQvmAQA=" DoubleValue="534411657759090.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ckkGaQvmAQA=" DoubleValue="534411657759090.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ckkGaQvmAQA=" DoubleValue="534411657759090.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025531" DistinctValues="0.664535">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ckkGaQvmAQA=" DoubleValue="534411657759090.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="682dXejwAQA=" DoubleValue="546355770412523.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038419" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="682dXejwAQA=" DoubleValue="546355770412523.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="244jif3wAQA=" DoubleValue="546446694911707.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.1093.1.0"/>
+        <dxl:InequalityOp Mdid="0.1094.1.0"/>
+        <dxl:LessThanOp Mdid="0.1095.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1096.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1097.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1098.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1092.1.0"/>
+        <dxl:ArrayType Mdid="0.1182.1.0"/>
+        <dxl:MinAgg Mdid="0.2138.1.0"/>
+        <dxl:MaxAgg Mdid="0.2122.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.23" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.22" Name="w" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000087" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="z4xFC4buAQA=" DoubleValue="543734458846415.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="z4xFC4buAQA=" DoubleValue="543734458846415.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000087" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zvF3C4buAQA=" DoubleValue="543734462149070.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zvF3C4buAQA=" DoubleValue="543734462149070.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000029" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RuS/C4buAQA=" DoubleValue="543734466864198.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="RuS/C4buAQA=" DoubleValue="543734466864198.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000145" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1+MMDIbuAQA=" DoubleValue="543734471910359.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="1+MMDIbuAQA=" DoubleValue="543734471910359.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="PjtKDIbuAQA=" DoubleValue="543734475930430.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="PjtKDIbuAQA=" DoubleValue="543734475930430.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oQfKfRLvAQA=" DoubleValue="544337675552673.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oQfKfRLvAQA=" DoubleValue="544337675552673.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000116" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="N7/vfRLvAQA=" DoubleValue="544337678024503.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="N7/vfRLvAQA=" DoubleValue="544337678024503.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000174" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="6P0lfhLvAQA=" DoubleValue="544337681579496.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="6P0lfhLvAQA=" DoubleValue="544337681579496.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000029" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="TOBpfhLvAQA=" DoubleValue="544337686028364.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="TOBpfhLvAQA=" DoubleValue="544337686028364.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000087" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="at2RfhLvAQA=" DoubleValue="544337688649066.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="at2RfhLvAQA=" DoubleValue="544337688649066.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.102865" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="o2r22d/vAQA=" DoubleValue="545219690261155.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="o2r22d/vAQA=" DoubleValue="545219690261155.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.112412" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="JFM+2t/vAQA=" DoubleValue="545219694973732.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="JFM+2t/vAQA=" DoubleValue="545219694973732.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.039428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lDq92t/vAQA=" DoubleValue="545219703290516.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="lDq92t/vAQA=" DoubleValue="545219703290516.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040903" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="/OkW29/vAQA=" DoubleValue="545219709168124.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="/OkW29/vAQA=" DoubleValue="545219709168124.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040064" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="01RM29/vAQA=" DoubleValue="545219712668883.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="01RM29/vAQA=" DoubleValue="545219712668883.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.096067" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="z1LnfobwAQA=" DoubleValue="545935422083791.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="z1LnfobwAQA=" DoubleValue="545935422083791.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.112584" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ztEUf4bwAQA=" DoubleValue="545935425065422.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ztEUf4bwAQA=" DoubleValue="545935425065422.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038994" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="+lZgf4bwAQA=" DoubleValue="545935430014714.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="+lZgf4bwAQA=" DoubleValue="545935430014714.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040701" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="g8Wuf4bwAQA=" DoubleValue="545935435154819.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="g8Wuf4bwAQA=" DoubleValue="545935435154819.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.042754" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oE7Qf4bwAQA=" DoubleValue="545935437352608.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="oE7Qf4bwAQA=" DoubleValue="545935437352608.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.097976" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="/dkA7LjwAQA=" DoubleValue="546152000838141.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="/dkA7LjwAQA=" DoubleValue="546152000838141.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111485" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7rYz7LjwAQA=" DoubleValue="546152004171502.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="7rYz7LjwAQA=" DoubleValue="546152004171502.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040440" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uM127LjwAQA=" DoubleValue="546152008568248.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="uM127LjwAQA=" DoubleValue="546152008568248.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040816" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zg/B7LjwAQA=" DoubleValue="546152013434830.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="zg/B7LjwAQA=" DoubleValue="546152013434830.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040643" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="u0bq7LjwAQA=" DoubleValue="546152016135867.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="u0bq7LjwAQA=" DoubleValue="546152016135867.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.15" Name="p" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.030877" DistinctValues="173.427930">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Lv3//w==" DoubleValue="-62380800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="l/7//w==" DoubleValue="-31190400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="l/7//w==" DoubleValue="-31190400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="l/7//w==" DoubleValue="-31190400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005731" DistinctValues="32.187455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="l/7//w==" DoubleValue="-31190400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2v7//w==" DoubleValue="-25401600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="MQAAAA==" DoubleValue="4233600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="MQAAAA==" DoubleValue="4233600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="4AEAAA==" DoubleValue="41472000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011161" DistinctValues="62.077861">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="4AEAAA==" DoubleValue="41472000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="RAIAAA==" DoubleValue="50112000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002374" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="RAIAAA==" DoubleValue="50112000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="RAIAAA==" DoubleValue="50112000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013058" DistinctValues="72.631098">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="RAIAAA==" DoubleValue="50112000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uQIAAA==" DoubleValue="60220800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uQIAAA==" DoubleValue="60220800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uQIAAA==" DoubleValue="60220800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000670" DistinctValues="3.724672">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uQIAAA==" DoubleValue="60220800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vwIAAA==" DoubleValue="60739200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001419" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vwIAAA==" DoubleValue="60739200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vwIAAA==" DoubleValue="60739200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011719" DistinctValues="65.181754">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vwIAAA==" DoubleValue="60739200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KAMAAA==" DoubleValue="69811200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002061" DistinctValues="11.405502">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KAMAAA==" DoubleValue="69811200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQMAAA==" DoubleValue="71280000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001477" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQMAAA==" DoubleValue="71280000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQMAAA==" DoubleValue="71280000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009212" DistinctValues="50.989302">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQMAAA==" DoubleValue="71280000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hQMAAA==" DoubleValue="77846400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001419" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hQMAAA==" DoubleValue="77846400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hQMAAA==" DoubleValue="77846400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020243" DistinctValues="112.042282">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hQMAAA==" DoubleValue="77846400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="LAQAAA==" DoubleValue="92275200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="LAQAAA==" DoubleValue="92275200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="LAQAAA==" DoubleValue="92275200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004485" DistinctValues="24.823739">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="LAQAAA==" DoubleValue="92275200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="UQQAAA==" DoubleValue="95472000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002664" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="UQQAAA==" DoubleValue="95472000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="UQQAAA==" DoubleValue="95472000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000606" DistinctValues="3.354559">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="UQQAAA==" DoubleValue="95472000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VgQAAA==" DoubleValue="95904000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028558" DistinctValues="160.404773">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VgQAAA==" DoubleValue="95904000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="WQUAAA==" DoubleValue="118281600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001390" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="WQUAAA==" DoubleValue="118281600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="WQUAAA==" DoubleValue="118281600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008049" DistinctValues="45.210612">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="WQUAAA==" DoubleValue="118281600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ogUAAA==" DoubleValue="124588800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019099" DistinctValues="107.277592">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ogUAAA==" DoubleValue="124588800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hgYAAA==" DoubleValue="144288000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001679" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hgYAAA==" DoubleValue="144288000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hgYAAA==" DoubleValue="144288000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017508" DistinctValues="98.337793">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="hgYAAA==" DoubleValue="144288000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VwcAAA==" DoubleValue="162345600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VwcAAA==" DoubleValue="162345600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2wgAAA==" DoubleValue="195868800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2wgAAA==" DoubleValue="195868800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="TQoAAA==" DoubleValue="227836800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="TQoAAA==" DoubleValue="227836800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sgsAAA==" DoubleValue="258681600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036491" DistinctValues="204.964703">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sgsAAA==" DoubleValue="258681600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="7QwAAA==" DoubleValue="285897600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="7QwAAA==" DoubleValue="285897600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="7QwAAA==" DoubleValue="285897600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000116" DistinctValues="0.650682">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="7QwAAA==" DoubleValue="285897600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="7gwAAA==" DoubleValue="285984000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005956" DistinctValues="33.293351">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="7gwAAA==" DoubleValue="285984000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Hg0AAA==" DoubleValue="290131200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Hg0AAA==" DoubleValue="290131200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Hg0AAA==" DoubleValue="290131200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003350" DistinctValues="18.727510">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Hg0AAA==" DoubleValue="290131200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQ0AAA==" DoubleValue="292464000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003446" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQ0AAA==" DoubleValue="292464000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQ0AAA==" DoubleValue="292464000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027300" DistinctValues="152.594524">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="OQ0AAA==" DoubleValue="292464000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="FQ4AAA==" DoubleValue="311472000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="FQ4AAA==" DoubleValue="311472000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Mw8AAA==" DoubleValue="336182400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Mw8AAA==" DoubleValue="336182400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KRAAAA==" DoubleValue="357436800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033294" DistinctValues="187.007658">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KRAAAA==" DoubleValue="357436800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="8hAAAA==" DoubleValue="374803200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="8hAAAA==" DoubleValue="374803200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="8hAAAA==" DoubleValue="374803200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003313" DistinctValues="18.607727">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="8hAAAA==" DoubleValue="374803200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="BhEAAA==" DoubleValue="376531200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="BhEAAA==" DoubleValue="376531200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KhIAAA==" DoubleValue="401760000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013024" DistinctValues="73.151627">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KhIAAA==" DoubleValue="401760000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023584" DistinctValues="132.463757">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="+hIAAA==" DoubleValue="419731200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032884" DistinctValues="184.705346">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="+hIAAA==" DoubleValue="419731200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zhMAAA==" DoubleValue="438048000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zhMAAA==" DoubleValue="438048000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zhMAAA==" DoubleValue="438048000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003723" DistinctValues="20.910039">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zhMAAA==" DoubleValue="438048000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5hMAAA==" DoubleValue="440121600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5hMAAA==" DoubleValue="440121600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="wxQAAA==" DoubleValue="459216000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026584" DistinctValues="147.863553">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="wxQAAA==" DoubleValue="459216000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PRUAAA==" DoubleValue="469756800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001795" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PRUAAA==" DoubleValue="469756800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PRUAAA==" DoubleValue="469756800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002615" DistinctValues="14.543956">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PRUAAA==" DoubleValue="469756800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="SRUAAA==" DoubleValue="470793600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001853" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="SRUAAA==" DoubleValue="470793600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="SRUAAA==" DoubleValue="470793600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000654" DistinctValues="3.635989">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="SRUAAA==" DoubleValue="470793600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="TBUAAA==" DoubleValue="471052800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001506" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="TBUAAA==" DoubleValue="471052800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="TBUAAA==" DoubleValue="471052800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006755" DistinctValues="37.571886">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="TBUAAA==" DoubleValue="471052800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="axUAAA==" DoubleValue="473731200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="axUAAA==" DoubleValue="473731200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KRYAAA==" DoubleValue="490147200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027821" DistinctValues="156.267692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KRYAAA==" DoubleValue="490147200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxYAAA==" DoubleValue="499996800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxYAAA==" DoubleValue="499996800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxYAAA==" DoubleValue="499996800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008786" DistinctValues="49.347692">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxYAAA==" DoubleValue="499996800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vxYAAA==" DoubleValue="503107200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vxYAAA==" DoubleValue="503107200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qRcAAA==" DoubleValue="523324800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019024" DistinctValues="106.335554">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qRcAAA==" DoubleValue="523324800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6xcAAA==" DoubleValue="529027200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001679" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6xcAAA==" DoubleValue="529027200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6xcAAA==" DoubleValue="529027200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016142" DistinctValues="90.224107">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6xcAAA==" DoubleValue="529027200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="IxgAAA==" DoubleValue="533865600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003069" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="IxgAAA==" DoubleValue="533865600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="IxgAAA==" DoubleValue="533865600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001441" DistinctValues="8.055724">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="IxgAAA==" DoubleValue="533865600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KBgAAA==" DoubleValue="534297600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006010" DistinctValues="33.429392">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="KBgAAA==" DoubleValue="534297600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PhgAAA==" DoubleValue="536198400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001477" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PhgAAA==" DoubleValue="536198400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PhgAAA==" DoubleValue="536198400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017757" DistinctValues="98.768657">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="PhgAAA==" DoubleValue="536198400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fxgAAA==" DoubleValue="541814400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005125" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fxgAAA==" DoubleValue="541814400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fxgAAA==" DoubleValue="541814400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007649" DistinctValues="42.546498">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fxgAAA==" DoubleValue="541814400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxgAAA==" DoubleValue="544233600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003417" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxgAAA==" DoubleValue="544233600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxgAAA==" DoubleValue="544233600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005191" DistinctValues="28.870838">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mxgAAA==" DoubleValue="544233600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="rhgAAA==" DoubleValue="545875200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036607" DistinctValues="206.615385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="rhgAAA==" DoubleValue="545875200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sBgAAA==" DoubleValue="546048000000000.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.14" Name="o" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.061069" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACAIAAAA=" DoubleValue="0.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACAIAAAA=" DoubleValue="0.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018332" DistinctValues="1131.867594">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACAIAAAA=" DoubleValue="0.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002027" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017997" DistinctValues="1111.172406">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAOAJgI" DoubleValue="14.220000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAcAAgH" DoubleValue="28.180000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004645" DistinctValues="286.811827">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAcAAgH" DoubleValue="28.180000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001245" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023905" DistinctValues="1475.985115">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAfAGwH" DoubleValue="31.190000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000695" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007778" DistinctValues="480.243059">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuAJAa" DoubleValue="46.680000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAzACAc" DoubleValue="51.720000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016211" DistinctValues="1000.456059">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAzACAc" DoubleValue="51.720000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AKAP" DoubleValue="58.400000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000695" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AKAP" DoubleValue="58.400000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AKAP" DoubleValue="58.400000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000825" DistinctValues="50.921416">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AKAP" DoubleValue="58.400000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001071" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003058" DistinctValues="188.708778">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA6AOgc" DoubleValue="58.740000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001419" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016235" DistinctValues="1001.953747">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA8AA==" DoubleValue="60.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABCAPQa" DoubleValue="66.690000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001090" DistinctValues="67.321200">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABCAPQa" DoubleValue="66.690000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000985" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035239" DistinctValues="2176.718800">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABDAPwI" DoubleValue="67.230000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABUAPQa" DoubleValue="84.690000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABUAPQa" DoubleValue="84.690000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABvAIQD" DoubleValue="111.090000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABvAIQD" DoubleValue="111.090000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACNAGAJ" DoubleValue="141.240000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020975" DistinctValues="1295.674390">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACNAGAJ" DoubleValue="141.240000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACfAFAU" DoubleValue="159.520000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000608" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACfAFAU" DoubleValue="159.520000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACfAFAU" DoubleValue="159.520000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015353" DistinctValues="948.365610">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACfAFAU" DoubleValue="159.520000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACsACgj" DoubleValue="172.900000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACsACgj" DoubleValue="172.900000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADQANAH" DoubleValue="208.200000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADQANAH" DoubleValue="208.200000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAD0AJAB" DoubleValue="244.040000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAD0AJAB" DoubleValue="244.040000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAZAUwE" DoubleValue="281.110000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021621" DistinctValues="1334.940945">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAZAUwE" DoubleValue="281.110000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003764" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007691" DistinctValues="474.896938">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAsAQ==" DoubleValue="300.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001216" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007016" DistinctValues="433.202117">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAyASAc" DoubleValue="306.720000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA4ATQh" DoubleValue="312.850000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA4ATQh" DoubleValue="312.850000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABhAUgm" DoubleValue="353.980000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005052" DistinctValues="312.061003">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABhAUgm" DoubleValue="353.980000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000840" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031276" DistinctValues="1931.978997">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABoAQ==" DoubleValue="360.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACNAYwK" DoubleValue="397.270000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002158" DistinctValues="133.294804">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAACNAYwK" DoubleValue="397.270000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACQAQ==" DoubleValue="400.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001448" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACQAQ==" DoubleValue="400.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACQAQ==" DoubleValue="400.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034170" DistinctValues="2110.745196">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACQAQ==" DoubleValue="400.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAC7AfwI" DoubleValue="443.230000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025487" DistinctValues="1574.381813">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAC7AfwI" DoubleValue="443.230000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000985" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010841" DistinctValues="669.658187">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADgAQ==" DoubleValue="480.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADvAQAZ" DoubleValue="495.640000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002509" DistinctValues="155.006565">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADvAQAZ" DoubleValue="495.640000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAD0AQ==" DoubleValue="500.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000840" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAD0AQ==" DoubleValue="500.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAD0AQ==" DoubleValue="500.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033819" DistinctValues="2089.033435">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAD0AQ==" DoubleValue="500.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuArAd" DoubleValue="558.760000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006731" DistinctValues="415.438998">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAAuArAd" DoubleValue="558.760000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA6Ag==" DoubleValue="570.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000753" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA6Ag==" DoubleValue="570.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA6Ag==" DoubleValue="570.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017967" DistinctValues="1108.822948">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAA6Ag==" DoubleValue="570.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008121" DistinctValues="501.187972">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAABYAg==" DoubleValue="600.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001824" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003509" DistinctValues="216.590082">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABlAuAV" DoubleValue="613.560000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABrAmgQ" DoubleValue="619.420000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAABrAmgQ" DoubleValue="619.420000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADIAuAV" DoubleValue="712.560000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002466" DistinctValues="152.318745">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADIAuAV" DoubleValue="712.560000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADQAg==" DoubleValue="720.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADQAg==" DoubleValue="720.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADQAg==" DoubleValue="720.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033863" DistinctValues="2091.721255">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADQAg==" DoubleValue="720.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA2A6QG" DoubleValue="822.170000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018726" DistinctValues="1156.723182">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAAA2A6QG" DoubleValue="822.170000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001013" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017602" DistinctValues="1087.316818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACEAw==" DoubleValue="900.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADNA0AG" DoubleValue="973.160000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003840" DistinctValues="237.076450">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADNA0AG" DoubleValue="973.160000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADoAw==" DoubleValue="1000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000666" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADoAw==" DoubleValue="1000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADoAw==" DoubleValue="1000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028612" DistinctValues="1766.590533">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADoAw==" DoubleValue="1000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001795" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003877" DistinctValues="239.373017">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAACwBA==" DoubleValue="1200.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADLBOgD" DoubleValue="1227.100000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018922" DistinctValues="1168.312433">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADLBOgD" DoubleValue="1227.100000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADcBQ==" DoubleValue="1500.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000753" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADcBQ==" DoubleValue="1500.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADcBQ==" DoubleValue="1500.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016813" DistinctValues="1038.081344">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAADcBQ==" DoubleValue="1500.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000695" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000594" DistinctValues="36.646224">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADOBsAS" DoubleValue="1742.480000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADXBpAB" DoubleValue="1751.040000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001424" DistinctValues="87.967748">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADAIAAADXBpAB" DoubleValue="1751.040000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000753" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034904" DistinctValues="2156.072252">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAAIBw==" DoubleValue="1800.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAC4Cw==" DoubleValue="3000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAACgIAAAC4Cw==" DoubleValue="3000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgIAAQAIAAwh8Ao=" DoubleValue="88460.280000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036328" DistinctValues="2245.040000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgIAAQAIAAwh8Ao=" DoubleValue="88460.280000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" IsNull="false" IsByValue="false" Value="AAAADgIAAQAzAL4TnBg=" DoubleValue="515054.630000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.7" Name="h" Width="12.000000" NullFreq="0.042131" NdvRemain="41551.000000" FreqRemain="0.913479" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.001622" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJhdWVy" LintValue="273302382"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUJhdWVy" LintValue="273302382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001448" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlY2tlcg==" LintValue="842154876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlY2tlcg==" LintValue="842154876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002259" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0Zpc2NoZXI=" LintValue="943342526"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0Zpc2NoZXI=" LintValue="943342526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001303" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhvZmZtYW5u" LintValue="564773862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhvZmZtYW5u" LintValue="564773862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hvZm1hbm4=" LintValue="564773750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hvZm1hbm4=" LintValue="564773750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001129" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsZWlu" LintValue="571065196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsZWlu" LintValue="571065196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEtvY2g=" LintValue="10027884"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEtvY2g=" LintValue="10027884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001969" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1leWVy" LintValue="846873452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1leWVy" LintValue="846873452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005589" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC03DvGxsZXI=" LintValue="993674030"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC03DvGxsZXI=" LintValue="993674030"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1JpY2h0ZXI=" LintValue="809649086"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1JpY2h0ZXI=" LintValue="809649086"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001245" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaG1pZA==" LintValue="850953084"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaG1pZA==" LintValue="850953084"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pZHQ=" LintValue="539132900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pZHQ=" LintValue="539132900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001448" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pdHQ=" LintValue="606241764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1NjaG1pdHQ=" LintValue="606241764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002722" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaG5laWRlcg==" LintValue="540689326"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVNjaG5laWRlcg==" LintValue="540689326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1NjaG5laWRlciBFbGVjdHJpYyBHbWJI" LintValue="581239798"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1NjaG5laWRlciBFbGVjdHJpYyBHbWJI" LintValue="581239798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001245" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaHVseg==" LintValue="870007668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClNjaHVseg==" LintValue="870007668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001390" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFNjaMOkZmVy" LintValue="271729470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFNjaMOkZmVy" LintValue="271729470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIVNlY3VyaXRhcyBHbWJIIEFkbWluaXN0cmF0aW9u" LintValue="17154942"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIVNlY3VyaXRhcyBHbWJIIEFkbWluaXN0cmF0aW9u" LintValue="17154942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFNlbmdlciBHbWJIICYgQ28uIEtH" LintValue="162325294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFNlbmdlciBHbWJIICYgQ28uIEtH" LintValue="162325294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002374" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlZCIEdyb25hdS1BaGF1cyBlRw==" LintValue="941155260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFlZCIEdyb25hdS1BaGF1cyBlRw==" LintValue="941155260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZHVSBlLlYuLSBWZXJzb3JndW5nc2thc3Nl" LintValue="611361646"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZHVSBlLlYuLSBWZXJzb3JndW5nc2thc3Nl" LintValue="611361646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001679" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhZ25lcg==" LintValue="278020924"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhZ25lcg==" LintValue="278020924"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001940" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVdlYmVy" LintValue="991052590"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVdlYmVy" LintValue="991052590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlppbW1lcm1hbm4=" LintValue="161071990"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlppbW1lcm1hbm4=" LintValue="161071990"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.6" Name="g" Width="2.000000" NullFreq="0.042089" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.407816" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.201883" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012063" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.287276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.047875" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBAgg Mdid="0.2126.1.0" Name="max" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1114.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.1114.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.47" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.46" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.39" Name="nn" Width="14.000000" NullFreq="0.000000" NdvRemain="330.000000" FreqRemain="0.717624" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.055841" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014264" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0JlY2ttYW5uLEhlaW5lcg==" LintValue="35799980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0JlY2ttYW5uLEhlaW5lcg==" LintValue="35799980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0JyZXllcixIZXJpYmVydA==" LintValue="69895142"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0JyZXllcixIZXJpYmVydA==" LintValue="69895142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006070" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUJ1cmd1bixTdGVmYW4=" LintValue="159499180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUJ1cmd1bixTdGVmYW4=" LintValue="159499180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF0LDpHJ3b2xmLElyaXMtQW5pdGE=" LintValue="872424292"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF0LDpHJ3b2xmLElyaXMtQW5pdGE=" LintValue="872424292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013574" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0LDvGNobGVyLFRob21hcw==" LintValue="11166718"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0LDvGNobGVyLFRob21hcw==" LintValue="11166718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011229" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEd1dHNjaGthLEFuZHJlYXM=" LintValue="590242812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEd1dHNjaGthLEFuZHJlYXM=" LintValue="590242812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006263" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFkhlaWRlbWFubnMsU3RlcGhhbg==" LintValue="830849838"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFkhlaWRlbWFubnMsU3RlcGhhbg==" LintValue="830849838"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007532" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEktpc3RuZXIsVGhvbWFz" LintValue="44721006"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEktpc3RuZXIsVGhvbWFz" LintValue="44721006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016305" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFktuw7ZwZmxlLEVuZ2VsYmVydA==" LintValue="630883300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFktuw7ZwZmxlLEVuZ2VsYmVydA==" LintValue="630883300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008415" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADktva2UsSsO2cmc=" LintValue="633922486"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADktva2UsSsO2cmc=" LintValue="633922486"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015974" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUt1aHNlLEhlbm5pbmc=" LintValue="564716532"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUt1aHNlLEhlbm5pbmc=" LintValue="564716532"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007697" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0vDtmhsZXIsSGVubmluZw==" LintValue="548987766"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0vDtmhsZXIsSGVubmluZw==" LintValue="548987766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005849" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEvDtnJuZXIsVGhvcnN0ZW4=" LintValue="694010686"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFEvDtnJuZXIsVGhvcnN0ZW4=" LintValue="694010686"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007284" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUvDtnN0ZXIsR3VpZG8=" LintValue="858121206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUvDtnN0ZXIsR3VpZG8=" LintValue="858121206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006180" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUvDvG1tZXJsZSxGbG9yaWFu" LintValue="19776510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUvDvG1tZXJsZSxGbG9yaWFu" LintValue="19776510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007587" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk1hbm4sRnJhbms=" LintValue="865952742"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk1hbm4sRnJhbms=" LintValue="865952742"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFE1lbnNpbmdlcixUaG9tYXM=" LintValue="11166574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFE1lbnNpbmdlcixUaG9tYXM=" LintValue="11166574"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006511" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE01pbG9zZXZpYyxTcmRhbg==" LintValue="976077630"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE01pbG9zZXZpYyxTcmRhbg==" LintValue="976077630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006290" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFU5pZXNzaW5nLEthaSBJbmdv" LintValue="549053356"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFU5pZXNzaW5nLEthaSBJbmdv" LintValue="549053356"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006511" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVJlaGZlbGR0LEF4ZWw=" LintValue="550601516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVJlaGZlbGR0LEF4ZWw=" LintValue="550601516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016112" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVNhdWVyLE1pY2hhZWw=" LintValue="823755628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVNhdWVyLE1pY2hhZWw=" LintValue="823755628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005987" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVNjaG1pZHQsQWxleGFuZGVy" LintValue="598361006"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVNjaG1pZHQsQWxleGFuZGVy" LintValue="598361006"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009132" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVNwaXR6LE1hdGhpYXM=" LintValue="975856492"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEVNwaXR6LE1hdGhpYXM=" LintValue="975856492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015974" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFRld2VzLFJhaW5lcg==" LintValue="813843390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFRld2VzLFJhaW5lcg==" LintValue="813843390"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.38" Name="mm" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.057689" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="14.375000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="44942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="15.375000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="44942"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="65562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000004" DistinctValues="0.001877">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="65562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="65671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005849" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="65671"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="65671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029820" DistinctValues="14.373123">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="65671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="900402"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="15.375000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="900402"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="15.375000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903036"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007284" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903036"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903036"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="14.375000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903036"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903695"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016112" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903695"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903695"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="14.375000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="903695"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="904176"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="15.375000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="904176"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="906862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="906862"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="906862"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005069" DistinctValues="1.933291">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="906862"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007697" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001185" DistinctValues="0.451907">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907849"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006511" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907849"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907849"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009162" DistinctValues="3.494423">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907849"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="909295"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008415" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="909295"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="909295"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014408" DistinctValues="5.495379">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="909295"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016305" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911569"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014751" DistinctValues="6.615424">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="913267"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006290" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="913267"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="913267"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015073" DistinctValues="6.759576">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="913267"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915002"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021561" DistinctValues="10.392263">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915002"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="918415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009132" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="918415"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="918415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008263" DistinctValues="3.982737">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="918415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="919723"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012009" DistinctValues="5.385822">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="919723"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921016"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015974" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921016"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921016"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014220" DistinctValues="6.377180">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921016"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="922547"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="922547"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="922547"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003594" DistinctValues="1.611998">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="922547"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="922934"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005646" DistinctValues="2.721442">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="922934"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="923611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006511" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="923611"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="923611"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024178" DistinctValues="11.653558">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="923611"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="926510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006180" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="926510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="926510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026581" DistinctValues="11.920742">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="926510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928797"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006070" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928797"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928797"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003243" DistinctValues="1.454258">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928797"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="929076"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022041" DistinctValues="10.623643">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="929076"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934182"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007532" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934182"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934182"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007783" DistinctValues="3.751357">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934182"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="935985"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007514" DistinctValues="3.621578">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="935985"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="936896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014264" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="936896"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="936896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022310" DistinctValues="10.753422">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="936896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="939601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013574" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="939601"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="939601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="14.375000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="939601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="944817"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="15.375000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="944817"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="954046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003765" DistinctValues="1.814905">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="954046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005987" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955493"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026059" DistinctValues="12.560095">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955493"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="965507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020833" DistinctValues="10.041463">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="965507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970519"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970519"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970519"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008991" DistinctValues="4.333537">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="972682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010461" DistinctValues="5.042211">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="972682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="975580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007587" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="975580"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="975580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019363" DistinctValues="9.332789">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="975580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="980944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="15.375000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="980944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="991775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029426" DistinctValues="14.183367">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="991775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015974" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000398" DistinctValues="0.191633">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997551"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003120" DistinctValues="1.399112">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997551"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997769"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011229" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997769"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997769"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026704" DistinctValues="11.975888">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="997769"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999635"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006263" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999635"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999635"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.31" Name="ff" Width="1.000000" NullFreq="0.000000" NdvRemain="468.000000" FreqRemain="0.076450" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.880897" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002897" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0FuZHJlYXM=" LintValue="590242814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUNocmlzdGlhbg==" LintValue="455459694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACERpcms=" LintValue="612459364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACERpcms=" LintValue="612459364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002373" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUZyYW5r" LintValue="278750054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0fDvG50ZXI=" LintValue="190464942"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0fDvG50ZXI=" LintValue="190464942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEplbnM=" LintValue="330457956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEplbnM=" LintValue="330457956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001462" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUpvc2Vm" LintValue="542163820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUrDtnJn" LintValue="115925796"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUrDtnJn" LintValue="115925796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0rDvHJnZW4=" LintValue="185975662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkthcmwtSGVpbno=" LintValue="11223910"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADkthcmwtSGVpbno=" LintValue="11223910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUtsYXVz" LintValue="622486380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACk1hcmt1cw==" LintValue="605447020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC01pY2hhZWw=" LintValue="806978430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001904" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACVBldGVy" LintValue="961168174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJhaW5lcg==" LintValue="547504956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJhaW5lcg==" LintValue="547504956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACFJhbGY=" LintValue="321176420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACFJhbGY=" LintValue="321176420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001214" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACFJlbmU=" LintValue="330605412"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACFJlbmU=" LintValue="330605412"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJ1ZG9sZg==" LintValue="413188980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClJ1ZG9sZg==" LintValue="413188980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001931" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClN0ZWZhbg==" LintValue="177324860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1N0ZWZmZW4=" LintValue="599376814"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC1N0ZWZmZW4=" LintValue="599376814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003393" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAClRob21hcw==" LintValue="278553470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001242" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldhbHRlcg==" LintValue="284836668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002566" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACldlcm5lcg==" LintValue="580272956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADFdvbGZnYW5n" LintValue="28894196"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.30" Name="ee" Width="22.000000" NullFreq="0.000000" NdvRemain="4991.000000" FreqRemain="0.820863" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.006208" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUJlcmxpbmVyIFZvbGtzYmFuayBlRw==" LintValue="571269950"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUJlcmxpbmVyIFZvbGtzYmFuayBlRw==" LintValue="571269950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006704" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHkNvbmRvciBBbGxnZW1laW5lIFZlcnMuLUFH" LintValue="848094206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHkNvbmRvciBBbGxnZW1laW5lIFZlcnMuLUFH" LintValue="848094206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004607" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIEVERUtBIFZlcnMuVmVybWl0dGx1bmdzLUdtYkg=" LintValue="285541366"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIEVERUtBIFZlcnMuVmVybWl0dGx1bmdzLUdtYkg=" LintValue="285541366"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHEZyYW5rZnVydGVyIFZvbGtzYmFuayBlRw==" LintValue="36496318"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHEZyYW5rZnVydGVyIFZvbGtzYmFuayBlRw==" LintValue="36496318"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024085" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007808" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RlYW1CYW5rIEFH" LintValue="454878014"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RlYW1CYW5rIEFH" LintValue="454878014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005325" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZCIERhcm1zdGFkdC1Tw7xkaGVzc2VuIGVH" LintValue="546628414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZCIERhcm1zdGFkdC1Tw7xkaGVzc2VuIGVH" LintValue="546628414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZCIFBhZGVyYm9ybi1Iw7Z4dGVyLURldG1vbGQgZUc=" LintValue="589095854"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZCIFBhZGVyYm9ybi1Iw7Z4dGVyLURldG1vbGQgZUc=" LintValue="589095854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004801" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZCIFNjaHdhcnp3YWxkLURvbmF1LU5lY2thciBlRw==" LintValue="572056380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZCIFNjaHdhcnp3YWxkLURvbmF1LU5lY2thciBlRw==" LintValue="572056380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006235" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZSIEJhbmsgUmhlaW4tTmVja2FyIGVH" LintValue="538501948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZSIEJhbmsgUmhlaW4tTmVja2FyIGVH" LintValue="538501948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004773" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZSIEJhbmsgU2Nod8OkYi5IYWxsLUNyYWlsc2guZUc=" LintValue="975496108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZSIEJhbmsgU2Nod8OkYi5IYWxsLUNyYWlsc2guZUc=" LintValue="975496108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006152" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFZSIEJhbmsgU8O8ZHBmYWx6IGVH" LintValue="286843836"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFZSIEJhbmsgU8O8ZHBmYWx6IGVH" LintValue="286843836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004994" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZSLUJhbmsgS3JlaXMgU3RlaW5mdXJ0IGVH" LintValue="984146750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZSLUJhbmsgS3JlaXMgU3RlaW5mdXJ0IGVH" LintValue="984146750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlZSLUJhbmsgZUc=" LintValue="822928188"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlZSLUJhbmsgZUc=" LintValue="822928188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006097" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZlcmVpbmlndGUgVm9sa3NiYW5rIGVH" LintValue="34399020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZlcmVpbmlndGUgVm9sa3NiYW5rIGVH" LintValue="34399020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004332" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZlcmVpbmlndGUgVm9sa3Niay4gTWFpbmdhdSBlRw==" LintValue="1631022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZlcmVpbmlndGUgVm9sa3Niay4gTWFpbmdhdSBlRw==" LintValue="1631022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHFZvbGtzYmFuayBBbHpleS1Xb3JtcyBlRw==" LintValue="10019756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHFZvbGtzYmFuayBBbHpleS1Xb3JtcyBlRw==" LintValue="10019756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004387" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZvbGtzYmFuayBLdXItIHUuUmhlaW5wZmFseiBlRw==" LintValue="822666172"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZvbGtzYmFuayBLdXItIHUuUmhlaW5wZmFseiBlRw==" LintValue="822666172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVZvbGtzYmFuayBMYWhyIGVH" LintValue="590930750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVZvbGtzYmFuayBMYWhyIGVH" LintValue="590930750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009049" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBQZm9yemhlaW0gZUc=" LintValue="319611708"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBQZm9yemhlaW0gZUc=" LintValue="319611708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006401" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZvbGtzYmFuayBSaGVpbkFockVpZmVsIGVH" LintValue="825025342"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZvbGtzYmFuayBSaGVpbkFockVpZmVsIGVH" LintValue="825025342"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005656" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBTdHV0dGdhcnQgZUc=" LintValue="154723246"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBTdHV0dGdhcnQgZUc=" LintValue="154723246"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023230" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFldlc3RlcndhbGQgQmFuayBlRw==" LintValue="305980204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFldlc3RlcndhbGQgQmFuayBlRw==" LintValue="305980204"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.23" Name="x" Width="22.000000" NullFreq="0.000000" NdvRemain="6214.000000" FreqRemain="0.824339" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.005711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUJlcmxpbmVyIFZvbGtzYmFuayBlRw==" LintValue="571269950"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUJlcmxpbmVyIFZvbGtzYmFuayBlRw==" LintValue="571269950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012056" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHkNvbmRvciBBbGxnZW1laW5lIFZlcnMuLUFH" LintValue="848094206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHkNvbmRvciBBbGxnZW1laW5lIFZlcnMuLUFH" LintValue="848094206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004083" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIEVERUtBIFZlcnMuVmVybWl0dGx1bmdzLUdtYkg=" LintValue="285541366"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIEVERUtBIFZlcnMuVmVybWl0dGx1bmdzLUdtYkg=" LintValue="285541366"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004663" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHEZyYW5rZnVydGVyIFZvbGtzYmFuayBlRw==" LintValue="36496318"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHEZyYW5rZnVydGVyIFZvbGtzYmFuayBlRw==" LintValue="36496318"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019092" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVIrViBMZWJlbnN2ZXJzaWNoZXJ1bmcgQUc=" LintValue="967107388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVIrViBMZWJlbnN2ZXJzaWNoZXJ1bmcgQUc=" LintValue="967107388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RlYW1CYW5rIEFH" LintValue="454878014"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RlYW1CYW5rIEFH" LintValue="454878014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005545" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZCIERhcm1zdGFkdC1Tw7xkaGVzc2VuIGVH" LintValue="546628414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZCIERhcm1zdGFkdC1Tw7xkaGVzc2VuIGVH" LintValue="546628414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009160" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZCIFBhZGVyYm9ybi1Iw7Z4dGVyLURldG1vbGQgZUc=" LintValue="589095854"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZCIFBhZGVyYm9ybi1Iw7Z4dGVyLURldG1vbGQgZUc=" LintValue="589095854"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004663" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZCIFNjaHdhcnp3YWxkLURvbmF1LU5lY2thciBlRw==" LintValue="572056380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZCIFNjaHdhcnp3YWxkLURvbmF1LU5lY2thciBlRw==" LintValue="572056380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005877" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZSIEJhbmsgUmhlaW4tTmVja2FyIGVH" LintValue="538501948"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZSIEJhbmsgUmhlaW4tTmVja2FyIGVH" LintValue="538501948"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004663" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZSIEJhbmsgU2Nod8OkYi5IYWxsLUNyYWlsc2guZUc=" LintValue="975496108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAI1ZSIEJhbmsgU2Nod8OkYi5IYWxsLUNyYWlsc2guZUc=" LintValue="975496108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005877" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFZSIEJhbmsgU8O8ZHBmYWx6IGVH" LintValue="286843836"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGFZSIEJhbmsgU8O8ZHBmYWx6IGVH" LintValue="286843836"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005187" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlZSLUJhbmsgZUc=" LintValue="822928188"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlZSLUJhbmsgZUc=" LintValue="822928188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005877" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZlcmVpbmlndGUgVm9sa3NiYW5rIGVH" LintValue="34399020"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAG1ZlcmVpbmlndGUgVm9sa3NiYW5rIGVH" LintValue="34399020"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZlcmVpbmlndGUgVm9sa3Niay4gTWFpbmdhdSBlRw==" LintValue="1631022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZlcmVpbmlndGUgVm9sa3Niay4gTWFpbmdhdSBlRw==" LintValue="1631022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004083" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHFZvbGtzYmFuayBBbHpleS1Xb3JtcyBlRw==" LintValue="10019756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHFZvbGtzYmFuayBBbHpleS1Xb3JtcyBlRw==" LintValue="10019756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004442" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZvbGtzYmFuayBLdXItIHUuUmhlaW5wZmFseiBlRw==" LintValue="822666172"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlZvbGtzYmFuayBLdXItIHUuUmhlaW5wZmFseiBlRw==" LintValue="822666172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004221" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVZvbGtzYmFuayBMYWhyIGVH" LintValue="590930750"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFVZvbGtzYmFuayBMYWhyIGVH" LintValue="590930750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008884" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004525" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBQZm9yemhlaW0gZUc=" LintValue="319611708"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBQZm9yemhlaW0gZUc=" LintValue="319611708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006456" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZvbGtzYmFuayBSaGVpbkFockVpZmVsIGVH" LintValue="825025342"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHlZvbGtzYmFuayBSaGVpbkFockVpZmVsIGVH" LintValue="825025342"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005270" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBTdHV0dGdhcnQgZUc=" LintValue="154723246"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGlZvbGtzYmFuayBTdHV0dGdhcnQgZUc=" LintValue="154723246"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021713" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFldlc3RlcndhbGQgQmFuayBlRw==" LintValue="305980204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFldlc3RlcndhbGQgQmFuayBlRw==" LintValue="305980204"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.22" Name="w" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.112923" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021244" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000138" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.134001" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.731557" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.15" Name="p" Width="2.000000" NullFreq="0.038652" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.474783" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.242482" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014926" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.130304" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.098852" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.7" Name="h" Width="1.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.348535" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026099" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUo=" LintValue="160776748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUo=" LintValue="160776748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000248" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUs=" LintValue="160784940"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABUs=" LintValue="160784940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.625117" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABU4=" LintValue="160809516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABU4=" LintValue="160809516"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.6" Name="g" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Lv3//w==" DoubleValue="-62380800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="NP///w==" DoubleValue="-17625600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="NP///w==" DoubleValue="-17625600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="DgEAAA==" DoubleValue="23328000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="DgEAAA==" DoubleValue="23328000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="UwIAAA==" DoubleValue="51408000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="UwIAAA==" DoubleValue="51408000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qQMAAA==" DoubleValue="80956800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qQMAAA==" DoubleValue="80956800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qQMAAA==" DoubleValue="80956800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="184.807692">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qQMAAA==" DoubleValue="80956800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wQAAA==" DoubleValue="108777600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wQAAA==" DoubleValue="108777600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ewYAAA==" DoubleValue="143337600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ewYAAA==" DoubleValue="143337600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2QcAAA==" DoubleValue="173577600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031708" DistinctValues="171.326923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2QcAAA==" DoubleValue="173577600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cAgAAA==" DoubleValue="186624000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cAgAAA==" DoubleValue="186624000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cAgAAA==" DoubleValue="186624000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001470" DistinctValues="7.942308">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cAgAAA==" DoubleValue="186624000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dwgAAA==" DoubleValue="187228800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dwgAAA==" DoubleValue="187228800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dwgAAA==" DoubleValue="187228800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000840" DistinctValues="4.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dwgAAA==" DoubleValue="187228800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ewgAAA==" DoubleValue="187574400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022761" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ewgAAA==" DoubleValue="187574400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ewgAAA==" DoubleValue="187574400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017009" DistinctValues="91.903846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ewgAAA==" DoubleValue="187574400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fAgAAA==" DoubleValue="187660800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026568" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fAgAAA==" DoubleValue="187660800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fAgAAA==" DoubleValue="187660800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017009" DistinctValues="91.903846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fAgAAA==" DoubleValue="187660800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fQgAAA==" DoubleValue="187747200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015698" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fQgAAA==" DoubleValue="187747200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fQgAAA==" DoubleValue="187747200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000740" DistinctValues="3.930602">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fQgAAA==" DoubleValue="187747200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fggAAA==" DoubleValue="187833600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002124" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fggAAA==" DoubleValue="187833600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fggAAA==" DoubleValue="187833600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008135" DistinctValues="43.236622">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="fggAAA==" DoubleValue="187833600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iQgAAA==" DoubleValue="188784000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iQgAAA==" DoubleValue="188784000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iQgAAA==" DoubleValue="188784000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000740" DistinctValues="3.930602">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iQgAAA==" DoubleValue="188784000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iggAAA==" DoubleValue="188870400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001986" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iggAAA==" DoubleValue="188870400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iggAAA==" DoubleValue="188870400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012572" DistinctValues="66.820234">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="iggAAA==" DoubleValue="188870400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mwgAAA==" DoubleValue="190339200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002373" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mwgAAA==" DoubleValue="190339200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mwgAAA==" DoubleValue="190339200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011832" DistinctValues="62.889632">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mwgAAA==" DoubleValue="190339200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qwgAAA==" DoubleValue="191721600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="qwgAAA==" DoubleValue="191721600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="XQkAAA==" DoubleValue="207100800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="XQkAAA==" DoubleValue="207100800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vAoAAA==" DoubleValue="237427200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017402" DistinctValues="94.538588">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="vAoAAA==" DoubleValue="237427200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VwsAAA==" DoubleValue="250819200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VwsAAA==" DoubleValue="250819200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VwsAAA==" DoubleValue="250819200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016616" DistinctValues="90.269104">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="VwsAAA==" DoubleValue="250819200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wsAAA==" DoubleValue="263606400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012907" DistinctValues="69.361118">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wsAAA==" DoubleValue="263606400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="YQwAAA==" DoubleValue="273801600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="YQwAAA==" DoubleValue="273801600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="YQwAAA==" DoubleValue="273801600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015095" DistinctValues="81.117240">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="YQwAAA==" DoubleValue="273801600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wwAAA==" DoubleValue="285724800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002290" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wwAAA==" DoubleValue="285724800000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wwAAA==" DoubleValue="285724800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004047" DistinctValues="21.748825">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="6wwAAA==" DoubleValue="285724800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="EA0AAA==" DoubleValue="288921600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001545" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="EA0AAA==" DoubleValue="288921600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="EA0AAA==" DoubleValue="288921600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001969" DistinctValues="10.580510">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="EA0AAA==" DoubleValue="288921600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Ig0AAA==" DoubleValue="290476800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015014" DistinctValues="81.125000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Ig0AAA==" DoubleValue="290476800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sQ0AAA==" DoubleValue="302832000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sQ0AAA==" DoubleValue="302832000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sQ0AAA==" DoubleValue="302832000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017324" DistinctValues="93.605769">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="sQ0AAA==" DoubleValue="302832000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001931" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001680" DistinctValues="9.076923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Vg4AAA==" DoubleValue="317088000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="Zg4AAA==" DoubleValue="318470400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="oA8AAA==" DoubleValue="345600000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000370" DistinctValues="1.997910">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="oA8AAA==" DoubleValue="345600000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ow8AAA==" DoubleValue="345859200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001876" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ow8AAA==" DoubleValue="345859200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ow8AAA==" DoubleValue="345859200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025390" DistinctValues="137.189799">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="ow8AAA==" DoubleValue="345859200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cRAAAA==" DoubleValue="363657600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003476" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cRAAAA==" DoubleValue="363657600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cRAAAA==" DoubleValue="363657600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008258" DistinctValues="44.619983">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="cRAAAA==" DoubleValue="363657600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="tBAAAA==" DoubleValue="369446400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001049" DistinctValues="5.668079">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="tBAAAA==" DoubleValue="369446400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uxAAAA==" DoubleValue="370051200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003559" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uxAAAA==" DoubleValue="370051200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uxAAAA==" DoubleValue="370051200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002548" DistinctValues="13.765334">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uxAAAA==" DoubleValue="370051200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zBAAAA==" DoubleValue="371520000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003807" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zBAAAA==" DoubleValue="371520000000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zBAAAA==" DoubleValue="371520000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030421" DistinctValues="164.374280">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="zBAAAA==" DoubleValue="371520000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="lxEAAA==" DoubleValue="389059200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028052" DistinctValues="152.397388">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="lxEAAA==" DoubleValue="389059200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001876" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005966" DistinctValues="32.410304">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="dBIAAA==" DoubleValue="408153600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="oxIAAA==" DoubleValue="412214400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="oxIAAA==" DoubleValue="412214400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="1hMAAA==" DoubleValue="438739200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029222" DistinctValues="158.755507">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="1hMAAA==" DoubleValue="438739200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mRQAAA==" DoubleValue="455587200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mRQAAA==" DoubleValue="455587200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mRQAAA==" DoubleValue="455587200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004795" DistinctValues="26.052186">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="mRQAAA==" DoubleValue="455587200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uRQAAA==" DoubleValue="458352000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025103" DistinctValues="136.375332">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="uRQAAA==" DoubleValue="458352000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="jxUAAA==" DoubleValue="476841600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001600" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="jxUAAA==" DoubleValue="476841600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="jxUAAA==" DoubleValue="476841600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008915" DistinctValues="48.432361">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="jxUAAA==" DoubleValue="476841600000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2xUAAA==" DoubleValue="483408000000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="2xUAAA==" DoubleValue="483408000000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5RYAAA==" DoubleValue="506390400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5RYAAA==" DoubleValue="506390400000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5RYAAA==" DoubleValue="506390400000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="184.807692">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5RYAAA==" DoubleValue="506390400000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5RcAAA==" DoubleValue="528508800000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014955" DistinctValues="81.243961">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="5RcAAA==" DoubleValue="528508800000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="QBgAAA==" DoubleValue="536371200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="QBgAAA==" DoubleValue="536371200000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="QBgAAA==" DoubleValue="536371200000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019063" DistinctValues="103.563731">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="QBgAAA==" DoubleValue="536371200000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="tBgAAA==" DoubleValue="546393600000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034018" DistinctValues="185.807692">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="tBgAAA==" DoubleValue="546393600000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" IsNull="false" IsByValue="true" Value="tRgAAA==" DoubleValue="546480000000000.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.14" Name="o" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.009554" DistinctValues="0.248742">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="164124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9315993"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9315993"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9315993"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000057" DistinctValues="0.001491">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9315993"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9370858"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9370858"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9370858"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028797" DistinctValues="0.749766">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="9370858"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36956682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36956682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="76429855"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="76429855"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="112154132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009258" DistinctValues="0.241053">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="112154132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="134417609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="134417609"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="134417609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028129" DistinctValues="0.732354">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="134417609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="202057241"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="202057241"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="202057241"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="0.026593">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="202057241"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204513309"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204513309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="259467861"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="259467861"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="294123296"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028693" DistinctValues="0.747040">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="294123296"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327861484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327861484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327861484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009716" DistinctValues="0.252960">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="327861484"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="339285764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="339285764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="405078651"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="405078651"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="418870800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009397" DistinctValues="0.244671">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="418870800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421640327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421640327"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421640327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029011" DistinctValues="0.755329">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421640327"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="430190199"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015050" DistinctValues="0.391847">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="430190199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433948424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433948424"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433948424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021586" DistinctValues="0.562018">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433948424"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439338768"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439338768"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439338768"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001772" DistinctValues="0.046134">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439338768"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439781246"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029276" DistinctValues="0.762224">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="439781246"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="464716262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="464716262"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="464716262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007992" DistinctValues="0.208072">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="464716262"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="471523046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="471523046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="471523046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001141" DistinctValues="0.029704">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="471523046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="472494767"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="472494767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="485764380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="485764380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="495394808"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="495394808"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="512756379"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="512756379"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531405749"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000293" DistinctValues="0.007628">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531405749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531514092"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531514092"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531514092"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022972" DistinctValues="0.598093">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="531514092"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="540009058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="540009058"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="540009058"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015144" DistinctValues="0.394279">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="540009058"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="545609177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002712" DistinctValues="0.070604">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="545609177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="553078016"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="553078016"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="553078016"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009363" DistinctValues="0.243768">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="553078016"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="578865160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="578865160"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="578865160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026334" DistinctValues="0.685628">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="578865160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="651394767"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="651394767"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="838533752"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004617" DistinctValues="0.120203">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="838533752"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="842811775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="842811775"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="842811775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033792" DistinctValues="0.879797">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="842811775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="874123714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="874123714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902506683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008970" DistinctValues="0.233538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902506683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907585271"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907585271"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907585271"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017487" DistinctValues="0.455281">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="907585271"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="917485968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="917485968"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="917485968"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011952" DistinctValues="0.311182">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="917485968"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="924253029"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006154" DistinctValues="0.160237">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="924253029"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928072088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928072088"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928072088"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007556" DistinctValues="0.196727">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="928072088"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="932760843"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="932760843"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="932760843"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019539" DistinctValues="0.508711">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="932760843"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="944885382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="944885382"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="944885382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004835" DistinctValues="0.125875">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="944885382"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="947885472"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="947885472"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="947885472"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000325" DistinctValues="0.008450">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="947885472"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="948086875"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014457" DistinctValues="0.376405">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="948086875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960063082"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960063082"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960063082"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012003" DistinctValues="0.312517">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960063082"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970006532"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970006532"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970006532"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011948" DistinctValues="0.311078">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="970006532"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="979904207"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020481" DistinctValues="0.533233">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="979904207"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="990525137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="990525137"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="990525137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003197" DistinctValues="0.083238">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="990525137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992183071"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992183071"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992183071"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014731" DistinctValues="0.383529">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992183071"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999822185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038408" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999822185"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999997732"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.1114.1.0" Name="timestamp" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.2060.1.0"/>
+        <dxl:InequalityOp Mdid="0.2061.1.0"/>
+        <dxl:LessThanOp Mdid="0.2062.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2063.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2064.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2065.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2045.1.0"/>
+        <dxl:ArrayType Mdid="0.1115.1.0"/>
+        <dxl:MinAgg Mdid="0.2142.1.0"/>
+        <dxl:MaxAgg Mdid="0.2126.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.21" Name="v" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.143275" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.856725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.20" Name="u" Width="9.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.297054" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC2Jlc3R1ZWI=" LintValue="410797038"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC2Jlc3R1ZWI=" LintValue="410797038"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.336683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJiZA==" LintValue="135824180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJiZA==" LintValue="135824180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.119064" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJnYQ==" LintValue="152576828"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJnYQ==" LintValue="152576828"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.123606" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJ1YQ==" LintValue="228074300"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJ1YQ==" LintValue="228074300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.122593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJ2YQ==" LintValue="219685684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADWJlc3R1ZWJ2YQ==" LintValue="219685684"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.13" Name="n" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="111111812"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="130049168"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003403" DistinctValues="602.477934">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="130049168"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="131330073"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001013" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="131330073"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="131330073"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015511" DistinctValues="2746.442017">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="131330073"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001593" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018823" DistinctValues="3332.810819">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="137169177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="144254937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="144254937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="167376355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000132" DistinctValues="23.294324">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="167376355"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="167430597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="167430597"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="167430597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037605" DistinctValues="6659.436445">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="167430597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002374" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000099" DistinctValues="17.505379">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182937428"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001100" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966720"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010436" DistinctValues="1847.563898">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="182966720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186058275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186058275"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186058275"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027202" DistinctValues="4815.661492">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="186058275"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="194116390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="194116390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204746079"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204746079"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="217457904"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003179" DistinctValues="562.991648">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="217457904"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="218295401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000753" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="218295401"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="218295401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034557" DistinctValues="6119.739121">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="218295401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="227399023"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004274" DistinctValues="756.838678">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="227399023"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001158" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020420" DistinctValues="3615.641737">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="229550624"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239829457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000376" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239829457"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239829457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013042" DistinctValues="2309.250355">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="239829457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="246394377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="246394377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="261987643"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="261987643"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="274498048"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="274498048"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="288925860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="288925860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="301613970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="301613970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="313956237"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037462" DistinctValues="6634.044113">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="313956237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="353146114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000811" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="353146114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="353146114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000275" DistinctValues="48.686656">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="353146114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="353433725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002488" DistinctValues="440.553608">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="353433725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="354168162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000985" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="354168162"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="354168162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035249" DistinctValues="6242.177162">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="354168162"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="364574355"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033417" DistinctValues="5917.714928">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="364574355"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="375777100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000405" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="375777100"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="375777100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004320" DistinctValues="765.015841">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="375777100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="377225341"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="377225341"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="395228412"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="395228412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="410990385"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024244" DistinctValues="4292.643003">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="410990385"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421678235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000666" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421678235"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421678235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005322" DistinctValues="942.327887">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="421678235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="424024449"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000376" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="424024449"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="424024449"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008171" DistinctValues="1446.759879">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="424024449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="427626601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012123" DistinctValues="2146.185684">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="427626601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433017692"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000376" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433017692"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433017692"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008807" DistinctValues="1559.227144">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="433017692"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436934378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436934378"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436934378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011459" DistinctValues="2028.676935">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436934378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="442030294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000840" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="442030294"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="442030294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005347" DistinctValues="946.641007">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="442030294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="444408200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019206" DistinctValues="3400.693308">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="444408200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="452999668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000521" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="452999668"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="452999668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006739" DistinctValues="1193.231194">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="452999668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="456014232"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001274" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="456014232"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="456014232"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011791" DistinctValues="2087.806267">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="456014232"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="461288839"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011423" DistinctValues="2021.733676">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="461288839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467731408"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467731408"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467731408"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000105" DistinctValues="18.543893">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467731408"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000579" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001453" DistinctValues="257.127564">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="467790501"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="468609878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000376" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="468609878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="468609878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015877" DistinctValues="2810.037557">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="468609878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="477564500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000463" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="477564500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="477564500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008698" DistinctValues="1539.341106">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="477564500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="482469850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000492" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="482469850"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="482469850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000181" DistinctValues="31.946973">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="482469850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="482571654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="482571654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="516102381"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001729" DistinctValues="306.197009">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="516102381"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="520184805"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000434" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="520184805"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="520184805"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036007" DistinctValues="6376.533760">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="520184805"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="605201032"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037737" DistinctValues="6683.730769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="605201032"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="900001207"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.12" Name="m" Width="11.000000" NullFreq="0.042131" NdvRemain="6965.000000" FreqRemain="0.850094" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.015491" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002316" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002432" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJyZW1lbg==" LintValue="136954748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJyZW1lbg==" LintValue="136954748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002722" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADERvcnRtdW5k" LintValue="140018660"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADERvcnRtdW5k" LintValue="140018660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005357" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003359" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0TDvHNzZWxkb3Jm" LintValue="613991398"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0TDvHNzZWxkb3Jm" LintValue="613991398"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002954" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkVyZnVydA==" LintValue="233472884"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkVyZnVydA==" LintValue="233472884"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002259" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUVzc2Vu" LintValue="39175022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUVzc2Vu" LintValue="39175022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005241" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002259" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEZyZWlidXJnIGltIEJyZWlzZ2F1" LintValue="840868860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEZyZWlidXJnIGltIEJyZWlzZ2F1" LintValue="840868860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0dyb25hdSAoV2VzdGYuKQ==" LintValue="177546150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0dyb25hdSAoV2VzdGYuKQ==" LintValue="177546150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009613" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003330" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUthcmxzcnVoZQ==" LintValue="157590374"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUthcmxzcnVoZQ==" LintValue="157590374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002288" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkthc3NlbA==" LintValue="809861996"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkthc3NlbA==" LintValue="809861996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005965" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004633" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0xlaXB6aWc=" LintValue="307553068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0xlaXB6aWc=" LintValue="307553068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002982" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004720" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002809" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002722" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU7DvHJuYmVyZw==" LintValue="101770100"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADU7DvHJuYmVyZw==" LintValue="101770100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002432" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlJhdmVuc2J1cmc=" LintValue="501801958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlJhdmVuc2J1cmc=" LintValue="501801958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004401" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007992" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.4" Name="e" Width="2.000000" NullFreq="0.000000" NdvRemain="9.750000" FreqRemain="0.006711" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.002237" DistinctValues="4.750000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.048473" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006197" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002237" DistinctValues="2.750000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025713" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000959" DistinctValues="0.750000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005009" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="21"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="21"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.500000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="21"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004199" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="25"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.500000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.068250" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="29"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.277689" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002237" DistinctValues="3.750000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.048936" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.081541" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.101723" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011061" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="35"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002237" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009498" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008137" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="39"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006283" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="40"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004372" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="41"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000479" DistinctValues="0.375000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008426" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.500000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022904" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001118" DistinctValues="0.875000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022933" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000447" DistinctValues="0.550000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006515" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001789" DistinctValues="2.200000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.139945" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001491" DistinctValues="1.833333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020009" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000746" DistinctValues="0.916667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009903" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000320" DistinctValues="0.142857">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005299" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="84"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001917" DistinctValues="0.857143">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025916" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237712.1.0.5" Name="f" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="557714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36534672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035061" DistinctValues="0.912956">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36534672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67163273"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67163273"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67163273"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003343" DistinctValues="0.087044">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67163273"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="70083515"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="70083515"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="106026343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="106026343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="121941872"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="121941872"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="228013170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="228013170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="322875215"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036415" DistinctValues="0.948214">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="322875215"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="339878617"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="339878617"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="339878617"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001989" DistinctValues="0.051786">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="339878617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="340807243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002360" DistinctValues="0.061440">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="340807243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="344594740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="344594740"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="344594740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026483" DistinctValues="0.689605">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="344594740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="387105662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="387105662"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="387105662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009561" DistinctValues="0.248955">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="387105662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="402452579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004022" DistinctValues="0.104738">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="402452579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="404042718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="404042718"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="404042718"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024205" DistinctValues="0.630274">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="404042718"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="413611563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="413611563"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="413611563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010177" DistinctValues="0.264988">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="413611563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="417634630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001642" DistinctValues="0.042766">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="417634630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="418222190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="418222190"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="418222190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031092" DistinctValues="0.809623">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="418222190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429345529"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429345529"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429345529"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003995" DistinctValues="0.104036">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="429345529"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="430774867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="430774867"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="430774867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001673" DistinctValues="0.043576">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="430774867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="431373548"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002330" DistinctValues="0.060668">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="431373548"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="432715671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="432715671"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="432715671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006704" DistinctValues="0.174571">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="432715671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436577583"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436577583"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436577583"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029370" DistinctValues="0.764760">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="436577583"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="453495809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021491" DistinctValues="0.559610">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="453495809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="462419724"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="462419724"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="462419724"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016913" DistinctValues="0.440390">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="462419724"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="469442470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012368" DistinctValues="0.322061">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="469442470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="475529073"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="475529073"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="475529073"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015348" DistinctValues="0.399656">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="475529073"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="483082134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="483082134"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="483082134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010687" DistinctValues="0.278283">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="483082134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="488341367"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002478" DistinctValues="0.064519">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="488341367"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="489564165"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="489564165"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="489564165"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.035926" DistinctValues="0.935481">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="489564165"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="507293972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008715" DistinctValues="0.226931">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="507293972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="511240425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="511240425"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="511240425"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017063" DistinctValues="0.444314">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="511240425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="518967282"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000087" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="518967282"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="518967282"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012625" DistinctValues="0.328754">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="518967282"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="524684489"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="524684489"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="539881124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018295" DistinctValues="0.476392">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="539881124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="547101685"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="547101685"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="547101685"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020108" DistinctValues="0.523608">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="547101685"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="555037872"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="555037872"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="568083563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023839" DistinctValues="0.620741">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="568083563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="650194837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="650194837"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="650194837"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014565" DistinctValues="0.379259">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="650194837"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="700363007"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037484" DistinctValues="0.976041">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="700363007"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843025145"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000087" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843025145"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843025145"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000059" DistinctValues="0.001540">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843025145"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843250270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843250270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843250270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000861" DistinctValues="0.022419">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="843250270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="846527125"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="846527125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="897323893"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="897323893"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="924107286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027366" DistinctValues="0.712595">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="924107286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940985315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940985315"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940985315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011037" DistinctValues="0.287405">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940985315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="947792598"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011403" DistinctValues="0.296914">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="947792598"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957076467"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957076467"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957076467"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027001" DistinctValues="0.703086">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957076467"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="979060459"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010520" DistinctValues="0.273927">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="979060459"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984770413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984770413"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984770413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014007" DistinctValues="0.364741">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984770413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992373369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000058" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992373369"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992373369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013876" DistinctValues="0.361332">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="992373369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999905250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038404" DistinctValues="0.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999905250"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999994784"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.237683.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.237683.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Row-oriented" DistributionPolicy="Hash" DistributionColumns="14" Keys="47,48,46" PartitionColumns="45" PartitionTypes="l" NumberLeafPartitions="1">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.1043.1.0" Nullable="false" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.20.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.20.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.21.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.21.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="f" Attno="6" Mdid="0.21.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="g" Attno="7" Mdid="0.1082.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="h" Attno="8" Mdid="0.1043.1.0" Nullable="false" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="i" Attno="9" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="j" Attno="10" Mdid="0.1114.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="k" Attno="11" Mdid="0.1043.1.0" Nullable="false" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="l" Attno="12" Mdid="0.1043.1.0" Nullable="false" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="m" Attno="13" Mdid="0.1114.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="n" Attno="14" Mdid="0.21.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="o" Attno="15" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="p" Attno="16" Mdid="0.1043.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="q" Attno="17" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="r" Attno="18" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="s" Attno="19" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="t" Attno="20" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="u" Attno="21" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="v" Attno="22" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="w" Attno="23" Mdid="0.1043.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x" Attno="24" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="y" Attno="25" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="z" Attno="26" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="aa" Attno="27" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="bb" Attno="28" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cc" Attno="29" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="dd" Attno="30" Mdid="0.1043.1.0" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ee" Attno="31" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ff" Attno="32" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gg" Attno="33" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="hh" Attno="34" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ii" Attno="35" Mdid="0.1043.1.0" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="jj" Attno="36" Mdid="0.1043.1.0" Nullable="true" ColWidth="30">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="kk" Attno="37" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ll" Attno="38" Mdid="0.1043.1.0" Nullable="true" ColWidth="50">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="mm" Attno="39" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="nn" Attno="40" Mdid="0.1043.1.0" Nullable="true" ColWidth="50">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="oo" Attno="41" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="pp" Attno="42" Mdid="0.1043.1.0" Nullable="true" ColWidth="50">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="qq" Attno="43" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="rr" Attno="44" Mdid="0.1700.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ss" Attno="45" Mdid="0.20.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tt" Attno="46" Mdid="0.20.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true">
+          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="false"/>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.45" Name="tt" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.014345" DistinctValues="109.905114">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003807" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018599" DistinctValues="142.496792">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001649" DistinctValues="12.636556">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10024"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10523"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10523"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="68569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="68569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002869" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005023" DistinctValues="38.190702">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003476" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016983" DistinctValues="129.132312">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003062" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005556" DistinctValues="42.248464">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007032" DistinctValues="53.466983">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009387" DistinctValues="72.187265">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003862" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025207" DistinctValues="193.851196">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003449" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000152" DistinctValues="1.160609">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004497" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016499" DistinctValues="125.926036">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003283" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017943" DistinctValues="136.951817">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102751"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="266.038462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="138124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="138124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="166226"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="166226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="176565"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="176565"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="188388"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="202239"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="202239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="230832"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005072" DistinctValues="38.855844">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="230832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003062" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017166" DistinctValues="131.519314">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003587" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012356" DistinctValues="94.663304">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="270326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001012" DistinctValues="7.778902">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="270326"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003449" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033582" DistinctValues="258.259559">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012185" DistinctValues="93.352517">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022409" DistinctValues="171.685944">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="319014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="319014"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="335234"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="335234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352511"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000506" DistinctValues="3.874886">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352511"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004580" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033832" DistinctValues="259.202562">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000256" DistinctValues="1.961013">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380623"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002980" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380623"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380623"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="266.038462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380623"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="410654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013714" DistinctValues="105.468495">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="410654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020879" DistinctValues="160.569966">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="450438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="450438"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004194" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="266.038462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="681013"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015546" DistinctValues="119.552279">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="681013"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003145" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019048" DistinctValues="146.486183">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770483"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030824" DistinctValues="237.051631">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770483"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003769" DistinctValues="28.986831">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="806543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027594" DistinctValues="211.410465">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="806543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007918" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003211" DistinctValues="24.603125">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003890" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003788" DistinctValues="29.024872">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899090"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034594" DistinctValues="267.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899090"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899781"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.44" Name="ss" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.015234" DistinctValues="132.664197">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019679" DistinctValues="171.374264">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="4397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10077"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="10077"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="73318"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018731" DistinctValues="161.506714">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="73318"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="88098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002814" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="88098"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="88098"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015189" DistinctValues="130.964680">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="88098"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002952" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000203" DistinctValues="1.748381">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100083"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003118" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000686" DistinctValues="5.911714">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100243"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002814" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000105" DistinctValues="0.906973">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100784"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005259" DistinctValues="45.650025">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022492" DistinctValues="195.226701">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="100961"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003338" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007162" DistinctValues="62.161736">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101491"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018192" DistinctValues="157.377935">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101491"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002759" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101788"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003246" DistinctValues="28.084278">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003476" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000245" DistinctValues="2.119568">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101841"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013230" DistinctValues="114.456680">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="101845"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102061"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008769" DistinctValues="76.359890">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102061"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003035" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026145" DistinctValues="227.678571">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102279"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102929"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="102929"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="160226"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="160226"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="167038"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="167038"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="177462"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="177462"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="190079"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029504" DistinctValues="256.936283">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="190079"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="202287"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002731" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="202287"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="202287"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005409" DistinctValues="47.102179">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="202287"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="204525"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="204525"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="230750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006333" DistinctValues="54.970246">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="230750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003890" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021137" DistinctValues="183.465070">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="236622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003311" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007443" DistinctValues="64.603146">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="256220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="263121"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007498" DistinctValues="65.292632">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="263121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002759" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027415" DistinctValues="238.745830">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="271326"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="301328"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009457" DistinctValues="82.086820">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="301328"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003945" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015091" DistinctValues="130.984692">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="304526"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002842" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010365" DistinctValues="89.966950">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="309629"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="313134"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="313134"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="326823"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="326823"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="349637"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003838" DistinctValues="33.425915">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="349637"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031075" DistinctValues="270.612546">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="352922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="379517"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001140" DistinctValues="9.930404">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="379517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003256" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033773" DistinctValues="294.108057">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="380415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="407011"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020340" DistinctValues="177.126170">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="407011"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003862" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014574" DistinctValues="126.912292">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="426426"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="440337"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="440337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="520185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002961" DistinctValues="25.783400">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="520185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003697" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031952" DistinctValues="278.255061">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="532095"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="660628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.019315" DistinctValues="168.205133">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="660628"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003007" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015598" DistinctValues="135.833328">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="721219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770149"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="770149"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028099" DistinctValues="243.087732">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="802614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007946" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003105" DistinctValues="26.860022">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="880364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003862" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003709" DistinctValues="32.090707">
+          <dxl:LowerBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="888955"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034913" DistinctValues="305.038462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="899629"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.37" Name="ll" Width="9.000000" NullFreq="0.000000" NdvRemain="2925.000000" FreqRemain="0.488137" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.464851" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH0JBRy1Ib2hlbmxvaGUtUmFpZmZlaXNlbiBlRw==" LintValue="43836204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH0JBRy1Ib2hlbmxvaGUtUmFpZmZlaXNlbiBlRw==" LintValue="43836204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001214" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0Jsw7ZtZXIsTWFuZnJlZA==" LintValue="40928174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0Jsw7ZtZXIsTWFuZnJlZA==" LintValue="40928174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001324" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEERhaG0sTWljaGFlbA==" LintValue="272204652"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEERhaG0sTWljaGFlbA==" LintValue="272204652"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001324" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0V3aWdtYW5uLEx1ZGdlcg==" LintValue="404898684"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAE0V3aWdtYW5uLEx1ZGdlcg==" LintValue="404898684"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUh1ZyxUaG9yc3RlbiBXb2xmZ2FuZw==" LintValue="60351476"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGUh1ZyxUaG9yc3RlbiBXb2xmZ2FuZw==" LintValue="60351476"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002014" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUthc3RlbmhvbHosRGFuaWVs" LintValue="270107516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUthc3RlbmhvbHosRGFuaWVs" LintValue="270107516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUtlbGxuZXIsQW5kcmU=" LintValue="346071974"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEUtlbGxuZXIsQW5kcmU=" LintValue="346071974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEExhbmcsVWxscmljaA==" LintValue="25494380"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEExhbmcsVWxscmljaA==" LintValue="25494380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkxpY2h0bmVyLEhlaWtl" LintValue="866165756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEkxpY2h0bmVyLEhlaWtl" LintValue="866165756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008415" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH01ha2xlciBBdXNnZXNjaGllZGVuIEtSQVZBRw==" LintValue="837608238"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAH01ha2xlciBBdXNnZXNjaGllZGVuIEtSQVZBRw==" LintValue="837608238"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001407" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk11aHIsRXJ3aW4=" LintValue="827179900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADk11aHIsRXJ3aW4=" LintValue="827179900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEE3DtmxsZXIsUm9sZg==" LintValue="581747574"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEE3DtmxsZXIsUm9sZg==" LintValue="581747574"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFk3Dtm5jaG1leWVyLEpvY2hlbg==" LintValue="54117164"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFk3Dtm5jaG1leWVyLEpvY2hlbg==" LintValue="54117164"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001435" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFU9iZXJtZWllcixTdGVwaGFu" LintValue="296076094"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFU9iZXJtZWllcixTdGVwaGFu" LintValue="296076094"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001628" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlIrViBBbGxnZW1laW5lIFZlcnNpY2hlcnVuZyBBRw==" LintValue="430236606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002124" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlNWRyBBc3Nlay1TZXJ2Lldlc3RmYWxlbi1MaXBwZQ==" LintValue="390636470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIlNWRyBBc3Nlay1TZXJ2Lldlc3RmYWxlbi1MaXBwZQ==" LintValue="390636470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003062" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1NhbW93LEFuZHJl" LintValue="916497332"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1NhbW93LEFuZHJl" LintValue="916497332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001186" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RhbWFzLFBldGVy" LintValue="945963966"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD1RhbWFzLFBldGVy" LintValue="945963966"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002207" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIVZCIFZlcnMuRGllbnN0IEJodi1DdXhsLiBHbWJI" LintValue="45417332"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAIVZCIFZlcnMuRGllbnN0IEJodi1DdXhsLiBHbWJI" LintValue="45417332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002621" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZEIFPDvGQtV2VzdCAoQWd0LURpcmVrdCk=" LintValue="741942260"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZEIFPDvGQtV2VzdCAoQWd0LURpcmVrdCk=" LintValue="741942260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAHVZvbGtzYmFuayBNaXR0ZWxoZXNzZW4gZUc=" LintValue="580182958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEFZvbGtzYmFuayBlRw==" LintValue="844606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001435" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEldlaXNzLFdhbGRlbWFy" LintValue="859456510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEldlaXNzLFdhbGRlbWFy" LintValue="859456510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEldpbmtsZXIsU2lsdmlh" LintValue="31466428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEldpbmtsZXIsU2lsdmlh" LintValue="31466428"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.36" Name="kk" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.464851" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032686" DistinctValues="203.733333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="44591"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032686" DistinctValues="204.733333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="44591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="64574"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001202" DistinctValues="7.491141">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="64574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002207" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95352"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031484" DistinctValues="196.242192">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="901630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002621" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="901630"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="901630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012033" DistinctValues="74.637242">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="901630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001407" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902867"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902867"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020652" DistinctValues="128.096091">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="902867"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="904990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032686" DistinctValues="204.733333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="904990"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="908504"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009588" DistinctValues="58.885267">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="908504"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002014" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012010" DistinctValues="73.759250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="911204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="914586"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="914586"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="914586"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003036" DistinctValues="18.647001">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="914586"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915441"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001269" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915441"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915441"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001907" DistinctValues="11.711625">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915441"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915978"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001766" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915978"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915978"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006144" DistinctValues="37.730190">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="917708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009900" DistinctValues="61.099095">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="917708"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="920409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="920409"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="920409"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002236" DistinctValues="13.798759">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="920409"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921019"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921019"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017992" DistinctValues="111.046079">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="921019"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="925928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001186" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="925928"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="925928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002558" DistinctValues="15.789400">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="925928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="926626"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017585" DistinctValues="109.069080">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="926626"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="931129"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003062" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="931129"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="931129"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015086" DistinctValues="93.567368">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="931129"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934992"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001297" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934992"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934992"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000016" DistinctValues="0.096886">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934992"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015206" DistinctValues="94.316140">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="934996"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="938454"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="938454"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="938454"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007634" DistinctValues="47.348993">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="938454"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001435" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940190"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009846" DistinctValues="61.068200">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="940190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="942429"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011480" DistinctValues="70.499425">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="942429"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="945972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001324" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="945972"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="945972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000645" DistinctValues="3.959748">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="945972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946171"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001214" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946171"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946171"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000006" DistinctValues="0.039796">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946171"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946173"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000993" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946173"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946173"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007261" DistinctValues="44.591931">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="946173"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="948414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="948414"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="948414"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013294" DistinctValues="81.642433">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="948414"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="952517"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021948" DistinctValues="136.133023">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="952517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001435" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957995"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957995"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006278" DistinctValues="38.941301">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="957995"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="959562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008415" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="959562"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="959562"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004459" DistinctValues="27.659010">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="959562"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960675"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000029" DistinctValues="0.178593">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960675"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001324" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960687"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960687"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007947" DistinctValues="49.291793">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="960687"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="963999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000993" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="963999"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="963999"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024710" DistinctValues="153.262947">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="963999"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="974297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018836" DistinctValues="116.829379">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="974297"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="981301"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001131" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="981301"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="981301"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.009765" DistinctValues="60.566458">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="981301"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984932"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000966" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984932"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984932"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004085" DistinctValues="25.337497">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="984932"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="986451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032686" DistinctValues="204.733333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="986451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999975"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032686" DistinctValues="204.733333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999975"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999986"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.29" Name="dd" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.106306" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTE=" LintValue="161096236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015049" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTI=" LintValue="161104428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000110" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTM=" LintValue="161112620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.144643" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTQ=" LintValue="161120812"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.732893" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABTU=" LintValue="161129004"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.28" Name="cc" Width="10.000000" NullFreq="0.000000" NdvRemain="3441.000000" FreqRemain="0.783976" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.006346" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkJhZCBOZXVlbmFoci1BaHJ3ZWlsZXI=" LintValue="27411262"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGkJhZCBOZXVlbmFoci1BaHJ3ZWlsZXI=" LintValue="27411262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.020195" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004414" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006732" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADURhcm1zdGFkdA==" LintValue="942048118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADURhcm1zdGFkdA==" LintValue="942048118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008415" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011063" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004442" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEZyZWlidXJnIGltIEJyZWlzZ2F1" LintValue="840868860"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAGEZyZWlidXJnIGltIEJyZWlzZ2F1" LintValue="840868860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008939" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dpZcOfZW4=" LintValue="281658366"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0dpZcOfZW4=" LintValue="281658366"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023230" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005049" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004304" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUthcmxzcnVoZQ==" LintValue="157590374"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUthcmxzcnVoZQ==" LintValue="157590374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004111" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkthc3NlbA==" LintValue="809861996"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkthc3NlbA==" LintValue="809861996"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014733" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004194" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACExhaHI=" LintValue="572670820"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACExhaHI=" LintValue="572670820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF0xhbmRhdSBpbiBkZXIgUGZhbHo=" LintValue="406012774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAF0xhbmRhdSBpbiBkZXIgUGZhbHo=" LintValue="406012774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004249" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haW56" LintValue="280707940"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haW56" LintValue="280707940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008001" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008691" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEE9iZXJ0c2hhdXNlbg==" LintValue="845005694"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAEE9iZXJ0c2hhdXNlbg==" LintValue="845005694"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005849" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBhZGVyYm9ybg==" LintValue="764527478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBhZGVyYm9ybg==" LintValue="764527478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007394" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015974" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005049" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlR1dHRsaW5nZW4=" LintValue="305775484"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADlR1dHRsaW5nZW4=" LintValue="305775484"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017188" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.21" Name="v" Width="10.000000" NullFreq="0.038652" NdvRemain="7309.000000" FreqRemain="0.843845" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.016664" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJlcmxpbg==" LintValue="556647228"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002455" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUJpZWxlZmVsZA==" LintValue="17335142"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUJpZWxlZmVsZA==" LintValue="17335142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001959" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0JvY2hvbHQ=" LintValue="840074230"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0JvY2hvbHQ=" LintValue="840074230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002869" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEJvbm4=" LintValue="328844132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002124" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJyZW1lbg==" LintValue="136954748"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACkJyZW1lbg==" LintValue="136954748"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003752" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0RyZXNkZW4=" LintValue="328057774"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002069" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0TDvHNzZWxkb3Jm" LintValue="613991398"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAD0TDvHNzZWxkb3Jm" LintValue="613991398"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001876" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUVzc2Vu" LintValue="39175022"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUVzc2Vu" LintValue="39175022"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004083" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFUZyYW5rZnVydCBhbSBNYWlu" LintValue="3261422"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006152" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0hhbWJ1cmc=" LintValue="113828708"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002014" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEhhbW0=" LintValue="52536172"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEhhbW0=" LintValue="52536172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002538" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADEhhbm5vdmVy" LintValue="326255420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002869" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUthcmxzcnVoZQ==" LintValue="157590374"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADUthcmxzcnVoZQ==" LintValue="157590374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001821" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEtpZWw=" LintValue="16876396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACEtpZWw=" LintValue="16876396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACUvDtmxu" LintValue="6931236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003559" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0xlaXB6aWc=" LintValue="307553068"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAC0xlaXB6aWc=" LintValue="307553068"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001793" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haW56" LintValue="280707940"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACU1haW56" LintValue="280707940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003504" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE1hbm5oZWlt" LintValue="842638206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004663" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5jaGVu" LintValue="327795500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002731" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADE3DvG5zdGVy" LintValue="335430444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003228" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBhZGVyYm9ybg==" LintValue="764527478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBhZGVyYm9ybg==" LintValue="764527478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001793" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBmb3J6aGVpbQ==" LintValue="999924734"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVBmb3J6aGVpbQ==" LintValue="999924734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001904" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAAFFNjaHfDpGJpc2NoIEhhbGw=" LintValue="573670388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004911" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVN0dXR0Z2FydA==" LintValue="741507956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028941" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAADVdpZXNiYWRlbg==" LintValue="545899310"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.20" Name="u" Width="5.000000" NullFreq="0.038652" NdvRemain="7089.000000" FreqRemain="0.902113" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.001490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAABA==" LintValue="159678980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003256" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTAwMDAw" LintValue="759563046"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTAwMDAw" LintValue="759563046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003725" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwNjIz" LintValue="752771878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTEwNjIz" LintValue="752771878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000938" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzMTU0" LintValue="742818670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTMzMTU0" LintValue="742818670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001324" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3Njcx" LintValue="215884590"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM3Njcx" LintValue="215884590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM4NzIz" LintValue="769549158"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTM4NzIz" LintValue="769549158"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001021" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQxODEy" LintValue="1063666478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQxODEy" LintValue="1063666478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ2NDQ2" LintValue="509002534"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ2NDQ2" LintValue="509002534"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ3NTMz" LintValue="265708398"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTQ3NTMz" LintValue="265708398"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzNDc0" LintValue="802587438"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTUzNDc0" LintValue="802587438"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU5MjY5" LintValue="1070539558"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU5MjY5" LintValue="1070539558"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU5MzAy" LintValue="1045316454"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU5MzAy" LintValue="1045316454"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001048" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU5OTI5" LintValue="1055335270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTU5OTI5" LintValue="1055335270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026320" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1MTg5" LintValue="474424166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001076" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1NzE5" LintValue="509551470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY1NzE5" LintValue="509551470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001214" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY3MzQ2" LintValue="256820070"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTY3MzQ2" LintValue="256820070"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001545" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcyMzM2" LintValue="1070515054"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTcyMzM2" LintValue="1070515054"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001931" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTIz" LintValue="265708390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTY0" LintValue="248939366"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0NTY0" LintValue="248939366"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000993" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0ODg5" LintValue="224863014"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc0ODg5" LintValue="224863014"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000993" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2NjQ2" LintValue="509526822"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2NjQ2" LintValue="509526822"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2ODI5" LintValue="535241510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc2ODI5" LintValue="535241510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000966" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3ODE1" LintValue="258384686"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3ODE1" LintValue="258384686"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001352" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTc3OTMz" LintValue="266756974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000966" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTk3OTgw" LintValue="241566564"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACTk3OTgw" LintValue="241566564"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.13" Name="n" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000552" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="-99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="-99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.879104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000717" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000055" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="60"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000110" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="63"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033824" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="74"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000138" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016416" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="80"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016222" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="81"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001104" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001159" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="83"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000028" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000138" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="87"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000276" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="88"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000193" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="89"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005987" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000883" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="91"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002014" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="92"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016747" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="93"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012305" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="94"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000166" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="95"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000138" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003669" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000469" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007559" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="99"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.12" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.275755" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ALr3gKWaAAA=" DoubleValue="170035624000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ALr3gKWaAAA=" DoubleValue="170035624000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032064" DistinctValues="196.368421">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ALr3gKWaAAA=" DoubleValue="170035624000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wN6TqQeeAAA=" DoubleValue="173755747000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030312" DistinctValues="184.690510">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wN6TqQeeAAA=" DoubleValue="173755747000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFXgfDeqAAA=" DoubleValue="187155295000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001931" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFXgfDeqAAA=" DoubleValue="187155295000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFXgfDeqAAA=" DoubleValue="187155295000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001553" DistinctValues="9.462896">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFXgfDeqAAA=" DoubleValue="187155295000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QO40VteqAAA=" DoubleValue="187841841000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011532" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QO40VteqAAA=" DoubleValue="187841841000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QO40VteqAAA=" DoubleValue="187841841000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000199" DistinctValues="1.215015">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QO40VteqAAA=" DoubleValue="187841841000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AHJq3OuqAAA=" DoubleValue="187929992000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.013188" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AHJq3OuqAAA=" DoubleValue="187929992000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AHJq3OuqAAA=" DoubleValue="187929992000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008207" DistinctValues="50.006243">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AHJq3OuqAAA=" DoubleValue="187929992000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QISJMwCrAAA=" DoubleValue="188017353000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.012553" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QISJMwCrAAA=" DoubleValue="188017353000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QISJMwCrAAA=" DoubleValue="188017353000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023857" DistinctValues="145.362179">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QISJMwCrAAA=" DoubleValue="188017353000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QHsEVDurAAA=" DoubleValue="188271301000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031397" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QHsEVDurAAA=" DoubleValue="188271301000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QHsEVDurAAA=" DoubleValue="188271301000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006732" DistinctValues="40.599545">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QHsEVDurAAA=" DoubleValue="188271301000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMigCfGrAAA=" DoubleValue="189051737000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005683" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMigCfGrAAA=" DoubleValue="189051737000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMigCfGrAAA=" DoubleValue="189051737000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011918" DistinctValues="71.874892">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMigCfGrAAA=" DoubleValue="189051737000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AM99uTKtAAA=" DoubleValue="190433372000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AM99uTKtAAA=" DoubleValue="190433372000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AM99uTKtAAA=" DoubleValue="190433372000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002980" DistinctValues="17.973938">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AM99uTKtAAA=" DoubleValue="190433372000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMJuK4OtAAA=" DoubleValue="190778881000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001490" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMJuK4OtAAA=" DoubleValue="190778881000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMJuK4OtAAA=" DoubleValue="190778881000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010433" DistinctValues="62.920046">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMJuK4OtAAA=" DoubleValue="190778881000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJwhx5yuAAA=" DoubleValue="191988379000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032064" DistinctValues="197.368421">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJwhx5yuAAA=" DoubleValue="191988379000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QPFtm3G8AAA=" DoubleValue="207196125000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032064" DistinctValues="197.368421">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QPFtm3G8AAA=" DoubleValue="207196125000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gNuB8gbYAAA=" DoubleValue="237524350000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016553" DistinctValues="101.373835">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gNuB8gbYAAA=" DoubleValue="237524350000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFqMA3DkAAA=" DoubleValue="251169747000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003780" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFqMA3DkAAA=" DoubleValue="251169747000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFqMA3DkAAA=" DoubleValue="251169747000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.015511" DistinctValues="94.994586">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wFqMA3DkAAA=" DoubleValue="251169747000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wKJzJxHwAAA=" DoubleValue="263956467000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.011973" DistinctValues="72.950485">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wKJzJxHwAAA=" DoubleValue="263956467000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMZRGhv5AAA=" DoubleValue="273894801000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001793" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMZRGhv5AAA=" DoubleValue="273894801000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMZRGhv5AAA=" DoubleValue="273894801000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014367" DistinctValues="87.538257">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QMZRGhv5AAA=" DoubleValue="273894801000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QFt6xPMDAQA=" DoubleValue="285820485000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001986" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QFt6xPMDAQA=" DoubleValue="285820485000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QFt6xPMDAQA=" DoubleValue="285820485000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005725" DistinctValues="34.879679">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QFt6xPMDAQA=" DoubleValue="285820485000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gHKmIUYIAQA=" DoubleValue="290572282000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014198" DistinctValues="86.508890">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gHKmIUYIAQA=" DoubleValue="290572282000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AD6e54sTAQA=" DoubleValue="302966584000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AD6e54sTAQA=" DoubleValue="302966584000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AD6e54sTAQA=" DoubleValue="302966584000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016282" DistinctValues="99.208762">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AD6e54sTAQA=" DoubleValue="302966584000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gA1iUnkgAQA=" DoubleValue="317180422000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002842" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gA1iUnkgAQA=" DoubleValue="317180422000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gA1iUnkgAQA=" DoubleValue="317180422000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001584" DistinctValues="9.650769">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gA1iUnkgAQA=" DoubleValue="317180422000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wM7UQLshAQA=" DoubleValue="318563107000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031963" DistinctValues="195.746549">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wM7UQLshAQA=" DoubleValue="318563107000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gJNXBVQ6AQA=" DoubleValue="345607518000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001462" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gJNXBVQ6AQA=" DoubleValue="345607518000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gJNXBVQ6AQA=" DoubleValue="345607518000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000102" DistinctValues="0.621872">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gJNXBVQ6AQA=" DoubleValue="345607518000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ADd0Bmg6AQA=" DoubleValue="345693436000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000574" DistinctValues="3.495445">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ADd0Bmg6AQA=" DoubleValue="345693436000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJRFEsw6AQA=" DoubleValue="346123131000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001655" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJRFEsw6AQA=" DoubleValue="346123131000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJRFEsw6AQA=" DoubleValue="346123131000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023648" DistinctValues="144.086799">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJRFEsw6AQA=" DoubleValue="346123131000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJ/JGuhKAQA=" DoubleValue="363835719000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001986" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJ/JGuhKAQA=" DoubleValue="363835719000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJ/JGuhKAQA=" DoubleValue="363835719000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007843" DistinctValues="47.786177">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="wJ/JGuhKAQA=" DoubleValue="363835719000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QDCS1T9QAQA=" DoubleValue="369710073000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000993" DistinctValues="6.051561">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QDCS1T9QAQA=" DoubleValue="369710073000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANZOqMxQAQA=" DoubleValue="370314904000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003531" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANZOqMxQAQA=" DoubleValue="370314904000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANZOqMxQAQA=" DoubleValue="370314904000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002130" DistinctValues="12.977583">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANZOqMxQAQA=" DoubleValue="370314904000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QAkrp/pRAQA=" DoubleValue="371611965000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003780" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QAkrp/pRAQA=" DoubleValue="371611965000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QAkrp/pRAQA=" DoubleValue="371611965000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028941" DistinctValues="176.339277">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QAkrp/pRAQA=" DoubleValue="371611965000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gLRtKgJiAQA=" DoubleValue="389236418000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026420" DistinctValues="161.800585">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gLRtKgJiAQA=" DoubleValue="389236418000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QEIDxEtzAQA=" DoubleValue="408244225000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001711" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QEIDxEtzAQA=" DoubleValue="408244225000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QEIDxEtzAQA=" DoubleValue="408244225000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005644" DistinctValues="34.567836">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QEIDxEtzAQA=" DoubleValue="408244225000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gCmHRf12AQA=" DoubleValue="412305142000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032064" DistinctValues="197.368421">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gCmHRf12AQA=" DoubleValue="412305142000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gOcFxR6PAQA=" DoubleValue="438837294000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026725" DistinctValues="162.833100">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gOcFxR6PAQA=" DoubleValue="438837294000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gIgRJwueAQA=" DoubleValue="455245714000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001545" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gIgRJwueAQA=" DoubleValue="455245714000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gIgRJwueAQA=" DoubleValue="455245714000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000845" DistinctValues="5.145585">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gIgRJwueAQA=" DoubleValue="455245714000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gMTK4IOeAQA=" DoubleValue="455764226000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002042" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gMTK4IOeAQA=" DoubleValue="455764226000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gMTK4IOeAQA=" DoubleValue="455764226000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004495" DistinctValues="27.389736">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="gMTK4IOeAQA=" DoubleValue="455764226000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AD2vfgahAQA=" DoubleValue="458524244000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023634" DistinctValues="144.738002">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="AD2vfgahAQA=" DoubleValue="458524244000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANjibcSxAQA=" DoubleValue="476932192000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001517" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANjibcSxAQA=" DoubleValue="476932192000000.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANjibcSxAQA=" DoubleValue="476932192000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008431" DistinctValues="51.630419">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ANjibcSxAQA=" DoubleValue="476932192000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QL7WSr23AQA=" DoubleValue="483498609000000.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032064" DistinctValues="197.368421">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="QL7WSr23AQA=" DoubleValue="483498609000000.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yEd+ZaTMAQA=" DoubleValue="506481426188232.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001738" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yEd+ZaTMAQA=" DoubleValue="506481426188232.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yEd+ZaTMAQA=" DoubleValue="506481426188232.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032064" DistinctValues="196.368421">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="yEd+ZaTMAQA=" DoubleValue="506481426188232.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ZLAjHMLgAQA=" DoubleValue="528599277088868.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.014096" DistinctValues="86.324769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="ZLAjHMLgAQA=" DoubleValue="528599277088868.000000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="tYpltOjnAQA=" DoubleValue="536461621693109.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002428" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="tYpltOjnAQA=" DoubleValue="536461621693109.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="tYpltOjnAQA=" DoubleValue="536461621693109.000000"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017969" DistinctValues="110.043652">
+          <dxl:LowerBound Closed="false" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="tYpltOjnAQA=" DoubleValue="536461621693109.000000"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.1114.1.0" IsNull="false" IsByValue="true" Value="BfqeRwbxAQA=" DoubleValue="546484250409477.000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.5" Name="f" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.002601" DistinctValues="0.634615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027369" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007802" DistinctValues="1.903846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031562" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="3.538462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037990" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005202" DistinctValues="0.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032583" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005202" DistinctValues="0.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024361" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033328" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025630" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030155" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006936" DistinctValues="1.025641">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022513" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003468" DistinctValues="0.512821">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036059" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027920" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030045" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030155" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.047150" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032831" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.017630" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005202" DistinctValues="0.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026237" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005202" DistinctValues="0.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="3.538462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.034128" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="407"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="3.538462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="407"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005675" DistinctValues="1.384615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022154" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004729" DistinctValues="1.153846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022154" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005202" DistinctValues="0.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024775" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005202" DistinctValues="0.769231">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008323" DistinctValues="2.030769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018981" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002081" DistinctValues="0.507692">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="3.538462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.028113" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026789" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.038901" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="2.538462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010403" DistinctValues="3.538462">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="780"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="808"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.237683.1.0.4" Name="e" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.002663" DistinctValues="0.644231">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026955" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007989" DistinctValues="1.932692">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032362" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="3.576923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036694" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005326" DistinctValues="0.788462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.031341" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005326" DistinctValues="0.788462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024665" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032638" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025493" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030265" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007102" DistinctValues="1.051282">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.022954" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003551" DistinctValues="0.525641">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.036252" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026817" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005326" DistinctValues="0.788462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.029824" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005326" DistinctValues="0.788462">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="3.576923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.030127" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.047481" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.032252" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007102" DistinctValues="1.051282">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.016857" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003551" DistinctValues="0.525641">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.025879" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.008454" DistinctValues="2.045177">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.033604" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002198" DistinctValues="0.531746">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="403"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="3.576923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="403"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="407"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="3.576923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="407"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006214" DistinctValues="1.503205">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.023506" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004439" DistinctValues="1.073718">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.021409" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.024775" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.018678" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.027865" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.026624" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.037714" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="2.576923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010653" DistinctValues="3.576923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="780"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" IsNull="false" IsByValue="true" Value="808"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.20.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.20.1.0"/>
+        <dxl:Ident ColId="4" ColName="d" TypeMdid="0.21.1.0"/>
+        <dxl:Ident ColId="5" ColName="e" TypeMdid="0.21.1.0"/>
+        <dxl:Ident ColId="7" ColName="g" TypeMdid="0.1082.1.0"/>
+        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="j" TypeMdid="0.1114.1.0"/>
+        <dxl:Ident ColId="13" ColName="m" TypeMdid="0.1114.1.0"/>
+        <dxl:Ident ColId="14" ColName="n" TypeMdid="0.21.1.0"/>
+        <dxl:Ident ColId="15" ColName="o" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="37" ColName="kk" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="39" ColName="mm" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="41" ColName="oo" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="45" ColName="ss" TypeMdid="0.20.1.0"/>
+        <dxl:Ident ColId="46" ColName="tt" TypeMdid="0.20.1.0"/>
+        <dxl:Ident ColId="20" ColName="t" TypeMdid="0.1043.1.0"/>
+        <dxl:Ident ColId="21" ColName="u" TypeMdid="0.1043.1.0"/>
+        <dxl:Ident ColId="22" ColName="v" TypeMdid="0.1043.1.0"/>
+        <dxl:Ident ColId="19" ColName="s" TypeMdid="0.1043.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.2064.1.0">
+            <dxl:Ident ColId="10" ColName="j" TypeMdid="0.1114.1.0"/>
+            <dxl:ScalarSubquery ColId="76">
+              <dxl:LogicalGroupBy>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="76" Alias="max">
+                    <dxl:AggFunc AggMdid="0.2126.1.0" AggDistinct="false" AggStage="Normal">
+                      <dxl:Ident ColId="66" ColName="q" TypeMdid="0.1114.1.0"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:LogicalGet>
+                  <dxl:TableDescriptor Mdid="0.237712.1.0" TableName="bar">
+                    <dxl:Columns>
+                      <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="52" Attno="3" ColName="c" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                      <dxl:Column ColId="53" Attno="4" ColName="d" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                      <dxl:Column ColId="54" Attno="5" ColName="e" TypeMdid="0.21.1.0"/>
+                      <dxl:Column ColId="55" Attno="6" ColName="f" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="56" Attno="7" ColName="g" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                      <dxl:Column ColId="57" Attno="8" ColName="h" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                      <dxl:Column ColId="58" Attno="9" ColName="i" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                      <dxl:Column ColId="59" Attno="10" ColName="j" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                      <dxl:Column ColId="60" Attno="11" ColName="k" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                      <dxl:Column ColId="61" Attno="12" ColName="l" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                      <dxl:Column ColId="62" Attno="13" ColName="m" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                      <dxl:Column ColId="63" Attno="14" ColName="n" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="64" Attno="15" ColName="o" TypeMdid="0.1700.1.0"/>
+                      <dxl:Column ColId="65" Attno="16" ColName="p" TypeMdid="0.1082.1.0"/>
+                      <dxl:Column ColId="66" Attno="17" ColName="q" TypeMdid="0.1114.1.0"/>
+                      <dxl:Column ColId="67" Attno="18" ColName="r" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                      <dxl:Column ColId="68" Attno="19" ColName="s" TypeMdid="0.1043.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="69" Attno="20" ColName="t" TypeMdid="0.1043.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="70" Attno="21" ColName="u" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                      <dxl:Column ColId="71" Attno="22" ColName="v" TypeMdid="0.21.1.0"/>
+                      <dxl:Column ColId="72" Attno="23" ColName="w" TypeMdid="0.1114.1.0"/>
+                      <dxl:Column ColId="73" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="74" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="75" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:LogicalGet>
+              </dxl:LogicalGroupBy>
+            </dxl:ScalarSubquery>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:CoerceViaIO TypeMdid="0.23.1.0" TypeModification="-1" CoercionForm="1" Location="0">
+              <dxl:Ident ColId="12" ColName="l" TypeMdid="0.1043.1.0"/>
+            </dxl:CoerceViaIO>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.237683.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.20.1.0"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.20.1.0"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.21.1.0"/>
+              <dxl:Column ColId="5" Attno="5" ColName="e" TypeMdid="0.21.1.0"/>
+              <dxl:Column ColId="6" Attno="6" ColName="f" TypeMdid="0.21.1.0"/>
+              <dxl:Column ColId="7" Attno="7" ColName="g" TypeMdid="0.1082.1.0"/>
+              <dxl:Column ColId="8" Attno="8" ColName="h" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="9" Attno="9" ColName="i" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="10" Attno="10" ColName="j" TypeMdid="0.1114.1.0"/>
+              <dxl:Column ColId="11" Attno="11" ColName="k" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="12" Attno="12" ColName="l" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="13" Attno="13" ColName="m" TypeMdid="0.1114.1.0"/>
+              <dxl:Column ColId="14" Attno="14" ColName="n" TypeMdid="0.21.1.0"/>
+              <dxl:Column ColId="15" Attno="15" ColName="o" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="16" Attno="16" ColName="p" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="17" Attno="17" ColName="q" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="18" Attno="18" ColName="r" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="19" Attno="19" ColName="s" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="20" Attno="20" ColName="t" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="21" Attno="21" ColName="u" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="22" Attno="22" ColName="v" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="23" Attno="23" ColName="w" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="24" Attno="24" ColName="x" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="25" Attno="25" ColName="y" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="26" Attno="26" ColName="z" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="27" Attno="27" ColName="aa" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="28" Attno="28" ColName="bb" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="29" Attno="29" ColName="cc" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="30" Attno="30" ColName="dd" TypeMdid="0.1043.1.0" ColWidth="1"/>
+              <dxl:Column ColId="31" Attno="31" ColName="ee" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="32" Attno="32" ColName="ff" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="33" Attno="33" ColName="gg" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="34" Attno="34" ColName="hh" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="35" Attno="35" ColName="ii" TypeMdid="0.1043.1.0" ColWidth="10"/>
+              <dxl:Column ColId="36" Attno="36" ColName="jj" TypeMdid="0.1043.1.0" ColWidth="30"/>
+              <dxl:Column ColId="37" Attno="37" ColName="kk" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="38" Attno="38" ColName="ll" TypeMdid="0.1043.1.0" ColWidth="50"/>
+              <dxl:Column ColId="39" Attno="39" ColName="mm" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="40" Attno="40" ColName="nn" TypeMdid="0.1043.1.0" ColWidth="50"/>
+              <dxl:Column ColId="41" Attno="41" ColName="oo" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="42" Attno="42" ColName="pp" TypeMdid="0.1043.1.0" ColWidth="50"/>
+              <dxl:Column ColId="43" Attno="43" ColName="qq" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="44" Attno="44" ColName="rr" TypeMdid="0.1700.1.0"/>
+              <dxl:Column ColId="45" Attno="45" ColName="ss" TypeMdid="0.20.1.0"/>
+              <dxl:Column ColId="46" Attno="46" ColName="tt" TypeMdid="0.20.1.0"/>
+              <dxl:Column ColId="47" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="48" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="49" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="0">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.927517" Rows="1.000000" Width="108"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="3" Alias="d">
+            <dxl:Ident ColId="3" ColName="d" TypeMdid="0.21.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="4" Alias="e">
+            <dxl:Ident ColId="4" ColName="e" TypeMdid="0.21.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="6" Alias="g">
+            <dxl:Ident ColId="6" ColName="g" TypeMdid="0.1082.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="i">
+            <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="j">
+            <dxl:Ident ColId="9" ColName="j" TypeMdid="0.1114.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="12" Alias="m">
+            <dxl:Ident ColId="12" ColName="m" TypeMdid="0.1114.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="13" Alias="n">
+            <dxl:Ident ColId="13" ColName="n" TypeMdid="0.21.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="14" Alias="o">
+            <dxl:Ident ColId="14" ColName="o" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="36" Alias="kk">
+            <dxl:Ident ColId="36" ColName="kk" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="38" Alias="mm">
+            <dxl:Ident ColId="38" ColName="mm" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="40" Alias="oo">
+            <dxl:Ident ColId="40" ColName="oo" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="44" Alias="ss">
+            <dxl:Ident ColId="44" ColName="ss" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="45" Alias="tt">
+            <dxl:Ident ColId="45" ColName="tt" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="19" Alias="t">
+            <dxl:Ident ColId="19" ColName="t" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="20" Alias="u">
+            <dxl:Ident ColId="20" ColName="u" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="21" Alias="v">
+            <dxl:Ident ColId="21" ColName="v" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="18" Alias="s">
+            <dxl:Ident ColId="18" ColName="s" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.927115" Rows="1.000000" Width="108"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="3" Alias="d">
+              <dxl:Ident ColId="3" ColName="d" TypeMdid="0.21.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="4" Alias="e">
+              <dxl:Ident ColId="4" ColName="e" TypeMdid="0.21.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="6" Alias="g">
+              <dxl:Ident ColId="6" ColName="g" TypeMdid="0.1082.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="i">
+              <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="j">
+              <dxl:Ident ColId="9" ColName="j" TypeMdid="0.1114.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="12" Alias="m">
+              <dxl:Ident ColId="12" ColName="m" TypeMdid="0.1114.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="13" Alias="n">
+              <dxl:Ident ColId="13" ColName="n" TypeMdid="0.21.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="14" Alias="o">
+              <dxl:Ident ColId="14" ColName="o" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="36" Alias="kk">
+              <dxl:Ident ColId="36" ColName="kk" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="38" Alias="mm">
+              <dxl:Ident ColId="38" ColName="mm" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="40" Alias="oo">
+              <dxl:Ident ColId="40" ColName="oo" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="44" Alias="ss">
+              <dxl:Ident ColId="44" ColName="ss" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="45" Alias="tt">
+              <dxl:Ident ColId="45" ColName="tt" TypeMdid="0.20.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="t">
+              <dxl:Ident ColId="19" ColName="t" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="u">
+              <dxl:Ident ColId="20" ColName="u" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="21" Alias="v">
+              <dxl:Ident ColId="21" ColName="v" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="s">
+              <dxl:Ident ColId="18" ColName="s" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.2064.1.0">
+              <dxl:Ident ColId="9" ColName="j" TypeMdid="0.1114.1.0"/>
+              <dxl:SubPlan TypeMdid="0.1114.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList/>
+                <dxl:Materialize Eager="true">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000501" Rows="3.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="75" Alias="max">
+                      <dxl:Ident ColId="75" ColName="max" TypeMdid="0.1114.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000493" Rows="3.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="75" Alias="max">
+                        <dxl:Ident ColId="75" ColName="max" TypeMdid="0.1114.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="75" Alias="max">
+                          <dxl:AggFunc AggMdid="0.2126.1.0" AggDistinct="false" AggStage="Final">
+                            <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.1114.1.0"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="76" Alias="ColRef_0076">
+                            <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.1114.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns/>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="76" Alias="ColRef_0076">
+                              <dxl:AggFunc AggMdid="0.2126.1.0" AggDistinct="false" AggStage="Partial">
+                                <dxl:Ident ColId="65" ColName="q" TypeMdid="0.1114.1.0"/>
+                              </dxl:AggFunc>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="65" Alias="q">
+                                <dxl:Ident ColId="65" ColName="q" TypeMdid="0.1114.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.237712.1.0" TableName="bar">
+                              <dxl:Columns>
+                                <dxl:Column ColId="49" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="50" Attno="2" ColName="b" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="51" Attno="3" ColName="c" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                <dxl:Column ColId="52" Attno="4" ColName="d" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                <dxl:Column ColId="53" Attno="5" ColName="e" TypeMdid="0.21.1.0"/>
+                                <dxl:Column ColId="54" Attno="6" ColName="f" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="55" Attno="7" ColName="g" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="56" Attno="8" ColName="h" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                <dxl:Column ColId="57" Attno="9" ColName="i" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                <dxl:Column ColId="58" Attno="10" ColName="j" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                <dxl:Column ColId="59" Attno="11" ColName="k" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                                <dxl:Column ColId="60" Attno="12" ColName="l" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                                <dxl:Column ColId="61" Attno="13" ColName="m" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                                <dxl:Column ColId="62" Attno="14" ColName="n" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="63" Attno="15" ColName="o" TypeMdid="0.1700.1.0"/>
+                                <dxl:Column ColId="64" Attno="16" ColName="p" TypeMdid="0.1082.1.0"/>
+                                <dxl:Column ColId="65" Attno="17" ColName="q" TypeMdid="0.1114.1.0"/>
+                                <dxl:Column ColId="66" Attno="18" ColName="r" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                                <dxl:Column ColId="67" Attno="19" ColName="s" TypeMdid="0.1043.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="68" Attno="20" ColName="t" TypeMdid="0.1043.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="69" Attno="21" ColName="u" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                                <dxl:Column ColId="70" Attno="22" ColName="v" TypeMdid="0.21.1.0"/>
+                                <dxl:Column ColId="71" Attno="23" ColName="w" TypeMdid="0.1114.1.0"/>
+                                <dxl:Column ColId="72" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:Aggregate>
+                      </dxl:GatherMotion>
+                    </dxl:Aggregate>
+                  </dxl:BroadcastMotion>
+                </dxl:Materialize>
+              </dxl:SubPlan>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000170" Rows="1.000000" Width="110"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="c">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="d">
+                <dxl:Ident ColId="3" ColName="d" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="4" Alias="e">
+                <dxl:Ident ColId="4" ColName="e" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="6" Alias="g">
+                <dxl:Ident ColId="6" ColName="g" TypeMdid="0.1082.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="i">
+                <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="j">
+                <dxl:Ident ColId="9" ColName="j" TypeMdid="0.1114.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="12" Alias="m">
+                <dxl:Ident ColId="12" ColName="m" TypeMdid="0.1114.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="n">
+                <dxl:Ident ColId="13" ColName="n" TypeMdid="0.21.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="o">
+                <dxl:Ident ColId="14" ColName="o" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="36" Alias="kk">
+                <dxl:Ident ColId="36" ColName="kk" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="38" Alias="mm">
+                <dxl:Ident ColId="38" ColName="mm" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="40" Alias="oo">
+                <dxl:Ident ColId="40" ColName="oo" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="44" Alias="ss">
+                <dxl:Ident ColId="44" ColName="ss" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="45" Alias="tt">
+                <dxl:Ident ColId="45" ColName="tt" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="t">
+                <dxl:Ident ColId="19" ColName="t" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="u">
+                <dxl:Ident ColId="20" ColName="u" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="v">
+                <dxl:Ident ColId="21" ColName="v" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="s">
+                <dxl:Ident ColId="18" ColName="s" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="l">
+                <dxl:Ident ColId="11" ColName="l" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="0.237683.1.0" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="77" Alias="ColRef_0077">
+                  <dxl:PartOid Level="0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000170" Rows="1.000000" Width="110"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="c">
+                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="3" Alias="d">
+                  <dxl:Ident ColId="3" ColName="d" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="4" Alias="e">
+                  <dxl:Ident ColId="4" ColName="e" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="6" Alias="g">
+                  <dxl:Ident ColId="6" ColName="g" TypeMdid="0.1082.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="i">
+                  <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="j">
+                  <dxl:Ident ColId="9" ColName="j" TypeMdid="0.1114.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="m">
+                  <dxl:Ident ColId="12" ColName="m" TypeMdid="0.1114.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="13" Alias="n">
+                  <dxl:Ident ColId="13" ColName="n" TypeMdid="0.21.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="o">
+                  <dxl:Ident ColId="14" ColName="o" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="36" Alias="kk">
+                  <dxl:Ident ColId="36" ColName="kk" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="38" Alias="mm">
+                  <dxl:Ident ColId="38" ColName="mm" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="40" Alias="oo">
+                  <dxl:Ident ColId="40" ColName="oo" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="44" Alias="ss">
+                  <dxl:Ident ColId="44" ColName="ss" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="45" Alias="tt">
+                  <dxl:Ident ColId="45" ColName="tt" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="t">
+                  <dxl:Ident ColId="19" ColName="t" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="u">
+                  <dxl:Ident ColId="20" ColName="u" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="v">
+                  <dxl:Ident ColId="21" ColName="v" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="s">
+                  <dxl:Ident ColId="18" ColName="s" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="l">
+                  <dxl:Ident ColId="11" ColName="l" TypeMdid="0.1043.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:CoerceViaIO TypeMdid="0.23.1.0" TypeModification="-1" CoercionForm="1" Location="0">
+                    <dxl:Ident ColId="11" ColName="l" TypeMdid="0.1043.1.0"/>
+                  </dxl:CoerceViaIO>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.237683.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.20.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.20.1.0"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="4" Attno="5" ColName="e" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="5" Attno="6" ColName="f" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="6" Attno="7" ColName="g" TypeMdid="0.1082.1.0"/>
+                  <dxl:Column ColId="7" Attno="8" ColName="h" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="8" Attno="9" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="9" Attno="10" ColName="j" TypeMdid="0.1114.1.0"/>
+                  <dxl:Column ColId="10" Attno="11" ColName="k" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="11" Attno="12" ColName="l" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="12" Attno="13" ColName="m" TypeMdid="0.1114.1.0"/>
+                  <dxl:Column ColId="13" Attno="14" ColName="n" TypeMdid="0.21.1.0"/>
+                  <dxl:Column ColId="14" Attno="15" ColName="o" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="15" Attno="16" ColName="p" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="16" Attno="17" ColName="q" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="17" Attno="18" ColName="r" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="18" Attno="19" ColName="s" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="19" Attno="20" ColName="t" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="20" Attno="21" ColName="u" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="21" Attno="22" ColName="v" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="22" Attno="23" ColName="w" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="23" Attno="24" ColName="x" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="24" Attno="25" ColName="y" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="25" Attno="26" ColName="z" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="26" Attno="27" ColName="aa" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="27" Attno="28" ColName="bb" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="28" Attno="29" ColName="cc" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="29" Attno="30" ColName="dd" TypeMdid="0.1043.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="30" Attno="31" ColName="ee" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="31" Attno="32" ColName="ff" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="32" Attno="33" ColName="gg" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="33" Attno="34" ColName="hh" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="34" Attno="35" ColName="ii" TypeMdid="0.1043.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="35" Attno="36" ColName="jj" TypeMdid="0.1043.1.0" ColWidth="30"/>
+                  <dxl:Column ColId="36" Attno="37" ColName="kk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="37" Attno="38" ColName="ll" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="38" Attno="39" ColName="mm" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="39" Attno="40" ColName="nn" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="40" Attno="41" ColName="oo" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="41" Attno="42" ColName="pp" TypeMdid="0.1043.1.0" ColWidth="50"/>
+                  <dxl:Column ColId="42" Attno="43" ColName="qq" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="43" Attno="44" ColName="rr" TypeMdid="0.1700.1.0"/>
+                  <dxl:Column ColId="44" Attno="45" ColName="ss" TypeMdid="0.20.1.0"/>
+                  <dxl:Column ColId="45" Attno="46" ColName="tt" TypeMdid="0.20.1.0"/>
+                  <dxl:Column ColId="46" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="47" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="48" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:Sequence>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
@@ -28,6 +28,7 @@ ULONG CPartTblTest::m_ulPartTblTestCounter = 0;  // start from first test
 // minidump files
 const CHAR *rgszPartTblFileNames[] =
 	{
+	"../data/dxl/minidump/CorrelatedNLJ-PartTabl-With-Subplan.mdp",
 	"../data/dxl/minidump/DonotPushPartConstThruLimit.mdp",
 	"../data/dxl/minidump/PartTbl-DPE-Correlated-NLOuter.mdp",
 	"../data/dxl/minidump/Select-Over-PartTbl.mdp",


### PR DESCRIPTION
When ORCA generates a plan with correlated NLJ,
PdxlnCorrelatedNLJoin() translates that to DXL.
The flow is as follows:

1. Get the inner, outer child of correlated NLJ and the filter predicate.
2. Build a subplan using the innerchild.
3. Now based on the outerchild, we decide whether or not to use the subplan
   (generated in #2 or #3) as a filter in the final result.
4. If the outer child is a Physical Sequence, we just discard the subplan
   assuming that the subplan is already present in the partition selector.
5. This code to discard the subplan was added because, previously, we were
   replacing the existing partition selector with the subplan based on the
   assumption that this subplan serves as a partition selector.
   However this subplan is different from partition selector. It serves as
   a filter for the correlated Nested Loop join.
   Hence we should not discard it and instead of replacing the existing
   partition selector with it, we should add the subplan as filter to the
   join node.

This commit fixes that.

Signed-off-by: Jemish Patel <jpatel@pivotal.io>