### PR TITLE
Get rid of UlSafeLength() function.

### DIFF
--- a/libgpopt/include/gpopt/operators/CExpression.h
+++ b/libgpopt/include/gpopt/operators/CExpression.h
@@ -202,7 +202,7 @@ namespace gpopt
 			// arity function
 			ULONG UlArity() const
 			{
-				return m_pdrgpexpr->UlSafeLength();
+				return m_pdrgpexpr == NULL ? 0 : m_pdrgpexpr->UlLength();
 			}
 			
 			// accessor for operator

--- a/libgpopt/src/base/CColRef.cpp
+++ b/libgpopt/src/base/CColRef.cpp
@@ -173,8 +173,8 @@ CColRef::FEqual
 	const DrgDrgPcr *pdrgdrgpcr2
 	)
 {
-	ULONG ulLen1 = pdrgdrgpcr1->UlSafeLength();
-	ULONG ulLen2 = pdrgdrgpcr2->UlSafeLength();
+	ULONG ulLen1 = (pdrgdrgpcr1 == NULL) ? 0 : pdrgdrgpcr1->UlLength();
+	ULONG ulLen2 = (pdrgdrgpcr2 == NULL) ? 0 : pdrgdrgpcr2->UlLength();
 
 	if (ulLen1 != ulLen2)
 	{

--- a/libgpopt/src/base/CPartIndexMap.cpp
+++ b/libgpopt/src/base/CPartIndexMap.cpp
@@ -54,7 +54,8 @@ CPartIndexMap::CPartTableInfo::CPartTableInfo
 				"Invalid manipulator type");
 
 	GPOS_ASSERT(pmdid->FValid());
-	GPOS_ASSERT(0 < pdrgppartkeys->UlSafeLength());
+	GPOS_ASSERT(pdrgppartkeys != NULL);
+	GPOS_ASSERT(0 < pdrgppartkeys->UlLength());
 	GPOS_ASSERT(NULL != ppartcnstrRel);
 	GPOS_ASSERT_IMP(CPartIndexMap::EpimConsumer != epim, 0 == ulPropagators);
 

--- a/libgpopt/src/base/CPartInfo.cpp
+++ b/libgpopt/src/base/CPartInfo.cpp
@@ -39,7 +39,8 @@ CPartInfo::CPartInfoEntry::CPartInfoEntry
 	m_ppartcnstrRel(ppartcnstrRel)
 {
 	GPOS_ASSERT(pmdid->FValid());
-	GPOS_ASSERT(0 < pdrgppartkeys->UlSafeLength());
+	GPOS_ASSERT(pdrgppartkeys != NULL);
+	GPOS_ASSERT(0 < pdrgppartkeys->UlLength());
 	GPOS_ASSERT(NULL != ppartcnstrRel);
 }
 

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -1,4 +1,4 @@
-	//---------------------------------------------------------------------------
+//---------------------------------------------------------------------------
 //	Greenplum Database
 //	Copyright (C) 2009 Greenplum, Inc.
 //
@@ -4675,13 +4675,16 @@ CUtils::FFunctionallyDependent
 	// not a constant: check if column is functionally dependent on the key
 	DrgPfd *pdrgpfd = pdprel->Pdrgpfd();
 
-	const ULONG ulSize = pdrgpfd->UlSafeLength();
-	for (ULONG ul = 0; ul < ulSize; ul++)
+	if (pdrgpfd != NULL)
 	{
-		CFunctionalDependency *pfd = (*pdrgpfd)[ul];
-		if (pfd->FFunctionallyDependent(pcrsKey, pcr))
+		const ULONG ulSize = pdrgpfd->UlLength();
+		for (ULONG ul = 0; ul < ulSize; ul++)
 		{
-			return true;
+			CFunctionalDependency *pfd = (*pdrgpfd)[ul];
+			if (pfd->FFunctionallyDependent(pcrsKey, pcr))
+			{
+				return true;
+			}
 		}
 	}
 	

--- a/libgpopt/src/operators/CExpression.cpp
+++ b/libgpopt/src/operators/CExpression.cpp
@@ -276,7 +276,7 @@ CExpression::CExpression
 {
 	GPOS_ASSERT(NULL != pmp);
 	GPOS_ASSERT(NULL != pop);
-	GPOS_ASSERT(pgexpr->UlArity() == pdrgpexpr->UlSafeLength());
+	GPOS_ASSERT(pgexpr->UlArity() == (pdrgpexpr == NULL ? 0 : pdrgpexpr->UlLength()));
 	GPOS_ASSERT(NULL != pgexpr->Pgroup());
 
 	CopyGroupPropsAndStats(pstatsInput);

--- a/libgpopt/src/operators/CExpressionFactorizer.cpp
+++ b/libgpopt/src/operators/CExpressionFactorizer.cpp
@@ -691,7 +691,7 @@ CExpressionFactorizer::AddInferredFiltersFromArray
 	DrgPexpr *pdrgpexprInferredFilters
 	)
 {
-	const ULONG ulEntryLength = pdrgpdrgpexpr->UlSafeLength();
+	const ULONG ulEntryLength = (pdrgpdrgpexpr == NULL) ? 0 : pdrgpdrgpexpr->UlLength();
 	if (ulEntryLength == ulDisjChildrenLength)
 	{
 		DrgPexpr *pdrgpexprDisjuncts = GPOS_NEW(pmp) DrgPexpr(pmp);

--- a/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -55,7 +55,7 @@ CPhysicalAgg::CPhysicalAgg
 	GPOS_ASSERT_IMP(EgbaggtypeGlobal != egbaggtype, fMultiStage);
 
 	ULONG ulDistrReqs = 1;
-	if (0 == pdrgpcrMinimal->UlSafeLength())
+	if (pdrgpcrMinimal == NULL || 0 == pdrgpcrMinimal->UlLength())
 	{
 		pdrgpcr->AddRef();
 		m_pdrgpcrMinimal = pdrgpcr;
@@ -76,7 +76,7 @@ CPhysicalAgg::CPhysicalAgg
 		//		possible data skew
 
 		ulDistrReqs = 2;
-		if (0 != pdrgpcrArgDQA->UlSafeLength())
+		if (pdrgpcrArgDQA != NULL && 0 != pdrgpcrArgDQA->UlLength())
 		{
 			// If the local aggregate has distinct columns we generate
 			// one optimization requests for its children:
@@ -226,7 +226,7 @@ CPhysicalAgg::PdsRequiredAgg
 		return PdsEnforceMaster(pmp, exprhdl, pdsInput, ulChildIndex);
 	}
 
-	if (COperator::EgbaggtypeLocal == m_egbaggtype && 0 != m_pdrgpcrArgDQA->UlSafeLength())
+	if (COperator::EgbaggtypeLocal == m_egbaggtype && m_pdrgpcrArgDQA != NULL && 0 != m_pdrgpcrArgDQA->UlLength())
 	{
 		GPOS_ASSERT(0 == ulOptReq);
 		return PdsMaximalHashed(pmp, m_pdrgpcrArgDQA);
@@ -590,7 +590,8 @@ CPhysicalAgg::FMatch
 	{
 		if (CColRef::FEqual(m_pdrgpcrMinimal, popAgg->m_pdrgpcrMinimal))
 		{
-			return (0 == m_pdrgpcrArgDQA->UlSafeLength()) || CColRef::FEqual(m_pdrgpcrArgDQA, popAgg->PdrgpcrArgDQA());
+			return (m_pdrgpcrArgDQA == NULL || 0 == m_pdrgpcrArgDQA->UlLength()) ||
+				CColRef::FEqual(m_pdrgpcrArgDQA, popAgg->PdrgpcrArgDQA());
 		}
 	}
 

--- a/libgpopt/src/operators/CPhysicalDynamicScan.cpp
+++ b/libgpopt/src/operators/CPhysicalDynamicScan.cpp
@@ -59,7 +59,8 @@ CPhysicalDynamicScan::CPhysicalDynamicScan
 	m_ppartcnstr(ppartcnstr),
 	m_ppartcnstrRel(ppartcnstrRel)
 {
-	GPOS_ASSERT(0 < pdrgpdrgpcrParts->UlSafeLength());
+	GPOS_ASSERT(NULL != pdrgpdrgpcrParts);
+	GPOS_ASSERT(0 < pdrgpdrgpcrParts->UlLength());
 	GPOS_ASSERT(NULL != ppartcnstr);
 	GPOS_ASSERT(NULL != ppartcnstrRel);
 }

--- a/libgpopt/src/search/CGroupExpression.cpp
+++ b/libgpopt/src/search/CGroupExpression.cpp
@@ -1001,7 +1001,7 @@ CGroupExpression::UlHash
 	
 	ULONG ulHash = pop->UlHash();
 	
-	ULONG ulArity = pdrgpgroup->UlSafeLength();
+	ULONG ulArity = pdrgpgroup->UlLength();
 	for (ULONG i = 0; i < ulArity; i++)
 	{
 		ulHash = UlCombineHashes(ulHash, (*pdrgpgroup)[i]->UlHash());

--- a/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -258,7 +258,7 @@ CTranslatorDXLToExpr::Pexpr
 
 	BOOL fGenerateRequiredColumns = COperator::EopLogicalUpdate != pexpr->Pop()->Eopid();
 	
-	const ULONG ulLen = pdrgpdxlnQueryOutput->UlSafeLength();
+	const ULONG ulLen = pdrgpdxlnQueryOutput->UlLength();
 	for (ULONG ul = 0; ul < ulLen; ul++)
 	{
 		CDXLNode *pdxlnIdent = (*pdrgpdxlnQueryOutput)[ul];
@@ -594,7 +594,7 @@ CTranslatorDXLToExpr::PexprLogicalGet
 	CExpression *pexpr = GPOS_NEW(m_pmp) CExpression(m_pmp, popGet);
 
 	GPOS_ASSERT(NULL != pdrgpcr);
-	GPOS_ASSERT(pdrgpcr->UlSafeLength() == pdxltabdesc->UlArity());
+	GPOS_ASSERT(pdrgpcr->UlLength() == pdxltabdesc->UlArity());
 
 	const ULONG ulColumns = pdrgpcr->UlLength();
 	// construct the mapping between the DXL ColId and CColRef

--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -82,7 +82,7 @@ CTranslatorExprToDXL::CTranslatorExprToDXL
 {
 	GPOS_ASSERT(NULL != pmp);
 	GPOS_ASSERT(NULL != pmda);
-	GPOS_ASSERT_IMP(NULL != pdrgpiSegments, (0 < pdrgpiSegments->UlSafeLength()));
+	GPOS_ASSERT_IMP(NULL != pdrgpiSegments, (0 < pdrgpiSegments->UlLength()));
 
 	InitScalarTranslators();
 	InitPhysicalTranslators();

--- a/libgpopt/src/xforms/CXformGbAgg2HashAgg.cpp
+++ b/libgpopt/src/xforms/CXformGbAgg2HashAgg.cpp
@@ -135,7 +135,7 @@ CXformGbAgg2HashAgg::Transform
 	pexprScalar->AddRef();
 
 	DrgPcr *pdrgpcrArgDQA = popAgg->PdrgpcrArgDQA();
-	if (0 != pdrgpcrArgDQA->UlSafeLength())
+	if (pdrgpcrArgDQA != NULL && 0 != pdrgpcrArgDQA->UlLength())
 	{
 		GPOS_ASSERT(NULL != pdrgpcrArgDQA);
 		pdrgpcrArgDQA->AddRef();

--- a/libgpopt/src/xforms/CXformGbAgg2ScalarAgg.cpp
+++ b/libgpopt/src/xforms/CXformGbAgg2ScalarAgg.cpp
@@ -105,9 +105,8 @@ CXformGbAgg2ScalarAgg::Transform
 	pexprScalar->AddRef();
 
 	DrgPcr *pdrgpcrArgDQA = popAgg->PdrgpcrArgDQA();
-	if (0 != pdrgpcrArgDQA->UlSafeLength())
+	if (pdrgpcrArgDQA != NULL && 0 != pdrgpcrArgDQA->UlLength())
 	{
-		GPOS_ASSERT(NULL != pdrgpcrArgDQA);
 		pdrgpcrArgDQA->AddRef();
 	}
 

--- a/libgpopt/src/xforms/CXformGbAgg2StreamAgg.cpp
+++ b/libgpopt/src/xforms/CXformGbAgg2StreamAgg.cpp
@@ -122,9 +122,8 @@ CXformGbAgg2StreamAgg::Transform
 	pexprScalar->AddRef();
 
 	DrgPcr *pdrgpcrArgDQA = popAgg->PdrgpcrArgDQA();
-	if (0 != pdrgpcrArgDQA->UlSafeLength())
+	if (pdrgpcrArgDQA != NULL && 0 != pdrgpcrArgDQA->UlLength())
 	{
-		GPOS_ASSERT(NULL != pdrgpcrArgDQA);
 		pdrgpcrArgDQA->AddRef();
 	}
 

--- a/libgpopt/src/xforms/CXformSimplifyGbAgg.cpp
+++ b/libgpopt/src/xforms/CXformSimplifyGbAgg.cpp
@@ -185,7 +185,7 @@ CXformSimplifyGbAgg::Transform
 	DrgPfd *pdrgpfd = CDrvdPropRelational::Pdprel(pexpr->PdpDerive())->Pdrgpfd();
 
 	// collect grouping columns FD's
-	const ULONG ulSize = pdrgpfd->UlSafeLength();
+	const ULONG ulSize = (pdrgpfd == NULL) ? 0 : pdrgpfd->UlLength();
 	for (ULONG ul = 0; ul < ulSize; ul++)
 	{
 		CFunctionalDependency *pfd = (*pdrgpfd)[ul];

--- a/libgpopt/src/xforms/CXformSplitDQA.cpp
+++ b/libgpopt/src/xforms/CXformSplitDQA.cpp
@@ -173,7 +173,7 @@ CXformSplitDQA::Transform
 	pxfres->Add(pexprAlt1);
 
 	DrgPcr *pDrgPcr = CLogicalGbAgg::PopConvert(pexpr->Pop())->Pdrgpcr();
-	BOOL fScalarDQA = (pDrgPcr == NULL) ? 0 : pDrgPcr->UlLength();
+	BOOL fScalarDQA = (pDrgPcr == NULL || pDrgPcr->UlLength() == 0);
 	BOOL fForce3StageScalarDQA = GPOS_FTRACE(EopttraceForceThreeStageScalarDQA);
 	if (!(fForce3StageScalarDQA && fScalarDQA)) {
 		// we skip this option if it is a Scalar DQA and we only want plans with 3-stages of aggregation

--- a/libgpopt/src/xforms/CXformSplitDQA.cpp
+++ b/libgpopt/src/xforms/CXformSplitDQA.cpp
@@ -172,7 +172,8 @@ CXformSplitDQA::Transform
         
 	pxfres->Add(pexprAlt1);
 
-	BOOL fScalarDQA = (0 == CLogicalGbAgg::PopConvert(pexpr->Pop())->Pdrgpcr()->UlSafeLength());
+	DrgPcr *pDrgPcr = CLogicalGbAgg::PopConvert(pexpr->Pop())->Pdrgpcr();
+	BOOL fScalarDQA = (pDrgPcr == NULL) ? 0 : pDrgPcr->UlLength();
 	BOOL fForce3StageScalarDQA = GPOS_FTRACE(EopttraceForceThreeStageScalarDQA);
 	if (!(fForce3StageScalarDQA && fScalarDQA)) {
 		// we skip this option if it is a Scalar DQA and we only want plans with 3-stages of aggregation

--- a/libgpos/include/gpos/common/CDynamicPtrArray.h
+++ b/libgpos/include/gpos/common/CDynamicPtrArray.h
@@ -184,19 +184,6 @@ namespace gpos
                 return m_ulSize;
             }
 
-			// safe version of length -- handles NULL pointers
-			ULONG UlSafeLength() const
-            {
-                if (NULL == this)
-                {
-                    return 0;
-                }
-                else
-                {
-                    return UlLength();
-                }
-            }
-			
 			// sort array
 			void Sort(PfnCompare pfncompare = PtrCmp)
             {

--- a/libgpos/server/src/unittest/gpos/common/CDynamicPtrArrayTest.cpp
+++ b/libgpos/server/src/unittest/gpos/common/CDynamicPtrArrayTest.cpp
@@ -105,10 +105,6 @@ CDynamicPtrArrayTest::EresUnittest_Basic()
 	DrgULONG *pdrgULONG = GPOS_NEW(pmp) DrgULONG(pmp, 1);
 	ULONG c = 256;
 
-	// safe length test
-	GPOS_ASSERT(0 == ((DrgULONG*)NULL)->UlSafeLength());
-
-
 	// add elements incl trigger resize of array
 	for (ULONG_PTR ulpK = c; ulpK > 0; ulpK--)
 	{
@@ -163,7 +159,6 @@ CDynamicPtrArrayTest::EresUnittest_Ownership()
 		pdrgULONG->Append(pul);
 		GPOS_ASSERT(k + 1 == pdrgULONG->UlLength());
 		GPOS_ASSERT(pul == (*pdrgULONG)[k]);
-		GPOS_ASSERT(pdrgULONG->UlLength() == pdrgULONG->UlSafeLength());
 	}
 	pdrgULONG->Release();
 

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLNode.h
@@ -100,7 +100,7 @@ namespace gpdxl
 			inline
 			ULONG UlArity() const
 			{
-				return m_pdrgpdxln->UlSafeLength();
+				return (m_pdrgpdxln == NULL) ? 0 : m_pdrgpdxln->UlLength();
 			}
 			
 			// accessor for operator

--- a/libnaucrates/src/CDXLUtils.cpp
+++ b/libnaucrates/src/CDXLUtils.cpp
@@ -486,7 +486,7 @@ CDXLUtils::PmdidParseDXL
 	// collect metadata objects from dxl parse handler
 	DrgPmdid *pdrgpmdid = pphdxl->Pdrgpmdid();
 	
-	GPOS_ASSERT(1 == pdrgpmdid->UlSafeLength());
+	GPOS_ASSERT(1 == pdrgpmdid->UlLength());
 	
 	IMDId *pmdid = (*pdrgpmdid)[0];
 	pmdid->AddRef();

--- a/libnaucrates/src/md/CMDIndexGPDB.cpp
+++ b/libnaucrates/src/md/CMDIndexGPDB.cpp
@@ -61,7 +61,7 @@ CMDIndexGPDB::CMDIndexGPDB
 	GPOS_ASSERT(pmdid->FValid());
 	GPOS_ASSERT(IMDIndex::EmdindSentinel > emdindt);
 	GPOS_ASSERT(NULL != pdrgpulKeyCols);
-	GPOS_ASSERT(0 < pdrgpulKeyCols->UlSafeLength());
+	GPOS_ASSERT(0 < pdrgpulKeyCols->UlLength());
 	GPOS_ASSERT(NULL != pdrgpulIncludedCols);
 	GPOS_ASSERT_IMP(NULL != pmdidItemType, IMDIndex::EmdindBitmap == emdindt);
 	GPOS_ASSERT_IMP(IMDIndex::EmdindBitmap == emdindt, NULL != pmdidItemType && pmdidItemType->FValid());

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -236,7 +236,7 @@ CMDRelationCtasGPDB::UlPosFromAttno
 ULONG
 CMDRelationCtasGPDB::UlDistrColumns() const
 {
-	return m_pdrgpulDistrColumns->UlSafeLength();
+	return (m_pdrgpulDistrColumns == NULL) ? 0 : m_pdrgpulDistrColumns->UlLength();
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationExternalGPDB.cpp
@@ -367,7 +367,7 @@ CMDRelationExternalGPDB::PmdidFmtErrRel() const
 ULONG
 CMDRelationExternalGPDB::UlKeySets() const
 {
-	return m_pdrgpdrgpulKeys->UlSafeLength();
+	return (m_pdrgpdrgpulKeys == NULL) ? 0 : m_pdrgpdrgpulKeys->UlLength();
 }
 
 //---------------------------------------------------------------------------
@@ -401,7 +401,7 @@ CMDRelationExternalGPDB::PdrgpulKeyset
 ULONG
 CMDRelationExternalGPDB::UlDistrColumns() const
 {
-	return m_pdrgpulDistrColumns->UlSafeLength();
+	return (m_pdrgpulDistrColumns == NULL) ? 0 : m_pdrgpulDistrColumns->UlLength();
 }
 
 //---------------------------------------------------------------------------
@@ -576,8 +576,7 @@ CMDRelationExternalGPDB::Serialize
 	}
 
 	// serialize key sets
-	const ULONG ulKeySets = m_pdrgpdrgpulKeys->UlSafeLength();
-	if (0 < ulKeySets)
+	if (m_pdrgpdrgpulKeys != NULL && 0 < m_pdrgpdrgpulKeys->UlLength())
 	{
 		CWStringDynamic *pstrKeys = CDXLUtils::PstrSerialize(m_pmp, m_pdrgpdrgpulKeys);
 		pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenKeys), pstrKeys);

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -350,7 +350,7 @@ CMDRelationGPDB::UlSystemColumns() const
 ULONG
 CMDRelationGPDB::UlKeySets() const
 {	
-	return m_pdrgpdrgpulKeys->UlSafeLength();
+	return (m_pdrgpdrgpulKeys == NULL) ? 0 : m_pdrgpdrgpulKeys->UlLength();
 }
 
 //---------------------------------------------------------------------------
@@ -384,7 +384,7 @@ CMDRelationGPDB::PdrgpulKeyset
 ULONG
 CMDRelationGPDB::UlDistrColumns() const
 {	
-	return m_pdrgpulDistrColumns->UlSafeLength();
+	return (m_pdrgpulDistrColumns == NULL) ? 0 : m_pdrgpulDistrColumns->UlLength();
 }
 
 //---------------------------------------------------------------------------
@@ -440,7 +440,7 @@ CMDRelationGPDB::UlPartitions() const
 ULONG
 CMDRelationGPDB::UlPartColumns() const
 {	
-	return m_pdrgpulPartColumns->UlSafeLength();
+	return (m_pdrgpulPartColumns == NULL) ? 0 : m_pdrgpulPartColumns->UlLength();
 }
 
 // Retrieve list of partition types
@@ -682,8 +682,7 @@ CMDRelationGPDB::Serialize
 	}
 	
 	// serialize key sets
-	const ULONG ulKeySets = m_pdrgpdrgpulKeys->UlSafeLength();
-	if (0 < ulKeySets)
+	if (m_pdrgpdrgpulKeys != NULL && m_pdrgpdrgpulKeys->UlLength() > 0)
 	{
 		CWStringDynamic *pstrKeys = CDXLUtils::PstrSerialize(m_pmp, m_pdrgpdrgpulKeys);
 		pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenKeys), pstrKeys);

--- a/libnaucrates/src/operators/CDXLCtasStorageOptions.cpp
+++ b/libnaucrates/src/operators/CDXLCtasStorageOptions.cpp
@@ -117,7 +117,7 @@ CDXLCtasStorageOptions::Serialize
 	
 	pxmlser->AddAttribute(CDXLTokens::PstrToken(EdxltokenOnCommitAction), PstrOnCommitAction(m_ectascommit));
 	
-	const ULONG ulOptions = m_pdrgpctasopt->UlSafeLength();
+	const ULONG ulOptions = (m_pdrgpctasopt == NULL) ? 0 : m_pdrgpctasopt->UlLength();
 	for (ULONG ul = 0; ul < ulOptions; ul++)
 	{
 		CDXLCtasOption *pdxlctasopt = (*m_pdrgpctasopt)[ul];

--- a/libnaucrates/src/operators/CDXLDirectDispatchInfo.cpp
+++ b/libnaucrates/src/operators/CDXLDirectDispatchInfo.cpp
@@ -81,7 +81,7 @@ CDXLDirectDispatchInfo::Serialize
 {
 	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenDirectDispatchInfo));
 	
-	const ULONG ulValueCombinations = m_pdrgpdrgpdxldatum->UlSafeLength();
+	const ULONG ulValueCombinations = (m_pdrgpdrgpdxldatum == NULL) ? 0 : m_pdrgpdrgpdxldatum->UlLength();
 	
 	for (ULONG ulA = 0; ulA < ulValueCombinations; ulA++)
 	{

--- a/libnaucrates/src/operators/CDXLLogicalConstTable.cpp
+++ b/libnaucrates/src/operators/CDXLLogicalConstTable.cpp
@@ -227,7 +227,8 @@ CDXLLogicalConstTable::AssertValid
 	) const
 {
 	// assert validity of col descr
-	GPOS_ASSERT(0 < m_pdrgpdxlcd->UlSafeLength());
+	GPOS_ASSERT(m_pdrgpdxlcd != NULL);
+	GPOS_ASSERT(0 < m_pdrgpdxlcd->UlLength());
 	GPOS_ASSERT(0 == pdxln->UlArity());
 }
 #endif // GPOS_DEBUG

--- a/libnaucrates/src/operators/CDXLPhysicalBroadcastMotion.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalBroadcastMotion.cpp
@@ -114,8 +114,10 @@ CDXLPhysicalBroadcastMotion::AssertValid
 	// assert proj list and filter are valid
 	CDXLPhysical::AssertValid(pdxln, fValidateChildren);
 
-	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlSafeLength());
-	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlSafeLength());
+	GPOS_ASSERT(m_pdrgpiInputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlLength());
+	GPOS_ASSERT(m_pdrgpiOutputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlLength());
 
 	GPOS_ASSERT(EdxlbmIndexSentinel == pdxln->UlArity());
 	

--- a/libnaucrates/src/operators/CDXLPhysicalGatherMotion.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalGatherMotion.cpp
@@ -60,7 +60,7 @@ CDXLPhysicalGatherMotion::Edxlop() const
 INT
 CDXLPhysicalGatherMotion::IOutputSegIdx() const
 {
-	GPOS_ASSERT(1 == m_pdrgpiOutputSegIds->UlSafeLength());
+	GPOS_ASSERT(1 == m_pdrgpiOutputSegIds->UlLength());
 	return *((*m_pdrgpiOutputSegIds)[0]);
 }
 
@@ -128,8 +128,10 @@ CDXLPhysicalGatherMotion::AssertValid
 {
 	// assert proj list and filter are valid
 	CDXLPhysical::AssertValid(pdxln, fValidateChildren);
-	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlSafeLength());
-	GPOS_ASSERT(1 == m_pdrgpiOutputSegIds->UlSafeLength());
+	GPOS_ASSERT(m_pdrgpiInputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlLength());
+	GPOS_ASSERT(m_pdrgpiOutputSegIds != NULL);
+	GPOS_ASSERT(1 == m_pdrgpiOutputSegIds->UlLength());
 
 	GPOS_ASSERT(EdxlgmIndexSentinel == pdxln->UlArity());
 	

--- a/libnaucrates/src/operators/CDXLPhysicalMotion.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalMotion.cpp
@@ -134,7 +134,7 @@ CDXLPhysicalMotion::SetSegmentInfo
 CWStringDynamic *
 CDXLPhysicalMotion::PstrSegIds(const DrgPi *pdrgpi) const
 {
-	GPOS_ASSERT(0 < pdrgpi->UlSafeLength());
+	GPOS_ASSERT(pdrgpi != NULL && 0 < pdrgpi->UlLength());
 	
 	CWStringDynamic *pstr = GPOS_NEW(m_pmp) CWStringDynamic(m_pmp);
 	

--- a/libnaucrates/src/operators/CDXLPhysicalRandomMotion.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalRandomMotion.cpp
@@ -121,8 +121,10 @@ CDXLPhysicalRandomMotion::AssertValid
 	// assert proj list and filter are valid
 	CDXLPhysical::AssertValid(pdxln, fValidateChildren);
 
-	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlSafeLength());
-	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlSafeLength());
+	GPOS_ASSERT(m_pdrgpiInputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlLength());
+	GPOS_ASSERT(m_pdrgpiOutputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlLength());
 
 	GPOS_ASSERT(EdxlrandommIndexSentinel == pdxln->UlArity());
 	

--- a/libnaucrates/src/operators/CDXLPhysicalRedistributeMotion.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalRedistributeMotion.cpp
@@ -124,8 +124,10 @@ CDXLPhysicalRedistributeMotion::AssertValid
 	// assert proj list and filter are valid
 	CDXLPhysical::AssertValid(pdxln, fValidateChildren);
 	
-	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlSafeLength());
-	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlSafeLength());
+	GPOS_ASSERT(m_pdrgpiInputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlLength());
+	GPOS_ASSERT(m_pdrgpiOutputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlLength());
 	
 	GPOS_ASSERT(EdxlrmIndexSentinel == pdxln->UlArity());
 	

--- a/libnaucrates/src/operators/CDXLPhysicalRoutedDistributeMotion.cpp
+++ b/libnaucrates/src/operators/CDXLPhysicalRoutedDistributeMotion.cpp
@@ -121,8 +121,10 @@ CDXLPhysicalRoutedDistributeMotion::AssertValid
 	// assert proj list and filter are valid
 	CDXLPhysical::AssertValid(pdxln, fValidateChildren);
 	
-	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlSafeLength());
-	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlSafeLength());
+	GPOS_ASSERT(m_pdrgpiInputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiInputSegIds->UlLength());
+	GPOS_ASSERT(m_pdrgpiOutputSegIds != NULL);
+	GPOS_ASSERT(0 < m_pdrgpiOutputSegIds->UlLength());
 	
 	GPOS_ASSERT(EdxlroutedmIndexSentinel == pdxln->UlArity());
 	

--- a/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -102,7 +102,7 @@ CDXLTableDescr::Pmdname() const
 ULONG
 CDXLTableDescr::UlArity() const
 {
-	return m_pdrgdxlcd->UlSafeLength();
+	return (m_pdrgdxlcd == NULL) ? 0 : m_pdrgdxlcd->UlLength();
 }
 
 //---------------------------------------------------------------------------

--- a/server/include/unittest/gpopt/CTestUtils.inl
+++ b/server/include/unittest/gpopt/CTestUtils.inl
@@ -78,7 +78,8 @@ namespace gpopt
 		CLogicalGet *popGetPartitioned = CLogicalGet::PopConvert(pexprGetPartitioned->Pop());
 		const DrgDrgPcr *pdrgpdrgpcr = popGetPartitioned->PdrgpdrgpcrPartColumns();
 
-		GPOS_ASSERT(0 < pdrgpdrgpcr->UlSafeLength());
+		GPOS_ASSERT(pdrgpdrgpcr != NULL);
+		GPOS_ASSERT(0 < pdrgpdrgpcr->UlLength());
 		DrgPcr *pdrgpcr = (*pdrgpdrgpcr)[0];
 		GPOS_ASSERT(1 == pdrgpcr->UlLength());
 		CColRef *pcrPartKey = (*pdrgpcr)[0];

--- a/server/src/unittest/CTestUtils.cpp
+++ b/server/src/unittest/CTestUtils.cpp
@@ -609,7 +609,8 @@ CTestUtils::PexprLogicalSelectPartitioned
 	CLogicalGet *popGet = CLogicalGet::PopConvert(pexprGet->Pop());
 	const DrgDrgPcr *pdrgpdrgpcr = popGet->PdrgpdrgpcrPartColumns();
 
-	GPOS_ASSERT(0 < pdrgpdrgpcr->UlSafeLength());
+	GPOS_ASSERT(pdrgpdrgpcr != NULL);
+	GPOS_ASSERT(0 < pdrgpdrgpcr->UlLength());
 	DrgPcr *pdrgpcr = (*pdrgpdrgpcr)[0];
 	GPOS_ASSERT(1 == pdrgpcr->UlLength());
 	CColRef *pcrPartKey = (*pdrgpcr)[0];

--- a/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
+++ b/server/src/unittest/gpopt/operators/CExpressionPreprocessorTest.cpp
@@ -1651,11 +1651,13 @@ CExpressionPreprocessorTest::EresUnittest_PreProcessOrPrefilters()
 
 	CColRefSet *pcrsInner = CDrvdPropRelational::Pdprel((*pexprJoin)[1]->PdpDerive())->PcrsOutput();
 	DrgPcr *pdrgpcrInner = pcrsInner->Pdrgpcr(pmp);
-	GPOS_ASSERT(3 <= pdrgpcrInner->UlSafeLength());
+	GPOS_ASSERT(pdrgpcrInner != NULL);
+	GPOS_ASSERT(3 <= pdrgpcrInner->UlLength());
 
 	CColRefSet *pcrsOuter = CDrvdPropRelational::Pdprel((*pexprJoin)[0]->PdpDerive())->PcrsOutput();
 	DrgPcr *pdrgpcrOuter = pcrsOuter->Pdrgpcr(pmp);
-	GPOS_ASSERT(3 <= pdrgpcrOuter->UlSafeLength());
+	GPOS_ASSERT(pdrgpcrOuter != NULL);
+	GPOS_ASSERT(3 <= pdrgpcrOuter->UlLength());
 
 	DrgPexpr *pdrgpexpr = GPOS_NEW(pmp) DrgPexpr(pmp);
 
@@ -1854,11 +1856,13 @@ CExpressionPreprocessorTest::EresUnittest_PreProcessOrPrefiltersPartialPush()
 
 	CColRefSet *pcrsInner = CDrvdPropRelational::Pdprel((*pexprJoin)[1]->PdpDerive())->PcrsOutput();
 	DrgPcr *pdrgpcrInner = pcrsInner->Pdrgpcr(pmp);
-	GPOS_ASSERT(3 <= pdrgpcrInner->UlSafeLength());
+	GPOS_ASSERT(pdrgpcrInner);
+	GPOS_ASSERT(3 <= pdrgpcrInner->UlLength());
 
 	CColRefSet *pcrsOuter = CDrvdPropRelational::Pdprel((*pexprJoin)[0]->PdpDerive())->PcrsOutput();
 	DrgPcr *pdrgpcrOuter = pcrsOuter->Pdrgpcr(pmp);
-	GPOS_ASSERT(3 <= pdrgpcrOuter->UlSafeLength());
+	GPOS_ASSERT(pdrgpcrOuter);
+	GPOS_ASSERT(3 <= pdrgpcrOuter->UlLength());
 
 	DrgPexpr *pdrgpexpr = GPOS_NEW(pmp) DrgPexpr(pmp);
 

--- a/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
+++ b/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
@@ -436,7 +436,7 @@ CTranslatorDXLToExprTest::EresUnittest_SelectQuery()
 		// the output column references from the logical get
 		DrgPcr *pdrgpcr = popGet->PdrgpcrOutput();
 
-		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlSafeLength());
+		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlLength());
 
 		CColRef *pcrLeft =  (*pdrgpcr)[0];
 		CColRef *pcrRight = (*pdrgpcr)[1];
