### PR TITLE
Adding support for ValueScan node in ORCA

### DIFF
--- a/data/dxl/parse_tests/q76-ValueScan.xml
+++ b/data/dxl/parse_tests/q76-ValueScan.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="column2" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalValuesGet>
+        <dxl:Columns>
+          <dxl:Column ColId="1" Attno="1" ColName="column1" TypeMdid="0.23.1.0"/>
+          <dxl:Column ColId="2" Attno="2" ColName="column2" TypeMdid="0.23.1.0"/>
+        </dxl:Columns>
+        <dxl:ValuesList>
+          <dxl:ConstTuple>
+            <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+            <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+          </dxl:ConstTuple>
+          <dxl:ConstTuple>
+            <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            <dxl:Datum TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
+          </dxl:ConstTuple>
+        </dxl:ValuesList>
+      </dxl:LogicalValuesGet>
+    </dxl:Query>
+</dxl:DXLMessage>

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -558,6 +558,8 @@ add_library(naucrates
             src/parser/CParseHandlerLogicalSelect.cpp
             include/naucrates/dxl/parser/CParseHandlerLogicalSetOp.h
             src/parser/CParseHandlerLogicalSetOp.cpp
+            include/naucrates/dxl/parser/CParseHandlerLogicalValuesGet.h
+            src/parser/CParseHandlerLogicalValuesGet.cpp
             include/naucrates/dxl/parser/CParseHandlerLogicalTVF.h
             src/parser/CParseHandlerLogicalTVF.cpp
             include/naucrates/dxl/parser/CParseHandlerLogicalUpdate.h

--- a/libnaucrates/CMakeLists.txt
+++ b/libnaucrates/CMakeLists.txt
@@ -214,6 +214,8 @@ add_library(naucrates
             src/operators/CDXLLogicalSelect.cpp
             include/naucrates/dxl/operators/CDXLLogicalSetOp.h
             src/operators/CDXLLogicalSetOp.cpp
+	    include/naucrates/dxl/operators/CDXLLogicalValuesGet.h
+	    src/operators/CDXLLogicalValuesGet.cpp
             include/naucrates/dxl/operators/CDXLLogicalTVF.h
             src/operators/CDXLLogicalTVF.cpp
             include/naucrates/dxl/operators/CDXLLogicalUpdate.h

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalValuesGet.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalValuesGet.h
@@ -6,7 +6,7 @@
 //		CDXLLogicalValuesGet.h
 //
 //	@doc:
-//		Class for representing DXL logical Value scan
+//		Class for representing DXL logical Value get
 //		
 //	@owner: 
 //		
@@ -27,7 +27,7 @@
 namespace gpdxl
 {
 
-	// Class for representing DXL logical Value Scan
+	// Class for representing DXL logical Values get
 	class CDXLLogicalValuesGet : public CDXLLogical
 	{
 		private:

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalValuesGet.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalValuesGet.h
@@ -1,0 +1,107 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Software, Inc.
+//
+//	@filename:
+//		CDXLLogicalValuesGet.h
+//
+//	@doc:
+//		Class for representing DXL logical Value scan
+//		
+//	@owner: 
+//		
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+#ifndef GPDXL_CDXLLogicalValuesGet_H
+#define GPDXL_CDXLLogicalValuesGet_H
+
+#include <gpos/assert.h>
+#include <gpos/common/CDynamicPtrArray.h>
+#include <gpos/types.h>
+#include <naucrates/dxl/operators/CDXLColDescr.h>
+#include <naucrates/dxl/operators/CDXLLogical.h>
+#include <naucrates/dxl/operators/CDXLOperator.h>
+
+namespace gpdxl
+{
+
+	// Class for representing DXL logical Value Scan
+	class CDXLLogicalValuesGet : public CDXLLogical
+	{
+		private:
+
+			// private copy ctor
+			CDXLLogicalValuesGet(CDXLLogicalValuesGet&);
+
+			// list of output column descriptors
+			DrgPdxlcd *m_pdrgpdxlcd;
+
+			// array of array of Const datums
+			DrgPdrgPdxldatum *m_pdrgpdrgpdxldatumValuesList;
+		
+		public:
+			// ctor
+			CDXLLogicalValuesGet
+				(
+				IMemoryPool *pmp,
+				DrgPdxlcd *pdrgdxlcd,
+				DrgPdrgPdxldatum *pdrgpdrgpdxldatum
+				);
+
+			// dtor
+			virtual
+			~CDXLLogicalValuesGet();
+
+			// operator id
+			Edxlopid Edxlop() const;
+
+			// operator name
+			const CWStringConst *PstrOpName() const;
+
+			// array of output columns
+			const DrgPdxlcd *Pdrgpdxlcd() const
+			{
+				return m_pdrgpdxlcd;
+			}
+
+			// number of output columns
+			ULONG UlArity() const
+			{
+				return m_pdrgpdxlcd->UlLength();
+			}
+
+			// output column descriptor at a given position
+			const CDXLColDescr *Pdxlcd
+				(
+				ULONG ulPos
+				)
+				const
+			{
+				return (*m_pdrgpdxlcd)[ulPos];
+			}
+
+			// serialize operator in DXL format
+			virtual
+			void SerializeToDXL(CXMLSerializer *pxmlser, const CDXLNode *pdxln) const;
+
+			// check if given column is defined by operator
+			virtual
+			BOOL FDefinesColumn(ULONG ulColId) const;
+
+			// conversion function
+			static
+			CDXLLogicalValuesGet *PdxlopConvert(CDXLOperator *pdxlop);
+			
+#ifdef GPOS_DEBUG
+			// checks whether the operator has valid structure, i.e. number and
+			// types of child nodes
+			void AssertValid(const CDXLNode *, BOOL fValidateChildren) const;
+#endif // GPOS_DEBUG
+
+	};
+}
+#endif // !GPDXL_CDXLLogicalValuesGet_H
+
+// EOF

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLOperator.h
@@ -50,6 +50,7 @@ namespace gpdxl
 		EdxlopLogicalUpdate,
 		
 		EdxlopLogicalCTAS,
+		EdxlopLogicalValuesGet,
 		EdxlopPhysicalCTAS,
 		
 		EdxlopScalarCmp,

--- a/libnaucrates/include/naucrates/dxl/operators/dxlops.h
+++ b/libnaucrates/include/naucrates/dxl/operators/dxlops.h
@@ -135,6 +135,7 @@
 #include "naucrates/dxl/operators/CDXLLogicalLimit.h"
 #include "naucrates/dxl/operators/CDXLLogicalConstTable.h"
 #include "naucrates/dxl/operators/CDXLLogicalSetOp.h"
+#include "naucrates/dxl/operators/CDXLLogicalValuesGet.h"
 #include "naucrates/dxl/operators/CDXLLogicalWindow.h"
 
 #include "naucrates/dxl/operators/CDXLLogicalInsert.h"

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
@@ -1414,6 +1414,15 @@ namespace gpdxl
 				CParseHandlerManager *pphm,
 				CParseHandlerBase *pphRoot
 				);
+		
+			// construct a logical value scan parse handler
+			static
+			CParseHandlerBase *PphLgValuesGet
+				(
+				IMemoryPool *pmp,
+				CParseHandlerManager *pphm,
+				CParseHandlerBase *pphRoot
+				);
 
 			// construct a logical select parse handler
 			static

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalValuesGet.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalValuesGet.h
@@ -1,0 +1,76 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Software, Inc.
+//
+//	@filename:
+//		CParseHandlerLogicalValuesGet.h
+//
+//	@doc:
+//		Parse handler for parsing a logical value scan
+//
+//	@owner: 
+//		
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+#ifndef GPDXL_CParseHandlerLogicalValuesGet_H
+#define GPDXL_CParseHandlerLogicalValuesGet_H
+
+#include "gpos/base.h"
+#include "naucrates/dxl/parser/CParseHandlerLogicalOp.h"
+
+namespace gpdxl
+{
+	using namespace gpos;
+
+	XERCES_CPP_NAMESPACE_USE
+
+	// Parse handler for parsing a logical value scan
+	class CParseHandlerLogicalValuesGet : public CParseHandlerLogicalOp
+	{
+		private:
+
+			// array of datum arrays
+			DrgPdrgPdxldatum *m_pdrgpdrgpdxldatum;
+
+			// array of datums
+			DrgPdxldatum *m_pdrgpdxldatum;
+
+			// private copy ctor
+			CParseHandlerLogicalValuesGet(const CParseHandlerLogicalValuesGet &);
+
+			// process the start of an element
+			void StartElement
+				(
+					const XMLCh* const xmlszUri, 		// URI of element's namespace
+ 					const XMLCh* const xmlszLocalname,	// local part of element's name
+					const XMLCh* const xmlszQname,		// element's qname
+					const Attributes& attr				// element's attributes
+				);
+
+			// process the end of an element
+			void EndElement
+				(
+					const XMLCh* const xmlszUri, 		// URI of element's namespace
+					const XMLCh* const xmlszLocalname,	// local part of element's name
+					const XMLCh* const xmlszQname		// element's qname
+				);
+
+		public:
+			// ctor
+			CParseHandlerLogicalValuesGet
+				(
+				IMemoryPool *pmp,
+				CParseHandlerManager *pphm,
+				CParseHandlerBase *pphRoot
+				);
+
+			// dtor
+			~CParseHandlerLogicalValuesGet();
+	};
+}
+
+#endif // !GPDXL_CParseHandlerLogicalValuesGet_H
+
+// EOF

--- a/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
+++ b/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
@@ -116,6 +116,7 @@
 #include "naucrates/dxl/parser/CParseHandlerLogicalGroupBy.h"
 #include "naucrates/dxl/parser/CParseHandlerLogicalLimit.h"
 #include "naucrates/dxl/parser/CParseHandlerLogicalSetOp.h"
+#include "naucrates/dxl/parser/CParseHandlerLogicalValuesGet.h"
 #include "naucrates/dxl/parser/CParseHandlerLogicalCTEProducer.h"
 #include "naucrates/dxl/parser/CParseHandlerLogicalCTEConsumer.h"
 #include "naucrates/dxl/parser/CParseHandlerLogicalCTEAnchor.h"

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -651,7 +651,7 @@ namespace gpdxl
 		EdxltokenLogicalDifference,
 		EdxltokenLogicalDifferenceAll,
 		EdxltokenLogicalValuesGet,
-		EdxltokenLogicalValuesList,
+		EdxltokenValuesList,
 
 		EdxltokenIndexDescr,
 		EdxltokenIndexName,

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -650,6 +650,8 @@ namespace gpdxl
 		EdxltokenLogicalIntersectAll,
 		EdxltokenLogicalDifference,
 		EdxltokenLogicalDifferenceAll,
+		EdxltokenLogicalValuesGet,
+		EdxltokenLogicalValuesList,
 
 		EdxltokenIndexDescr,
 		EdxltokenIndexName,

--- a/libnaucrates/src/operators/CDXLLogicalValuesGet.cpp
+++ b/libnaucrates/src/operators/CDXLLogicalValuesGet.cpp
@@ -1,0 +1,180 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Software, Inc.
+//
+//	@filename:
+//		CDXLLogicalValuesGet.cpp
+//
+//	@doc:
+//		Implementation of DXL logical Value scan
+//		
+//	@owner: 
+//		
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+
+#include "gpos/string/CWStringDynamic.h"
+
+#include "naucrates/dxl/CDXLUtils.h"
+#include "naucrates/dxl/operators/CDXLLogicalValuesGet.h"
+#include "naucrates/dxl/operators/CDXLNode.h"
+#include "naucrates/dxl/xml/CXMLSerializer.h"
+
+
+using namespace gpos;
+using namespace gpdxl;
+
+// Ctor
+CDXLLogicalValuesGet::CDXLLogicalValuesGet
+	(
+	IMemoryPool *pmp,
+	DrgPdxlcd *pdrgdxlcd,
+	DrgPdrgPdxldatum *pdrgpdrgpdxldatum
+	)
+	:
+	CDXLLogical(pmp),
+	m_pdrgpdxlcd(pdrgdxlcd),
+	m_pdrgpdrgpdxldatumValuesList(pdrgpdrgpdxldatum)
+{
+	GPOS_ASSERT(NULL != m_pdrgpdxlcd);
+	GPOS_ASSERT(NULL != m_pdrgpdrgpdxldatumValuesList);
+	
+#ifdef GPOS_DEBUG	
+	const ULONG ulCols = m_pdrgpdxlcd->UlLength();
+	const ULONG ulLen = m_pdrgpdrgpdxldatumValuesList->UlLength();
+	for (ULONG ul = 0; ul < ulLen; ul++)
+	{
+		DrgPdxldatum *pdrgpdatum = (*m_pdrgpdrgpdxldatumValuesList)[ul];
+		GPOS_ASSERT(ulCols == pdrgpdatum->UlLength());
+	}
+
+#endif	
+}
+
+// Dtor
+CDXLLogicalValuesGet::~CDXLLogicalValuesGet()
+{
+	m_pdrgpdxlcd->Release();
+	m_pdrgpdrgpdxldatumValuesList->Release();
+}
+
+
+// Operator type
+Edxlopid
+CDXLLogicalValuesGet::Edxlop() const
+{
+	return EdxlopLogicalValuesGet;
+}
+
+
+// Operator name
+const CWStringConst *
+CDXLLogicalValuesGet::PstrOpName() const
+{
+		return CDXLTokens::PstrToken(EdxltokenLogicalValuesGet);
+}
+
+// Serialize operator in DXL format
+void
+CDXLLogicalValuesGet::SerializeToDXL
+	(
+	CXMLSerializer *pxmlser,
+	const CDXLNode *// pdxln
+	)
+	const
+{
+	const CWStringConst *pstrElemName = PstrOpName();
+	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
+
+	// serialize output columns
+	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenColumns));
+	GPOS_ASSERT(NULL != m_pdrgpdxlcd);
+
+	const ULONG ulLen = m_pdrgpdxlcd->UlLength();
+	for (ULONG ul = 0; ul < ulLen; ul++)
+	{
+		CDXLColDescr *pdxlcd = (*m_pdrgpdxlcd)[ul];
+		pdxlcd->SerializeToDXL(pxmlser);
+	}
+	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenColumns));
+
+	// serialize Values List
+	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenLogicalValuesList));
+	GPOS_ASSERT(NULL != m_pdrgpdrgpdxldatumValuesList);
+
+	const ULONG ulTuples = m_pdrgpdrgpdxldatumValuesList->UlLength();
+	for (ULONG ulTuplePos = 0; ulTuplePos < ulTuples; ulTuplePos++)
+	{
+		// serialize a const tuple
+		pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenConstTuple));
+		DrgPdxldatum *pdrgpdxldatum = (*m_pdrgpdrgpdxldatumValuesList)[ulTuplePos];
+
+		const ULONG ulCols = pdrgpdxldatum->UlLength();
+		for (ULONG ulColPos = 0; ulColPos < ulCols; ulColPos++)
+		{
+			CDXLDatum *pdxldatum = (*pdrgpdxldatum)[ulColPos];
+			pdxldatum->Serialize(pxmlser, CDXLTokens::PstrToken(EdxltokenDatum));
+		}
+
+		pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenConstTuple));
+	}
+
+	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenLogicalValuesList));
+
+	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
+}
+
+// Check if given column is defined by operator
+BOOL
+CDXLLogicalValuesGet::FDefinesColumn
+	(
+	ULONG ulColId
+	)
+	const
+{
+	const ULONG ulSize = UlArity();
+	for (ULONG ulDescr = 0; ulDescr < ulSize; ulDescr++)
+	{
+		ULONG ulId = Pdxlcd(ulDescr)->UlID();
+		if (ulId == ulColId)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// conversion function
+CDXLLogicalValuesGet *
+CDXLLogicalValuesGet::PdxlopConvert
+	(
+	CDXLOperator *pdxlop
+	)
+{
+	GPOS_ASSERT(NULL != pdxlop);
+	GPOS_ASSERT(EdxlopLogicalValuesGet == pdxlop->Edxlop());
+	
+	return dynamic_cast<CDXLLogicalValuesGet*>(pdxlop);
+}
+
+#ifdef GPOS_DEBUG
+
+// Checks whether operator node is well-structured
+void
+CDXLLogicalValuesGet::AssertValid
+	(
+	const CDXLNode *pdxln,
+	BOOL // fValidateChildren
+	) const
+{
+	// assert validity of col descr
+	GPOS_ASSERT(0 < m_pdrgpdxlcd->UlSafeLength());
+	GPOS_ASSERT(0 == pdxln->UlArity());
+}
+
+#endif // GPOS_DEBUG
+
+// EOF

--- a/libnaucrates/src/operators/CDXLLogicalValuesGet.cpp
+++ b/libnaucrates/src/operators/CDXLLogicalValuesGet.cpp
@@ -101,7 +101,7 @@ CDXLLogicalValuesGet::SerializeToDXL
 	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenColumns));
 
 	// serialize Values List
-	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenLogicalValuesList));
+	pxmlser->OpenElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenValuesList));
 	GPOS_ASSERT(NULL != m_pdrgpdrgpdxldatumValuesList);
 
 	const ULONG ulTuples = m_pdrgpdrgpdxldatumValuesList->UlLength();
@@ -121,7 +121,7 @@ CDXLLogicalValuesGet::SerializeToDXL
 		pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenConstTuple));
 	}
 
-	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenLogicalValuesList));
+	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), CDXLTokens::PstrToken(EdxltokenValuesList));
 
 	pxmlser->CloseElement(CDXLTokens::PstrToken(EdxltokenNamespacePrefix), pstrElemName);
 }

--- a/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -272,6 +272,8 @@ CParseHandlerFactory::Init
 			{EdxltokenLogicalDifference, &PphLgSetOp},
 			{EdxltokenLogicalDifferenceAll, &PphLgSetOp},
 
+			{EdxltokenLogicalValuesGet, &PphLgValuesGet},
+		
 			{EdxltokenStatistics, &PphStats},
 			{EdxltokenStatsDerivedColumn, &PphStatsDerivedColumn},
 			{EdxltokenStatsDerivedRelation, &PphStatsDerivedRelation},
@@ -2765,6 +2767,19 @@ CParseHandlerFactory::PphLgSetOp
 	)
 {
 	return GPOS_NEW(pmp) CParseHandlerLogicalSetOp(pmp, pphm, pphRoot);
+}
+
+
+// Creates a parse handler for parsing a logical value scan operator
+CParseHandlerBase *
+CParseHandlerFactory::PphLgValuesGet
+(
+	IMemoryPool *pmp,
+	CParseHandlerManager *pphm,
+	CParseHandlerBase *pphRoot
+	)
+{
+	return GPOS_NEW(pmp) CParseHandlerLogicalValuesGet(pmp, pphm, pphRoot);
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/parser/CParseHandlerLogicalValuesGet.cpp
+++ b/libnaucrates/src/parser/CParseHandlerLogicalValuesGet.cpp
@@ -1,0 +1,159 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal Software, Inc.
+//
+//	@filename:
+//		CParseHandlerLogicalValuesGet.cpp
+//
+//	@doc:
+//		Implementation of the SAX parse handler class for parsing logical
+//		value scan.
+//
+//	@owner: 
+//		
+//
+//	@test:
+//
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/parser/CParseHandlerLogicalValuesGet.h"
+#include "naucrates/dxl/parser/CParseHandlerColDescr.h"
+#include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+#include "naucrates/dxl/parser/CParseHandlerFactory.h"
+
+using namespace gpdxl;
+
+XERCES_CPP_NAMESPACE_USE
+
+// Ctor
+CParseHandlerLogicalValuesGet::CParseHandlerLogicalValuesGet
+	(
+	IMemoryPool *pmp,
+	CParseHandlerManager *pphm,
+	CParseHandlerBase *pphRoot
+	)
+	:
+	CParseHandlerLogicalOp(pmp, pphm, pphRoot),
+	m_pdrgpdrgpdxldatum(NULL),
+	m_pdrgpdxldatum(NULL)
+{
+}
+
+// Dtor
+CParseHandlerLogicalValuesGet::~CParseHandlerLogicalValuesGet()
+{
+}
+
+// Invoked by Xerces to process an opening tag
+void
+CParseHandlerLogicalValuesGet::StartElement
+	(
+	const XMLCh* const , // xmlszUri,
+	const XMLCh* const xmlszLocalname,
+	const XMLCh* const , // xmlszQname,
+	const Attributes& attrs
+	)
+{
+	if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenLogicalValuesGet), xmlszLocalname))
+	{
+		// start of a const table operator node
+		GPOS_ASSERT(0 == this->UlLength());
+
+		// install a parse handler for the columns
+		CParseHandlerBase *pphColDescr = CParseHandlerFactory::Pph(m_pmp, CDXLTokens::XmlstrToken(EdxltokenColumns), m_pphm, this);
+		m_pphm->ActivateParseHandler(pphColDescr);
+
+		// store parse handler
+		this->Append(pphColDescr);
+	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenValuesList), xmlszLocalname))
+	{
+		GPOS_ASSERT(NULL == m_pdrgpdrgpdxldatum);
+
+		// initialize the array of const tuples (datum arrays)
+		m_pdrgpdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdrgPdxldatum(m_pmp);
+	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenConstTuple), xmlszLocalname))
+	{
+		GPOS_ASSERT(NULL != m_pdrgpdrgpdxldatum); // we must have already seen a logical values list
+		GPOS_ASSERT(NULL == m_pdrgpdxldatum);
+
+		// initialize the array of datums (const tuple)
+		m_pdrgpdxldatum = GPOS_NEW(m_pmp) DrgPdxldatum(m_pmp);
+	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenDatum), xmlszLocalname))
+	{
+		// we must have already seen a logical values list and a const tuple
+		GPOS_ASSERT(NULL != m_pdrgpdrgpdxldatum);
+		GPOS_ASSERT(NULL != m_pdrgpdxldatum);
+
+		// translate the datum and add it to the datum array
+		CDXLDatum *pdxldatum = CDXLOperatorFactory::Pdxldatum(m_pphm->Pmm(), attrs, EdxltokenScalarConstValue);
+		m_pdrgpdxldatum->Append(pdxldatum);
+	}
+	else
+	{
+		CWStringDynamic *pstr = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), xmlszLocalname);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, pstr->Wsz());
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerLogicalValuesGet::EndElement
+//
+//	@doc:
+//		Invoked by Xerces to process a closing tag
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerLogicalValuesGet::EndElement
+	(
+	const XMLCh* const, // xmlszUri,
+	const XMLCh* const xmlszLocalname,
+	const XMLCh* const // xmlszQname
+	)
+{
+	if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenLogicalValuesGet), xmlszLocalname))
+	{
+		GPOS_ASSERT(1 == this->UlLength());
+
+		CParseHandlerColDescr *pphColDescr = dynamic_cast<CParseHandlerColDescr *>((*this)[0]);
+		GPOS_ASSERT(NULL != pphColDescr->Pdrgpdxlcd());
+
+		DrgPdxlcd *pdrgpdxlcd = pphColDescr->Pdrgpdxlcd();
+		pdrgpdxlcd->AddRef();
+
+		CDXLLogicalValuesGet *pdxlopValuesGet = GPOS_NEW(m_pmp) CDXLLogicalValuesGet(m_pmp, pdrgpdxlcd, m_pdrgpdrgpdxldatum);
+		m_pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, pdxlopValuesGet);
+
+#ifdef GPOS_DEBUG
+		pdxlopValuesGet->AssertValid(m_pdxln, false /* fValidateChildren */);
+#endif // GPOS_DEBUG
+
+		// deactivate handler
+	  	m_pphm->DeactivateHandler();
+	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenValuesList), xmlszLocalname))
+	{
+		// Do nothing
+	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenConstTuple), xmlszLocalname))
+	{
+		GPOS_ASSERT(NULL != m_pdrgpdxldatum);
+		m_pdrgpdrgpdxldatum->Append(m_pdrgpdxldatum);
+
+		m_pdrgpdxldatum = NULL; // re-initialize for the parsing the next const tuple (if needed)
+	}
+
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenDatum), xmlszLocalname))
+	{
+		// Do nothing
+	}
+	else
+	{
+		CWStringDynamic *pstr = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), xmlszLocalname);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, pstr->Wsz());
+	}
+}
+// EOF

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -674,6 +674,7 @@ CDXLTokens::Init
 			{EdxltokenLogicalDifferenceAll, GPOS_WSZ_LIT("DifferenceAll")},
 
 			{EdxltokenLogicalValuesGet, GPOS_WSZ_LIT("LogicalValuesGet")},