@@ -491,7 +491,7 @@ CTranslatorDXLToExprTest::EresUnittest_SelectQueryWithConst()
 
 		// the output column references from the logical get
 		DrgPcr *pdrgpcr = popGet->PdrgpcrOutput();
-		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlSafeLength());
+		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlLength());
 
 		CColRef *pcrLeft =  (*pdrgpcr)[0];
 		ULONG ulVal = 5;
@@ -539,7 +539,7 @@ CTranslatorDXLToExprTest::EresUnittest_SelectQueryWithConstInList()
 
 		// the output column references from the logical get
 		DrgPcr *pdrgpcr = popGet->PdrgpcrOutput();
-		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlSafeLength());
+		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlLength());
 
 		CColRef *pcr =  (*pdrgpcr)[0];
 		ULONG ulVal1 = 5;
@@ -607,7 +607,7 @@ CTranslatorDXLToExprTest::EresUnittest_SelectQueryWithBoolExpr()
 		// the output column references from the logical get
 		DrgPcr *pdrgpcr = popGet->PdrgpcrOutput();
 
-		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlSafeLength());
+		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlLength());
 
 		// create a scalar compare for a = 5
 		CColRef *pcrLeft =  (*pdrgpcr)[0];
@@ -676,7 +676,7 @@ CTranslatorDXLToExprTest::EresUnittest_SelectQueryWithScalarOp()
 		// the output column references from the logical get
 		DrgPcr *pdrgpcr = popGet->PdrgpcrOutput();
 
-		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlSafeLength());
+		GPOS_ASSERT(NULL != pdrgpcr && 2 == pdrgpcr->UlLength());
 
 		// create a scalar op (arithmetic) for b + 2
 		CColRef *pcrLeft =  (*pdrgpcr)[1];


### PR DESCRIPTION
It made the assumption that it's OK to call it on a NULL pointer, which
isn't cool with all C++ compilers and options. I'm getting a bunch of
warnings like this because of it:

/home/heikki/gpdb/optimizer-main/libgpos/include/gpos/common/CDynamicPtrArray.inl:382:3: warning: nonnull argument ‘this’ compared to NULL [-Wnonnull-compare]
   if (NULL == this)
   ^~

There are a few other places that produce the same error, but one step at
a time. This is most important because it's in an inline function, so this
produces warnings also in any code that uses ORCA, like the translator code
in GPDB's src/backend/gpopt/ directory, not just ORCA itself.

Since the function is now gone, all references to it also need to be removed
from the translator code outside ORCA.