+			{EdxltokenValuesList, GPOS_WSZ_LIT("ValuesList")},
 
 			{EdxltokenIndexDescr, GPOS_WSZ_LIT("IndexDescriptor")},
 			{EdxltokenIndexName, GPOS_WSZ_LIT("IndexName")},

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -673,6 +673,8 @@ CDXLTokens::Init
 			{EdxltokenLogicalDifference, GPOS_WSZ_LIT("Difference")},
 			{EdxltokenLogicalDifferenceAll, GPOS_WSZ_LIT("DifferenceAll")},
 
+			{EdxltokenLogicalValuesGet, GPOS_WSZ_LIT("LogicalValuesGet")},
+
 			{EdxltokenIndexDescr, GPOS_WSZ_LIT("IndexDescriptor")},
 			{EdxltokenIndexName, GPOS_WSZ_LIT("IndexName")},
 			{EdxltokenScalarIndexCondList, GPOS_WSZ_LIT("IndexCondList")},

--- a/server/src/unittest/dxl/CParseHandlerTest.cpp
+++ b/server/src/unittest/dxl/CParseHandlerTest.cpp
@@ -117,6 +117,7 @@ CParseHandlerTest::m_rgszQueryDXLFileNames[] =
 		"../data/dxl/parse_tests/q68-ArrayRef1.xml",
 		"../data/dxl/parse_tests/q69-ArrayRef2.xml",
 		"../data/dxl/parse_tests/q75-MinMax.xml",
+		"../data/dxl/parse_tests/q76-ValueScan.xml",
 	};
 
 // files for the statistics tests


### PR DESCRIPTION
Postgres and thus (GPDB Planner) supports Values via an operator called ValueScan.
```
explain SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS t (num,letter);
                          QUERY PLAN
--------------------------------------------------------------
 Values Scan on "*VALUES*"  (cost=0.00..0.04 rows=1 width=36)
 Optimizer status: legacy query optimizer
(2 rows)
```
However, inside Orca we expand each row in the Values list into a Result node that projects two constants.
Thus the above query with three rows having 2 columns is represented as a plan by GPORCA as an append with three Result nodes.
Each of the Result nodes is a CTG with project elements.
```
explain SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS t (num,letter);
                   QUERY PLAN
-------------------------------------------------
 Append  (cost=0.00..0.00 rows=1 width=12)
   ->  Result  (cost=0.00..0.00 rows=1 width=12)
   ->  Result  (cost=0.00..0.00 rows=1 width=12)
   ->  Result  (cost=0.00..0.00 rows=1 width=12)
 Settings:  optimizer=on
 Optimizer status: PQO version 2.32.0
(6 rows)
```
As a first step of this effort of adding support for ValueScan node inside ORCA; this PR implements the DXL representation of the Value Scan along with the ParseHandler changes for this newly added DXL node. 
The Translator changes for GPDB are in progress, where in the QueryToDXL translator will generate a valuescan node instead of a unionall for queries with value list. 