### PR TITLE
Enable GPORCA to generate better plans for non-correlated exists subquery in the WHERE clause

### DIFF
--- a/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
+++ b/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
@@ -1,0 +1,804 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
+      <dxl:TraceFlags Value="101013,102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3742"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7598"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7598"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="11745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="11745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="15903"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="15903"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="19936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="19936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="23966"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="23966"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="28155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="28155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="32285"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="32285"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39915"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="43764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="43764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47628"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="55154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="55154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="58988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="58988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="62978"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="62978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="71280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="71280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="83323"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="83323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="87255"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="87255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="91375"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="91375"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95343"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99961"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3742"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3742"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7598"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="7598"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="11745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="11745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="15903"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="15903"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="19936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="19936"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="23966"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="23966"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="28155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="28155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="32285"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="32285"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36081"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36081"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39915"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="39915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="43764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="43764"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="47628"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="51440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="55154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="55154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="58988"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="58988"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="62978"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="62978"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67235"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="67235"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="71280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="71280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75169"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="75169"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79332"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79332"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="83323"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="83323"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="87255"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="87255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="91375"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="91375"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="3982.800000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="95343"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="99961"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.16531.1.0" Name="bar" Rows="99570.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.16531.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16528.1.0" Name="foo" Rows="1000809.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16528.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36582"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36582"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79388"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="118632"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="118632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="164443"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="164443"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="244737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="244737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="281391"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="281391"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="318509"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="318509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="357676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="357676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="395046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="395046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="431410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="431410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="473463"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="473463"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="513018"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="513018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="551495"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="551495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="588434"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="588434"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="630133"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="630133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="673940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="673940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="714130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="714130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="754005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="754005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="794294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="794294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="832747"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="832747"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="873584"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="873584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955297"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36582"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="36582"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="79388"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="118632"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="118632"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="164443"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="164443"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204512"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="204512"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="244737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="244737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="281391"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="281391"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="318509"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="318509"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="357676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="357676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="395046"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="395046"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="431410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="431410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="473463"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="473463"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="513018"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="513018"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="551495"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="551495"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="588434"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="588434"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="630133"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="630133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="673940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="673940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="714130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="714130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="754005"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="754005"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="794294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="794294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="832747"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="832747"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="873584"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="873584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915842"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="915842"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.040000" DistinctValues="40032.360000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="955297"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="999999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="99570.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1000809.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16531.1.0.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16528.1.0.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:SubqueryExists>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.16531.1.0" TableName="bar">
+                <dxl:Columns>
+                  <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:SubqueryExists>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16528.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="12">
+      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1311.703342" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:JoinFilter>
+          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+        </dxl:JoinFilter>
+        <dxl:Limit>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.755409" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList/>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.755408" Rows="1.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:Limit>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.755405" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.693671" Rows="99570.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16531.1.0" TableName="bar">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:LimitCount>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:LimitCount>
+              <dxl:LimitOffset>
+                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+              </dxl:LimitOffset>
+            </dxl:Limit>
+          </dxl:GatherMotion>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          </dxl:LimitOffset>
+        </dxl:Limit>
+        <dxl:Materialize Eager="true">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="448.947884" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="448.947876" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="448.947846" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="0.16528.1.0" TableName="foo">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:GatherMotion>
+        </dxl:Materialize>
+      </dxl:NestedLoopJoin>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -427,10 +427,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-<dxl:Plan Id="0" SpaceSize="279471">
+<dxl:Plan Id="0" SpaceSize="21960">
   <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
     <dxl:Properties>
-      <dxl:Cost StartupCost="0" TotalCost="16.184570" Rows="1.000000" Width="8"/>
+      <dxl:Cost StartupCost="0" TotalCost="17.186035" Rows="1.000000" Width="8"/>
     </dxl:Properties>
     <dxl:ProjList>
       <dxl:ProjElem ColId="0" Alias="i">
@@ -442,9 +442,9 @@
     </dxl:ProjList>
     <dxl:Filter/>
     <dxl:SortingColumnList/>
-    <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false">
+    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
       <dxl:Properties>
-        <dxl:Cost StartupCost="0" TotalCost="15.180664" Rows="1.000000" Width="8"/>
+        <dxl:Cost StartupCost="0" TotalCost="16.182129" Rows="1.000000" Width="8"/>
       </dxl:Properties>
       <dxl:ProjList>
         <dxl:ProjElem ColId="0" Alias="i">
@@ -458,6 +458,167 @@
       <dxl:JoinFilter>
         <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
       </dxl:JoinFilter>
+      <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="7.178223" Rows="2.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:ProjList/>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Limit>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.176270" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList/>
+          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="5.174316" Rows="1.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="4.173828" Rows="1.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="j">
+                    <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="3.128906" Rows="2.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="19" Alias="j">
+                    <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashJoin JoinType="In">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="2.125000" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="19" Alias="j">
+                      <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="18" Alias="i">
+                        <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="19" Alias="j">
+                        <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.1159276.1.1" TableName="a">
+                      <dxl:Columns>
+                        <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="27" Alias="i">
+                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="j">
+                        <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
+                        <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                        </dxl:Array>
+                      </dxl:ArrayComp>
+                    </dxl:Filter>
+                    <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
+                      <dxl:Columns>
+                        <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:HashJoin>
+              </dxl:BroadcastMotion>
+            </dxl:HashJoin>
+          </dxl:GatherMotion>
+          <dxl:LimitCount>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="1"/>
+          </dxl:LimitCount>
+          <dxl:LimitOffset>
+            <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+          </dxl:LimitOffset>
+        </dxl:Limit>
+      </dxl:BroadcastMotion>
       <dxl:TableScan>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="1.000000" Width="8"/>
@@ -485,154 +646,6 @@
           </dxl:Columns>
         </dxl:TableDescriptor>
       </dxl:TableScan>
-      <dxl:Materialize Eager="true">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.176758" Rows="2.000000" Width="1"/>
-        </dxl:Properties>
-        <dxl:ProjList/>
-        <dxl:Filter/>
-        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5.174805" Rows="2.000000" Width="1"/>
-          </dxl:Properties>
-          <dxl:ProjList/>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:HashJoin JoinType="Inner">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="4.173828" Rows="1.000000" Width="1"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:JoinFilter/>
-            <dxl:HashCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:HashCondList>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="j">
-                  <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                <dxl:Columns>
-                  <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="10" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-            <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.128906" Rows="2.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="19" Alias="j">
-                  <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashJoin JoinType="In">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2.125000" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="j">
-                    <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.007812" Rows="1.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="18" Alias="i">
-                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="19" Alias="j">
-                      <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.1159276.1.1" TableName="a">
-                    <dxl:Columns>
-                      <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1.023438" Rows="1.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="27" Alias="i">
-                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="28" Alias="j">
-                      <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter>
-                    <dxl:ArrayComp OperatorName="&lt;&gt;" OperatorMdid="0.518.1.0" OperatorType="All">
-                      <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Array ArrayType="0.1007.1.0" ElementType="0.23.1.0" MultiDimensional="false">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-                      </dxl:Array>
-                    </dxl:ArrayComp>
-                  </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="0.1159322.1.1" TableName="c">
-                    <dxl:Columns>
-                      <dxl:Column ColId="27" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="28" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="30" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="31" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="32" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="33" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="34" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="35" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:HashJoin>
-            </dxl:BroadcastMotion>
-          </dxl:HashJoin>
-        </dxl:BroadcastMotion>
-      </dxl:Materialize>
     </dxl:NestedLoopJoin>
   </dxl:GatherMotion>
 </dxl:Plan>

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -1075,6 +1075,9 @@ namespace gpopt
 			// get execution locality
 			static
 			EExecLocalityType ExecLocalityType(CDistributionSpec *pds);
+
+            // generate a limit expression on top of the given relational child with the given offset and limit count
+			static CExpression *PexprLimit(IMemoryPool *pmp, CExpression *pexpr, ULONG ulOffSet, ULONG ulCount);
 	}; // class CUtils
 
 	// hash set from expressions

--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -89,6 +89,10 @@ namespace gpopt
 			static
 			CExpression *PexprTrimExistentialSubqueries(IMemoryPool *pmp, CExpression *pexpr);
 
+			// simplify exists subqueries
+			static
+			CExpression *PexprSimplifyExistentialPredicates(IMemoryPool *pmp, CExpression *pexpe);
+
 			// simplify quantified subqueries
 			static
 			CExpression *PexprSimplifyQuantifiedSubqueries(IMemoryPool *pmp, CExpression *pexpr);

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -58,14 +58,7 @@ using namespace gpmd;
 const ULONG ulBufferCapacity = 16 * 1024 * 1024;
 static WCHAR wszBuffer[ulBufferCapacity];
 
-//---------------------------------------------------------------------------
-//	@function:
-//		PrintExpr
-//
-//	@doc:
-//		Global wrapper for debug print of expression
-//
-//---------------------------------------------------------------------------
+// global wrapper for debug print of expression
 void PrintExpr
 	(
 	void *pv
@@ -74,14 +67,7 @@ void PrintExpr
 	gpopt::CUtils::PrintExpression((gpopt::CExpression*)pv);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PrintExpression
-//
-//	@doc:
-//		Debug print expression
-//
-//---------------------------------------------------------------------------
+// debug print expression
 void
 CUtils::PrintExpression
 	(
@@ -104,15 +90,7 @@ CUtils::PrintExpression
 	str.Reset();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		PrintMemo
-//
-//	@doc:
-//		Global wrapper for debug print of memo
-//
-//---------------------------------------------------------------------------
+// global wrapper for debug print of memo
 void PrintMemo
 	(
 	void *pv
@@ -121,14 +99,7 @@ void PrintMemo
 	gpopt::CUtils::PrintMemo((gpopt::CMemo*)pv);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PrintMemo
-//
-//	@doc:
-//		Debug print Memo structure
-//
-//---------------------------------------------------------------------------
+// debug print Memo structure
 void
 CUtils::PrintMemo
 	(
@@ -153,14 +124,7 @@ CUtils::PrintMemo
 	str.Reset();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::OsPrintDrgPcoldesc
-//
-//	@doc:
-//		Helper function to print a column descriptor array
-//
-//---------------------------------------------------------------------------
+// helper function to print a column descriptor array
 IOstream &
 CUtils::OsPrintDrgPcoldesc
 	(
@@ -184,15 +148,7 @@ CUtils::OsPrintDrgPcoldesc
 
 #endif // GPOS_DEBUG
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarIdent
-//
-//	@doc:
-//		Generate a ScalarIdent expression
-//
-//---------------------------------------------------------------------------
+// generate a ScalarIdent expression
 CExpression *
 CUtils::PexprScalarIdent
 	(
@@ -205,15 +161,7 @@ CUtils::PexprScalarIdent
 	return GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CScalarIdent(pmp, pcr));
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarProjectElement
-//
-//	@doc:
-//		Generate a ScalarProjectElement expression
-//
-//---------------------------------------------------------------------------
+// generate a ScalarProjectElement expression
 CExpression *
 CUtils::PexprScalarProjectElement
 	(
@@ -228,14 +176,7 @@ CUtils::PexprScalarProjectElement
 	return GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CScalarProjectElement(pmp, pcr), pexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PmdidScCmp
-//
-//	@doc:
-//		Return the scalar comparison operator id between the two types
-//
-//---------------------------------------------------------------------------
+// return the scalar comparison operator id between the two types
 IMDId *
 CUtils::PmdidScCmp
 	(
@@ -279,14 +220,7 @@ CUtils::PmdidScCmp
 	return pmda->Pmdsccmp(pmdidLeft, pmdidRight, ecmpt)->PmdidOp();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression over two columns
-//
-//---------------------------------------------------------------------------
+// generate a comparison expression over two columns
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -324,14 +258,8 @@ CUtils::PexprScalarCmp
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FCmpOrCastedCmpExists
-//
-//	@doc:
-//		Check is a comparison between given types or a comparison after casting
-//		one side to an another exists
-//---------------------------------------------------------------------------
+// check is a comparison between given types or a comparison after casting
+// one side to an another exists
 BOOL
 CUtils::FCmpOrCastedCmpExists
 	(
@@ -360,14 +288,7 @@ CUtils::FCmpOrCastedCmpExists
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression between a column and an expression
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression between a column and an expression
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -405,14 +326,7 @@ CUtils::PexprScalarCmp
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression between two columns
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression between two columns
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -432,14 +346,7 @@ CUtils::PexprScalarCmp
 	return PexprScalarCmp(pmp, pexprLeft, pexprRight, ecmpt);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression over a column and an expression
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression over a column and an expression
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -458,14 +365,7 @@ CUtils::PexprScalarCmp
 	return PexprScalarCmp(pmp, pexprLeft, pexprRight, ecmpt);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression between an expression and a column
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression between an expression and a column
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -484,14 +384,7 @@ CUtils::PexprScalarCmp
 	return PexprScalarCmp(pmp, pexprLeft, pexprRight, ecmpt);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression over an expression and a column
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression over an expression and a column
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -529,14 +422,7 @@ CUtils::PexprScalarCmp
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression over two expressions
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression over two expressions
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -574,14 +460,7 @@ CUtils::PexprScalarCmp
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarCmp
-//
-//	@doc:
-//		Generate a comparison expression over two expressions
-//
-//---------------------------------------------------------------------------
+// Generate a comparison expression over two expressions
 CExpression *
 CUtils::PexprScalarCmp
 	(
@@ -641,14 +520,7 @@ CUtils::PexprScalarCmp
 	return pexprResult;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarEqCmp
-//
-//	@doc:
-//		Generate an equality comparison expression over two columns
-//
-//---------------------------------------------------------------------------
+// Generate an equality comparison expression over two columns
 CExpression *
 CUtils::PexprScalarEqCmp
 	(
@@ -663,14 +535,7 @@ CUtils::PexprScalarEqCmp
 	return PexprScalarCmp(pmp, pcrLeft, pcrRight, IMDType::EcmptEq);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarEqCmp
-//
-//	@doc:
-//		Generate an equality comparison expression over two expressions
-//
-//---------------------------------------------------------------------------
+// Generate an equality comparison expression over two expressions
 CExpression *
 CUtils::PexprScalarEqCmp
 	(
@@ -685,15 +550,7 @@ CUtils::PexprScalarEqCmp
 	return PexprScalarCmp(pmp, pexprLeft, pexprRight, IMDType::EcmptEq);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarEqCmp
-//
-//	@doc:
-//		Generate an equality comparison expression over a column reference and
-//		an expression
-//
-//---------------------------------------------------------------------------
+// Generate an equality comparison expression over a column reference and an expression
 CExpression *
 CUtils::PexprScalarEqCmp
 	(
@@ -708,15 +565,7 @@ CUtils::PexprScalarEqCmp
 	return PexprScalarCmp(pmp, pcrLeft, pexprRight, IMDType::EcmptEq);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarEqCmp
-//
-//	@doc:
-//		Generate an equality comparison expression over an expression and a
-//		column reference
-//
-//---------------------------------------------------------------------------
+// Generate an equality comparison expression over an expression and a column reference
 CExpression *
 CUtils::PexprScalarEqCmp
 	(
@@ -890,14 +739,7 @@ CUtils::PexprCollapseConstArray
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarArrayCmp
-//
-//	@doc:
-//		Generate an ArrayCmp expression given an array of CScalarConst's
-//
-//---------------------------------------------------------------------------
+// generate an ArrayCmp expression given an array of CScalarConst's
 CExpression *
 CUtils::PexprScalarArrayCmp
 	(
@@ -941,14 +783,7 @@ CUtils::PexprScalarArrayCmp
 				);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprZeroCmp
-//
-//	@doc:
-//		Generate a comparison against Zero
-//
-//---------------------------------------------------------------------------
+// generate a comparison against Zero
 CExpression *
 CUtils::PexprCmpWithZero
 	(
@@ -978,14 +813,7 @@ CUtils::PexprCmpWithZero
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprIDF
-//
-//	@doc:
-//		Generate an Is Distinct From expression
-//
-//---------------------------------------------------------------------------
+// generate an Is Distinct From expression
 CExpression *
 CUtils::PexprIDF
 	(
@@ -1035,15 +863,7 @@ CUtils::PexprIDF
 				);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprINDF
-//
-//	@doc:
-//		Generate an Is NOT Distinct From expression for two columns;
-//		the two columns must have the same type
-//
-//---------------------------------------------------------------------------
+// generate an Is NOT Distinct From expression for two columns; the two columns must have the same type
 CExpression *
 CUtils::PexprINDF
 	(
@@ -1058,15 +878,8 @@ CUtils::PexprINDF
 	return PexprINDF(pmp, PexprScalarIdent(pmp, pcrLeft), PexprScalarIdent(pmp, pcrRight));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprINDF
-//
-//	@doc:
-//		Generate an Is NOT Distinct From expression for scalar expressions;
-//		the two expressions must have the same type
-//
-//---------------------------------------------------------------------------
+// Generate an Is NOT Distinct From expression for scalar expressions;
+// the two expressions must have the same type
 CExpression *
 CUtils::PexprINDF
 	(
@@ -1081,14 +894,7 @@ CUtils::PexprINDF
 	return PexprNegate(pmp, PexprIDF(pmp, pexprLeft, pexprRight));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprIsNull
-//
-//	@doc:
-//		Generate an Is Null expression
-//
-//---------------------------------------------------------------------------
+// Generate an Is Null expression
 CExpression *
 CUtils::PexprIsNull
 	(
@@ -1100,14 +906,8 @@ CUtils::PexprIsNull
 
 	return GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CScalarNullTest(pmp), pexpr);
 }
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprIsNotNull
-//
-//	@doc:
-//		Generate an Is Not Null expression
-//
-//---------------------------------------------------------------------------
+
+// Generate an Is Not Null expression
 CExpression *
 CUtils::PexprIsNotNull
 	(
@@ -1120,14 +920,7 @@ CUtils::PexprIsNotNull
 	return PexprNegate(pmp, PexprIsNull(pmp, pexpr));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprIsNotFalse
-//
-//	@doc:
-//		Generate an Is Not False expression
-//
-//---------------------------------------------------------------------------
+// Generate an Is Not False expression
 CExpression *
 CUtils::PexprIsNotFalse
 	(
@@ -1140,15 +933,8 @@ CUtils::PexprIsNotFalse
 	return PexprIDF(pmp, pexpr, PexprScalarConstBool(pmp, false /*fVal*/));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FUsesNullableCol
-//
-//	@doc:
-//		Find if a scalar expression uses a nullable column from the
-//		output of a logical expression
-//
-//---------------------------------------------------------------------------
+// Find if a scalar expression uses a nullable column from the
+// output of a logical expression
 BOOL
 CUtils::FUsesNullableCol
 	(
@@ -1171,14 +957,7 @@ CUtils::FUsesNullableCol
 	return fUsesNullableCol;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrExtractPartKey
-//
-//	@doc:
-//		Extract the partition key at the given level from the given array of partition keys
-//
-//---------------------------------------------------------------------------
+// Extract the partition key at the given level from the given array of partition keys
 CColRef *
 CUtils::PcrExtractPartKey
 	(
@@ -1195,14 +974,7 @@ CUtils::PcrExtractPartKey
 	return (*pdrgpcrPartKey)[0];
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasSubquery
-//
-//	@doc:
-//		Check for existence of subqueries
-//
-//---------------------------------------------------------------------------
+// check for existence of subqueries
 BOOL
 CUtils::FHasSubquery
 	(
@@ -1296,15 +1068,7 @@ CUtils::FHasCorrelatedApply
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasOuterRefs
-//
-//	@doc:
-//		Check for existence of outer references
-//
-//---------------------------------------------------------------------------
+// check for existence of outer references
 BOOL
 CUtils::FHasOuterRefs
 	(
@@ -1318,15 +1082,7 @@ CUtils::FHasOuterRefs
 	return 0 < CDrvdPropRelational::Pdprel(pdp)->PcrsOuter()->CElements();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FLogicalJoin
-//
-//	@doc:
-//		Check if a given operator is a logical join
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a logical join
 BOOL
 CUtils::FLogicalJoin
 	(
@@ -1346,15 +1102,7 @@ CUtils::FLogicalJoin
 	return (NULL != popJoin);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FLogicalSetOp
-//
-//	@doc:
-//		Check if a given operator is a logical set operation
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a logical set operation
 BOOL
 CUtils::FLogicalSetOp
 	(
@@ -1374,15 +1122,7 @@ CUtils::FLogicalSetOp
 	return (NULL != popSetOp);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FLogicalUnary
-//
-//	@doc:
-//		Check if a given operator is a logical unary operator
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a logical unary operator
 BOOL
 CUtils::FLogicalUnary
 	(
@@ -1402,15 +1142,7 @@ CUtils::FLogicalUnary
 	return (NULL != popUnary);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHashJoin
-//
-//	@doc:
-//		Check if a given operator is a hash join
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a hash join
 BOOL
 CUtils::FHashJoin
 	(
@@ -1428,15 +1160,7 @@ CUtils::FHashJoin
 	return (NULL != popHJN);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FCorrelatedNLJoin
-//
-//	@doc:
-//		Check if a given operator is a correlated nested loops join
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a correlated nested loops join
 BOOL
 CUtils::FCorrelatedNLJoin
 	(
@@ -1454,15 +1178,7 @@ CUtils::FCorrelatedNLJoin
 	return fCorrelatedNLJ;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FNLJoin
-//
-//	@doc:
-//		Check if a given operator is a nested loops join
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a nested loops join
 BOOL
 CUtils::FNLJoin
 	(
@@ -1480,15 +1196,7 @@ CUtils::FNLJoin
 	return (NULL != popNLJ);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FPhysicalJoin
-//
-//	@doc:
-//		Check if a given operator is a logical join
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a logical join
 BOOL
 CUtils::FPhysicalJoin
 	(
@@ -1500,15 +1208,7 @@ CUtils::FPhysicalJoin
 	return FHashJoin(pop) || FNLJoin(pop);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FPhysicalOuterJoin
-//
-//	@doc:
-//		Check if a given operator is a physical outer join
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a physical outer join
 BOOL
 CUtils::FPhysicalOuterJoin
 	(
@@ -1522,15 +1222,7 @@ CUtils::FPhysicalOuterJoin
 		COperator::EopPhysicalCorrelatedLeftOuterNLJoin == pop->Eopid();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FPhysicalScan
-//
-//	@doc:
-//		Check if a given operator is a physical agg
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a physical agg
 BOOL
 CUtils::FPhysicalScan
 	(
@@ -1550,15 +1242,7 @@ CUtils::FPhysicalScan
 	return (NULL != popScan);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FPhysicalAgg
-//
-//	@doc:
-//		Check if a given operator is a physical agg
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a physical agg
 BOOL
 CUtils::FPhysicalAgg
 	(
@@ -1578,14 +1262,7 @@ CUtils::FPhysicalAgg
 	return (NULL != popAgg);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FPhysicalMotion
-//
-//	@doc:
-//		Check if a given operator is a physical motion
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a physical motion
 BOOL
 CUtils::FPhysicalMotion
 	(
@@ -1605,15 +1282,7 @@ CUtils::FPhysicalMotion
 	return (NULL != popMotion);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FEnforcer
-//
-//	@doc:
-//		Check if a given operator is an FEnforcer
-//
-//---------------------------------------------------------------------------
+// check if a given operator is an FEnforcer
 BOOL
 CUtils::FEnforcer
 	(
@@ -1630,14 +1299,7 @@ CUtils::FEnforcer
 		FPhysicalMotion(pop);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FApply
-//
-//	@doc:
-//		Check if a given operator is an Apply
-//
-//---------------------------------------------------------------------------
+// check if a given operator is an Apply
 BOOL
 CUtils::FApply
 	(
@@ -1657,15 +1319,7 @@ CUtils::FApply
 	return (NULL != popApply);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FCorrelatedApply
-//
-//	@doc:
-//		Check if a given operator is a correlated Apply
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a correlated Apply
 BOOL
 CUtils::FCorrelatedApply
 	(
@@ -1683,15 +1337,7 @@ CUtils::FCorrelatedApply
 	return  fCorrelatedApply;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FLeftSemiApply
-//
-//	@doc:
-//		Check if a given operator is left semi apply
-//
-//---------------------------------------------------------------------------
+// check if a given operator is left semi apply
 BOOL
 CUtils::FLeftSemiApply
 	(
@@ -1709,14 +1355,7 @@ CUtils::FLeftSemiApply
 	return fLeftSemiApply;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FLeftAntiSemiApply
-//
-//	@doc:
-//		Check if a given operator is left anti semi apply
-//
-//---------------------------------------------------------------------------
+// check if a given operator is left anti semi apply
 BOOL
 CUtils::FLeftAntiSemiApply
 	(
@@ -1734,14 +1373,7 @@ CUtils::FLeftAntiSemiApply
 	return fLeftAntiSemiApply;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FSubquery
-//
-//	@doc:
-//		Check if a given operator is a subquery
-//
-//---------------------------------------------------------------------------
+// check if a given operator is a subquery
 BOOL
 CUtils::FSubquery
 	(
@@ -1759,15 +1391,7 @@ CUtils::FSubquery
 			COperator::EopScalarSubqueryAny == eopid);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FExistentialSubquery
-//
-//	@doc:
-//		Check if a given operator is existential subquery
-//
-//---------------------------------------------------------------------------
+// check if a given operator is existential subquery
 BOOL
 CUtils::FExistentialSubquery
 	(
@@ -1782,15 +1406,7 @@ CUtils::FExistentialSubquery
 			COperator::EopScalarSubqueryNotExists == eopid);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FQuantifiedSubquery
-//
-//	@doc:
-//		Check if a given operator is quantified subquery
-//
-//---------------------------------------------------------------------------
+// check if a given operator is quantified subquery
 BOOL
 CUtils::FQuantifiedSubquery
 	(
@@ -1805,16 +1421,8 @@ CUtils::FQuantifiedSubquery
 			COperator::EopScalarSubqueryAny == eopid);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FProjectConstTableWithOneScalarSubq
-//
-//	@doc:
-//		Check if given expression is a Project on ConstTable with one
-//		scalar subquery in Project List
-//
-//---------------------------------------------------------------------------
+// check if given expression is a Project on ConstTable with one
+// scalar subquery in Project List
 BOOL
 CUtils::FProjectConstTableWithOneScalarSubq
 	(
@@ -1838,15 +1446,7 @@ CUtils::FProjectConstTableWithOneScalarSubq
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FProjElemWithScalarSubq
-//
-//	@doc:
-//		Check if given expression is a Project Element with scalar subquery
-//
-//---------------------------------------------------------------------------
+// check if given expression is a Project Element with scalar subquery
 BOOL
 CUtils::FProjElemWithScalarSubq
 	(
@@ -1859,15 +1459,7 @@ CUtils::FProjElemWithScalarSubq
 		COperator::EopScalarSubquery == (*pexpr)[0]->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarSubqWithConstTblGet
-//
-//	@doc:
-//		Check if given expression is a scalar subquery with a ConstTableGet
-//		as the only child
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar subquery with a ConstTableGet as the only child
 BOOL
 CUtils::FScalarSubqWithConstTblGet
 (
@@ -1886,14 +1478,7 @@ CUtils::FScalarSubqWithConstTblGet
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasZeroOffset
-//
-//	@doc:
-//		Check if a limit expression has 0 offset
-//
-//---------------------------------------------------------------------------
+// check if a limit expression has 0 offset
 BOOL
 CUtils::FHasZeroOffset
 	(
@@ -1906,14 +1491,7 @@ CUtils::FHasZeroOffset
 	return FScalarConstIntZero((*pexpr)[1]);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarConstZero
-//
-//	@doc:
-//		Check if an expression is a 0 integer
-//
-//---------------------------------------------------------------------------
+// check if an expression is a 0 integer
 BOOL
 CUtils::FScalarConstIntZero
 	(
@@ -1941,14 +1519,7 @@ CUtils::FScalarConstIntZero
 	}
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpexprDedup
-//
-//	@doc:
-//		Deduplicate an array of expressions
-//
-//---------------------------------------------------------------------------
+// deduplicate an array of expressions
 DrgPexpr *
 CUtils::PdrgpexprDedup
 	(
@@ -1979,14 +1550,7 @@ CUtils::PdrgpexprDedup
 	return pdrgpexprDedup;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FEqual
-//
-//	@doc:
-//		Deep equality of expression arrays
-//
-//---------------------------------------------------------------------------
+// deep equality of expression arrays
 BOOL
 CUtils::FEqual
 	(
@@ -2021,14 +1585,7 @@ CUtils::FEqual
 	return fEqual;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FEqual
-//
-//	@doc:
-//		Deep equality of expression trees
-//
-//---------------------------------------------------------------------------
+// deep equality of expression trees
 BOOL
 CUtils::FEqual
 	(
@@ -2065,14 +1622,7 @@ CUtils::FEqual
 	return FMatchChildrenUnordered(pexprLeft, pexprRight);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FMatchChildrenUnordered
-//
-//	@doc:
-//		Check if two expressions have the same children in any order
-//
-//---------------------------------------------------------------------------
+// check if two expressions have the same children in any order
 BOOL
 CUtils::FMatchChildrenUnordered
 	(
@@ -2093,14 +1643,7 @@ CUtils::FMatchChildrenUnordered
 	return fEqual;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FMatchChildrenOrdered
-//
-//	@doc:
-//		Check if two expressions have the same children in the same order
-//
-//---------------------------------------------------------------------------
+// check if two expressions have the same children in the same order
 BOOL
 CUtils::FMatchChildrenOrdered
 	(
@@ -2121,15 +1664,7 @@ CUtils::FMatchChildrenOrdered
 	return fEqual;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlOccurrences
-//
-//	@doc:
-//		Return the number of occurrences of the given expression in the given
-//		array of expressions
-//
-//---------------------------------------------------------------------------
+// return the number of occurrences of the given expression in the given array of expressions
 ULONG
 CUtils::UlOccurrences
 	(
@@ -2152,14 +1687,7 @@ CUtils::UlOccurrences
 	return ulCount;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FEqualAny
-//
-//	@doc:
-//		Compare expression against an array of expressions
-//
-//---------------------------------------------------------------------------
+// compare expression against an array of expressions
 BOOL
 CUtils::FEqualAny
 	(
@@ -2179,15 +1707,7 @@ CUtils::FEqualAny
 	return fEqual;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FContains
-//
-//	@doc:
-//		Check if first expression array contains all expressions in
-//		second array
-//
-//---------------------------------------------------------------------------
+// check if first expression array contains all expressions in second array
 BOOL
 CUtils::FContains
 	(
@@ -2218,15 +1738,7 @@ CUtils::FContains
 	return fContains;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprNegate
-//
-//	@doc:
-//		Generate a Not expression on top of the given expression
-//
-//---------------------------------------------------------------------------
+// generate a Not expression on top of the given expression
 CExpression *
 CUtils::PexprNegate
 	(
@@ -2240,15 +1752,7 @@ CUtils::PexprNegate
 	return PexprScalarBoolOp(pmp, CScalarBoolOp::EboolopNot, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarOp
-//
-//	@doc:
-//		Generate a ScalarOp expression over a column and an expression
-//
-//---------------------------------------------------------------------------
+// generate a ScalarOp expression over a column and an expression
 CExpression *
 CUtils::PexprScalarOp
 	(
@@ -2272,15 +1776,7 @@ CUtils::PexprScalarOp
 			);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarBoolOp
-//
-//	@doc:
-//		Generate a ScalarBoolOp expression
-//
-//---------------------------------------------------------------------------
+// generate a ScalarBoolOp expression
 CExpression *
 CUtils::PexprScalarBoolOp
 	(
@@ -2300,15 +1796,7 @@ CUtils::PexprScalarBoolOp
 			);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarConstBool
-//
-//	@doc:
-//		Generate a boolean scalar constant expression
-//
-//---------------------------------------------------------------------------
+// generate a boolean scalar constant expression
 CExpression *
 CUtils::PexprScalarConstBool
 	(
@@ -2329,15 +1817,7 @@ CUtils::PexprScalarConstBool
 	return pexpr;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarConstInt4
-//
-//	@doc:
-//		Generate an int4 scalar constant expression
-//
-//---------------------------------------------------------------------------
+// generate an int4 scalar constant expression
 CExpression *
 CUtils::PexprScalarConstInt4
 	(
@@ -2357,14 +1837,7 @@ CUtils::PexprScalarConstInt4
 	return pexpr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarConstInt8
-//
-//	@doc:
-//		Generate an int8 scalar constant expression
-//
-//---------------------------------------------------------------------------
+// generate an int8 scalar constant expression
 CExpression *
 CUtils::PexprScalarConstInt8
 	(
@@ -2385,14 +1858,7 @@ CUtils::PexprScalarConstInt8
 	return pexpr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarConstOid
-//
-//	@doc:
-//		Generate an oid scalar constant expression
-//
-//---------------------------------------------------------------------------
+// generate an oid scalar constant expression
 CExpression *
 CUtils::PexprScalarConstOid
 	(
@@ -2412,14 +1878,7 @@ CUtils::PexprScalarConstOid
 	return pexpr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrFromProjElem
-//
-//	@doc:
-//		Get column reference defined by project element
-//
-//---------------------------------------------------------------------------
+// get column reference defined by project element
 CColRef *
 CUtils::PcrFromProjElem
 	(
@@ -2429,14 +1888,7 @@ CUtils::PcrFromProjElem
 	return (CScalarProjectElement::PopConvert(pexprPrEl->Pop()))->Pcr();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PopAggFunc
-//
-//	@doc:
-//		Generate an aggregate function operator
-//
-//---------------------------------------------------------------------------
+// generate an aggregate function operator
 CScalarAggFunc *
 CUtils::PopAggFunc
 	(
@@ -2456,14 +1908,7 @@ CUtils::PopAggFunc
 	return GPOS_NEW(pmp) CScalarAggFunc(pmp, pmdidAggFunc, pmdidResolvedReturnType, pstrAggFunc, fDistinct, eaggfuncstage, fSplit);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprAggFunc
-//
-//	@doc:
-//		Generate an aggregate function
-//
-//---------------------------------------------------------------------------
+// generate an aggregate function
 CExpression *
 CUtils::PexprAggFunc
 	(
@@ -2490,15 +1935,7 @@ CUtils::PexprAggFunc
 	return GPOS_NEW(pmp) CExpression(pmp, popScAggFunc, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarFunc
-//
-//	@doc:
-//		Construct a scalar function
-//
-//---------------------------------------------------------------------------
+// construct a scalar function
 CExpression *
 CUtils::PexprScalarFunc
 	(
@@ -2517,14 +1954,7 @@ CUtils::PexprScalarFunc
 	return GPOS_NEW(pmp) CExpression(pmp, popScFunc, pdrgpexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCountStar
-//
-//	@doc:
-//		generate a count(*) expression
-//
-//---------------------------------------------------------------------------
+// generate a count(*) expression
 CExpression *
 CUtils::PexprCountStar
 	(
@@ -2545,15 +1975,7 @@ CUtils::PexprCountStar
 	return pexprCountStar;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCountStar
-//
-//	@doc:
-//		Generate a GbAgg with count(*) function over the given expression
-//
-//---------------------------------------------------------------------------
+// generate a GbAgg with count(*) function over the given expression
 CExpression *
 CUtils::PexprCountStar
 	(
@@ -2579,15 +2001,7 @@ CUtils::PexprCountStar
 	return PexprLogicalGbAggGlobal(pmp, pdrgpcr, pexprLogical, pexprPrjList);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCountStarAndSum
-//
-//	@doc:
-//		Generate a GbAgg with count(*) and sum(col) over the given expression
-//
-//---------------------------------------------------------------------------
+// generate a GbAgg with count(*) and sum(col) over the given expression
 CExpression *
 CUtils::PexprCountStarAndSum
 	(
@@ -2622,15 +2036,7 @@ CUtils::PexprCountStarAndSum
 	return PexprLogicalGbAggGlobal(pmp, pdrgpcr, pexprLogical, pexprPrjList);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FCountAggProjElem
-//
-//	@doc:
-//		Return True if passed expression is a Project Element defined on
-//		count(*)/count(Any) agg
-//
-//---------------------------------------------------------------------------
+// return True if passed expression is a Project Element defined on count(*)/count(Any) agg
 BOOL
 CUtils::FCountAggProjElem
 	(
@@ -2660,16 +2066,7 @@ CUtils::FCountAggProjElem
 	return FHasCountAgg((*pexprPrjElem)[0], ppcrCount);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasCountAgg
-//
-//	@doc:
-//		Check if the given expression has a count(*)/count(Any) agg,
-//		return the top-most found count column
-//
-//---------------------------------------------------------------------------
+// check if the given expression has a count(*)/count(Any) agg, return the top-most found count column
 BOOL
 CUtils::FHasCountAgg
 	(
@@ -2747,14 +2144,7 @@ CUtils::FHasCountAggMatchingColumn
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprSum
-//
-//	@doc:
-//		generate a sum(col) expression
-//
-//---------------------------------------------------------------------------
+// generate a sum(col) expression
 CExpression *
 CUtils::PexprSum
 	(
@@ -2767,16 +2157,7 @@ CUtils::PexprSum
 	return PexprAgg(pmp, pmda, IMDType::EaggSum, pcr, false /*fDistinct*/);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprGbAggSum
-//
-//	@doc:
-//		Generate a GbAgg with sum(col) expressions for all columns in the
-//		passed array
-//
-//---------------------------------------------------------------------------
+// generate a GbAgg with sum(col) expressions for all columns in the passed array
 CExpression *
 CUtils::PexprGbAggSum
 	(
@@ -2807,15 +2188,7 @@ CUtils::PexprGbAggSum
 	return PexprLogicalGbAggGlobal(pmp, pdrgpcr, pexprLogical, pexprPrjList);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCount
-//
-//	@doc:
-//		Generate a count(<distinct> col) expression
-//
-//---------------------------------------------------------------------------
+// generate a count(<distinct> col) expression
 CExpression *
 CUtils::PexprCount
 	(
@@ -2829,14 +2202,7 @@ CUtils::PexprCount
 	return PexprAgg(pmp, pmda, IMDType::EaggCount, pcr, fDistinct);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprMin
-//
-//	@doc:
-//		Generate a min(col) expression
-//
-//---------------------------------------------------------------------------
+// generate a min(col) expression
 CExpression *
 CUtils::PexprMin
 	(
@@ -2848,14 +2214,7 @@ CUtils::PexprMin
  	return PexprAgg(pmp, pmda, IMDType::EaggMin, pcr, false /*fDistinct*/);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprMin
-//
-//	@doc:
-//		Generate an aggregate expression of the specified type
-//
-//---------------------------------------------------------------------------
+// generate an aggregate expression of the specified type
 CExpression *
 CUtils::PexprAgg
 	(
@@ -2878,14 +2237,7 @@ CUtils::PexprAgg
 	return PexprAggFunc(pmp, pmdidAgg, pstr, pcr, fDistinct, EaggfuncstageGlobal /*fGlobal*/, false /*fSplit*/);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalSelect
-//
-//	@doc:
-//		Generate a select expression
-//
-//---------------------------------------------------------------------------
+// generate a select expression
 CExpression *
 CUtils::PexprLogicalSelect
 	(
@@ -2906,16 +2258,7 @@ CUtils::PexprLogicalSelect
 						);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprSafeSelect
-//
-//	@doc:
-//		If predicate is True return logical expression, otherwise return
-//		a new select node
-//
-//---------------------------------------------------------------------------
+// if predicate is True return logical expression, otherwise return a new select node
 CExpression *
 CUtils::PexprSafeSelect
 	(
@@ -2937,16 +2280,8 @@ CUtils::PexprSafeSelect
 	return PexprLogicalSelect(pmp, pexprLogical, pexprPred);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCollapseSelect
-//
-//	@doc:
-//		Generate a select expression, if child is another Select expression
-//		collapse both Selects into one expression
-//
-//---------------------------------------------------------------------------
+// generate a select expression, if child is another Select expression
+// collapse both Selects into one expression
 CExpression *
 CUtils::PexprCollapseSelect
 	(
@@ -2978,15 +2313,7 @@ CUtils::PexprCollapseSelect
 	return GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CLogicalSelect(pmp), pexpr, pexprPredicate);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalProject
-//
-//	@doc:
-//		Generate a project expression
-//
-//---------------------------------------------------------------------------
+// generate a project expression
 CExpression *
 CUtils::PexprLogicalProject
 	(
@@ -3019,16 +2346,7 @@ CUtils::PexprLogicalProject
 						);
 }
 
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalSequenceProject
-//
-//	@doc:
-//		Generate a sequence project expression
-//
-//---------------------------------------------------------------------------
+// generate a sequence project expression
 CExpression *
 CUtils::PexprLogicalSequenceProject
 	(
@@ -3057,15 +2375,8 @@ CUtils::PexprLogicalSequenceProject
 			);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalProjectNulls
-//
-//	@doc:
-//		Construct a projection of NULL constants using the given column
-//		names and types on top of the given expression
-//
-//---------------------------------------------------------------------------
+// construct a projection of NULL constants using the given column
+// names and types on top of the given expression
 CExpression *
 CUtils::PexprLogicalProjectNulls
 	(
@@ -3082,15 +2393,8 @@ CUtils::PexprLogicalProjectNulls
 	return PexprLogicalProject(pmp, pexpr, pexprProjList, false /*fNewComputedCol*/);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarProjListConst
-//
-//	@doc:
-//		Construct a project list using the column names and types of the given
-//		array of column references, and the given datums
-//
-//---------------------------------------------------------------------------
+// construct a project list using the column names and types of the given
+// array of column references, and the given datums
 CExpression *
 CUtils::PexprScalarProjListConst
 	(
@@ -3140,14 +2444,7 @@ CUtils::PexprScalarProjListConst
 	return GPOS_NEW(pmp) CExpression(pmp, pscprl, pdrgpexprProjElems);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprAddProjection
-//
-//	@doc:
-//		Generate a project expression with one additional project element
-//
-//---------------------------------------------------------------------------
+// generate a project expression with one additional project element
 CExpression *
 CUtils::PexprAddProjection
 	(
@@ -3168,14 +2465,7 @@ CUtils::PexprAddProjection
 	return pexprProjection;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprAddProjection
-//
-//	@doc:
-//		Generate a project expression with one or more additional project elements
-//
-//---------------------------------------------------------------------------
+// generate a project expression with one or more additional project elements
 CExpression *
 CUtils::PexprAddProjection
 	(
@@ -3217,14 +2507,7 @@ CUtils::PexprAddProjection
 	return PexprLogicalProject(pmp, pexpr, pexprPrjList, true /*fNewComputedCol*/);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalGbAgg
-//
-//	@doc:
-//		Generate an aggregate expression
-//
-//---------------------------------------------------------------------------
+// generate an aggregate expression
 CExpression *
 CUtils::PexprLogicalGbAgg
 	(
@@ -3245,14 +2528,7 @@ CUtils::PexprLogicalGbAgg
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pexprRelational, pexprPrL);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalGbAggGlobal
-//
-//	@doc:
-//		Generate a global aggregate expression
-//
-//---------------------------------------------------------------------------
+// generate a global aggregate expression
 CExpression *
 CUtils::PexprLogicalGbAggGlobal
 	(
@@ -3265,14 +2541,7 @@ CUtils::PexprLogicalGbAggGlobal
 	return PexprLogicalGbAgg(pmp, pdrgpcr, pexprRelational, pexprProjList, COperator::EgbaggtypeGlobal);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasGlobalAggFunc
-//
-//	@doc:
-//		Check if given project list has a global aggregate function
-//
-//---------------------------------------------------------------------------
+// check if given project list has a global aggregate function
 BOOL
 CUtils::FHasGlobalAggFunc
 	(
@@ -3297,14 +2566,7 @@ CUtils::FHasGlobalAggFunc
 	return fGlobal;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::Ecmpt
-//
-//	@doc:
-// 		Return the comparison type for the given mdid
-//
-//---------------------------------------------------------------------------
+// return the comparison type for the given mdid
 IMDType::ECmpType
 CUtils::Ecmpt
 	(
@@ -3316,14 +2578,7 @@ CUtils::Ecmpt
 	return pmdscop->Ecmpt();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::Ecmpt
-//
-//	@doc:
-// 		Return the comparison type for the given mdid
-//
-//---------------------------------------------------------------------------
+// return the comparison type for the given mdid
 IMDType::ECmpType
 CUtils::Ecmpt
 	(
@@ -3335,14 +2590,7 @@ CUtils::Ecmpt
 	return pmdscop->Ecmpt();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarConstBool
-//
-//	@doc:
-//		Check if the expression is a scalar boolean const
-//
-//---------------------------------------------------------------------------
+// check if the expression is a scalar boolean const
 BOOL
 CUtils::FScalarConstBool
 	(
@@ -3366,15 +2614,7 @@ CUtils::FScalarConstBool
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarConstTrue
-//
-//	@doc:
-//		Checks to see if the expression is a scalar const TRUE
-//
-//---------------------------------------------------------------------------
+// checks to see if the expression is a scalar const TRUE
 BOOL
 CUtils::FScalarConstTrue
 	(
@@ -3384,15 +2624,7 @@ CUtils::FScalarConstTrue
 	return FScalarConstBool(pexpr, true /*fVal*/);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarConstFalse
-//
-//	@doc:
-//		Checks to see if the expression is a scalar const FALSE
-//
-//---------------------------------------------------------------------------
+// checks to see if the expression is a scalar const FALSE
 BOOL
 CUtils::FScalarConstFalse
 	(
@@ -3402,14 +2634,7 @@ CUtils::FScalarConstFalse
 	return FScalarConstBool(pexpr, false /*fVal*/);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrNonSystemCols
-//
-//	@doc:
-//		Return an array of non-system columns in the given set
-//
-//---------------------------------------------------------------------------
+// return an array of non-system columns in the given set
 DrgPcr *
 CUtils::PdrgpcrNonSystemCols
 	(
@@ -3434,16 +2659,7 @@ CUtils::PdrgpcrNonSystemCols
 	return pdrgpcr;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrGroupingKey
-//
-//	@doc:
-//		Create an array of expression's output columns including a key for
-//		grouping
-//
-//---------------------------------------------------------------------------
+//	create an array of expression's output columns including a key for grouping
 DrgPcr *
 CUtils::PdrgpcrGroupingKey
 	(
@@ -3487,17 +2703,9 @@ CUtils::PdrgpcrGroupingKey
 	return pdrgpcr;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrsAddEquivClass
-//
-//	@doc:
-//		Add an equivalence class to the array. If the new equiv class contains
-//		columns from separate equiv classes, then these are merged. Returns a new
-//		array of equivalence classes
-//
-//---------------------------------------------------------------------------
+// add an equivalence class to the array. If the new equiv class contains
+// columns from separate equiv classes, then these are merged. Returns a new
+// array of equivalence classes
 DrgPcrs *
 CUtils::PdrgpcrsAddEquivClass
 	(
@@ -3528,14 +2736,7 @@ CUtils::PdrgpcrsAddEquivClass
 	return pdrgpcrsNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrsMergeEquivClasses
-//
-//	@doc:
-//		Merge 2 arrays of equivalence classes
-//
-//---------------------------------------------------------------------------
+// merge 2 arrays of equivalence classes
 DrgPcrs *
 CUtils::PdrgpcrsMergeEquivClasses
 	(
@@ -3561,15 +2762,8 @@ CUtils::PdrgpcrsMergeEquivClasses
 	return pdrgpcrsMerged;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrsIntersectEquivClasses
-//
-//	@doc:
-//		Intersect 2 arrays of equivalence classes. This is accomplished by using
-//		a hashmap to find intersects between two arrays of colomun referance sets
-//
-//---------------------------------------------------------------------------
+// intersect 2 arrays of equivalence classes. This is accomplished by using
+// a hashmap to find intersects between two arrays of colomun referance sets
 DrgPcrs *
 CUtils::PdrgpcrsIntersectEquivClasses
 	(
@@ -3653,15 +2847,7 @@ CUtils::PdrgpcrsIntersectEquivClasses
 	return pdrgpcrs;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrsCopyChildEquivClasses
-//
-//	@doc:
-//		Return a copy of equivalence classes from all children
-//
-//---------------------------------------------------------------------------
+// return a copy of equivalence classes from all children
 DrgPcrs *
 CUtils::PdrgpcrsCopyChildEquivClasses
 	(
@@ -3696,15 +2882,7 @@ CUtils::PdrgpcrsCopyChildEquivClasses
 	return pdrgpcrs;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrExcludeColumns
-//
-//	@doc:
-//		Return a copy of the given array of columns, excluding the columns
-//		in the given colrefset
-//
-//---------------------------------------------------------------------------
+// return a copy of the given array of columns, excluding the columns in the given colrefset
 DrgPcr *
 CUtils::PdrgpcrExcludeColumns
 	(
@@ -3730,14 +2908,7 @@ CUtils::PdrgpcrExcludeColumns
 	return pdrgpcr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::OsPrintDrgPcr
-//
-//	@doc:
-//		Helper function to print a colref array
-//
-//---------------------------------------------------------------------------
+// helper function to print a colref array
 IOstream &
 CUtils::OsPrintDrgPcr
 	(
@@ -3764,14 +2935,7 @@ CUtils::OsPrintDrgPcr
 	return os;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarCmp
-//
-//	@doc:
-//		 Check if given expression is a scalar comparison
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar comparison
 BOOL
 CUtils::FScalarCmp
 	(
@@ -3781,15 +2945,7 @@ CUtils::FScalarCmp
 	return (COperator::EopScalarCmp == pexpr->Pop()->Eopid());
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarArrayCmp
-//
-//	@doc:
-//		 Check if given expression is a scalar array comparison
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar array comparison
 BOOL
 CUtils::FScalarArrayCmp
 	(
@@ -3799,14 +2955,7 @@ CUtils::FScalarArrayCmp
 	return (COperator::EopScalarArrayCmp == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasOneStagePhysicalAgg
-//
-//	@doc:
-//		 Check if given expression has any one stage agg nodes
-//
-//---------------------------------------------------------------------------
+// check if given expression has any one stage agg nodes
 BOOL
 CUtils::FHasOneStagePhysicalAgg
 	(
@@ -3834,15 +2983,7 @@ CUtils::FHasOneStagePhysicalAgg
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FOpExists
-//
-//	@doc:
-//		 Check if given operator exists in the given list
-//
-//---------------------------------------------------------------------------
+// check if given operator exists in the given list
 BOOL
 CUtils::FOpExists
 	(
@@ -3866,15 +3007,7 @@ CUtils::FOpExists
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasOp
-//
-//	@doc:
-//		 Check if given expression has any operator in the given list
-//
-//---------------------------------------------------------------------------
+// check if given expression has any operator in the given list
 BOOL
 CUtils::FHasOp
 	(
@@ -3905,14 +3038,7 @@ CUtils::FHasOp
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlInlinableCTEs
-//
-//	@doc:
-//		Return number of inlinable CTEs in the given expression
-//
-//---------------------------------------------------------------------------
+// return number of inlinable CTEs in the given expression
 ULONG
 CUtils::UlInlinableCTEs
 	(
@@ -3944,14 +3070,7 @@ CUtils::UlInlinableCTEs
 	return ulChildCTEs;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlJoins
-//
-//	@doc:
-//		Return number of joins in the given expression
-//
-//---------------------------------------------------------------------------
+// return number of joins in the given expression
 ULONG
 CUtils::UlJoins
 	(
@@ -3992,14 +3111,7 @@ CUtils::UlJoins
 	return ulJoins + ulChildJoins;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlSubqueries
-//
-//	@doc:
-//		Return number of subqueries in the given expression
-//
-//---------------------------------------------------------------------------
+// return number of subqueries in the given expression
 ULONG
 CUtils::UlSubqueries
 	(
@@ -4035,15 +3147,7 @@ CUtils::UlSubqueries
 	return ulSubqueries + ulChildSubqueries;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarBoolOp
-//
-//	@doc:
-//		 Check if given expression is a scalar boolean operator
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar boolean operator
 BOOL
 CUtils::FScalarBoolOp
 	(
@@ -4053,14 +3157,7 @@ CUtils::FScalarBoolOp
 	return (COperator::EopScalarBoolOp == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarBoolOp
-//
-//	@doc:
-//		Is the given expression a scalar bool op of the passed type?
-//
-//---------------------------------------------------------------------------
+// is the given expression a scalar bool op of the passed type?
 BOOL
 CUtils::FScalarBoolOp
 	(
@@ -4077,14 +3174,7 @@ CUtils::FScalarBoolOp
 		eboolop == CScalarBoolOp::PopConvert(pop)->Eboolop();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarNullTest
-//
-//	@doc:
-//		 Check if given expression is a scalar null test
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar null test
 BOOL
 CUtils::FScalarNullTest
 	(
@@ -4094,14 +3184,7 @@ CUtils::FScalarNullTest
 	return (COperator::EopScalarNullTest == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarNotNull
-//
-//	@doc:
-//		 Check if given expression is a NOT NULL predicate
-//
-//---------------------------------------------------------------------------
+// check if given expression is a NOT NULL predicate
 BOOL
 CUtils::FScalarNotNull
 	(
@@ -4112,14 +3195,7 @@ CUtils::FScalarNotNull
 			FScalarNullTest((*pexpr)[0]);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarIdent
-//
-//	@doc:
-//		 Check if given expression is a scalar identifier
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar identifier
 BOOL
 CUtils::FScalarIdent
 	(
@@ -4129,14 +3205,7 @@ CUtils::FScalarIdent
 	return (COperator::EopScalarIdent == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarIdentBoolType
-//
-//	@doc:
-//		 Check if given expression is a scalar boolean identifier
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar boolean identifier
 BOOL
 CUtils::FScalarIdentBoolType
 	(
@@ -4147,14 +3216,7 @@ CUtils::FScalarIdentBoolType
 			IMDType::EtiBool == CScalarIdent::PopConvert(pexpr->Pop())->Pcr()->Pmdtype()->Eti();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarArray
-//
-//	@doc:
-//		 Check if given expression is a scalar array
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar array
 BOOL
 CUtils::FScalarArray
 	(
@@ -4164,14 +3226,7 @@ CUtils::FScalarArray
 	return (COperator::EopScalarArray == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarArrayCoerce
-//
-//	@doc:
-//		 Check if given expression is a scalar array coerce
-//
-//---------------------------------------------------------------------------
+// check if given expression is a scalar array coerce
 BOOL
 CUtils::FScalarArrayCoerce
 	(
@@ -4181,16 +3236,7 @@ CUtils::FScalarArrayCoerce
 	return (COperator::EopScalarArrayCoerceExpr == pexpr->Pop()->Eopid());
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarIdent
-//
-//	@doc:
-//		Is the given expression a scalar identifier with the given column
-//		reference
-//
-//---------------------------------------------------------------------------
+// is the given expression a scalar identifier with the given column reference
 BOOL
 CUtils::FScalarIdent
 	(
@@ -4205,14 +3251,7 @@ CUtils::FScalarIdent
 			CScalarIdent::PopConvert(pexpr->Pop())->Pcr() == pcr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FScalarConst
-//
-//	@doc:
-//		Check if the expression is a scalar const
-//
-//---------------------------------------------------------------------------
+// check if the expression is a scalar const
 BOOL
 CUtils::FScalarConst
 	(
@@ -4222,14 +3261,7 @@ CUtils::FScalarConst
 	return (COperator::EopScalarConst == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FVarFreeExpr
-//
-//	@doc:
-//		Check if the expression is variable-free
-//
-//---------------------------------------------------------------------------
+// check if the expression is variable-free
 BOOL
 CUtils::FVarFreeExpr
 	(
@@ -4256,15 +3288,7 @@ CUtils::FVarFreeExpr
 	return 0 == pcrsUsed->CElements();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FPredicate
-//
-//	@doc:
-//		Check if the expression is a scalar predicate, i.e. bool op, comparison,
-//		or null test
-//
-//---------------------------------------------------------------------------
+// check if the expression is a scalar predicate, i.e. bool op, comparison, or null test
 BOOL
 CUtils::FPredicate
 	(
@@ -4280,15 +3304,7 @@ CUtils::FPredicate
 		FScalarNullTest(pexpr));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasAllDefaultComparisons
-//
-//	@doc:
-//		Checks that the given type has all the comparisons: Eq, NEq, L, LEq, G,
-//		GEq.
-//
-//---------------------------------------------------------------------------
+// checks that the given type has all the comparisons: Eq, NEq, L, LEq, G, GEq.
 BOOL
 CUtils::FHasAllDefaultComparisons(const IMDType *pmdtype)
 {
@@ -4302,15 +3318,8 @@ CUtils::FHasAllDefaultComparisons(const IMDType *pmdtype)
 		IMDId::FValid(pmdtype->PmdidCmp(IMDType::EcmptGEq));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FConstrainableType
-//
-//	@doc:
-//		Determine whether a type is supported for use in contradiction detection.
-//		The assumption is that we only compare data of the same type.
-//
-//---------------------------------------------------------------------------
+// determine whether a type is supported for use in contradiction detection.
+// The assumption is that we only compare data of the same type.
 BOOL
 CUtils::FConstrainableType
 	(
@@ -4331,14 +3340,7 @@ CUtils::FConstrainableType
 	return FHasAllDefaultComparisons(pmdtype);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FIntType
-//
-//	@doc:
-//		Determine whether a type is an integer type
-//
-//---------------------------------------------------------------------------
+// determine whether a type is an integer type
 BOOL
 CUtils::FIntType
 	(
@@ -4353,14 +3355,7 @@ CUtils::FIntType
 			IMDType::EtiInt8 == eti);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FUsesChildColsOnly
-//
-//	@doc:
-//		Check if a binary operator uses only columns produced by its children
-//
-//---------------------------------------------------------------------------
+// check if a binary operator uses only columns produced by its children
 BOOL
 CUtils::FUsesChildColsOnly
 	(
@@ -4381,16 +3376,7 @@ CUtils::FUsesChildColsOnly
 	return fUsesChildCols;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FInnerUsesExternalCols
-//
-//	@doc:
-//		Check if inner child of a binary operator uses columns not produced
-//		by outer child
-//
-//---------------------------------------------------------------------------
+// check if inner child of a binary operator uses columns not produced by outer child
 BOOL
 CUtils::FInnerUsesExternalCols
 	(
@@ -4409,17 +3395,7 @@ CUtils::FInnerUsesExternalCols
 	return !pcrsOutput->FSubset(pcrsOuterRefs);
 }
 
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FInnerUsesExternalColsOnly
-//
-//	@doc:
-//		Check if inner child of a binary operator uses only columns not
-//		produced by outer child
-//
-//---------------------------------------------------------------------------
+// check if inner child of a binary operator uses only columns not produced by outer child
 BOOL
 CUtils::FInnerUsesExternalColsOnly
 	(
@@ -4430,14 +3406,7 @@ CUtils::FInnerUsesExternalColsOnly
 			exprhdl.Pdprel(1)->PcrsOuter()->FDisjoint(exprhdl.Pdprel(0)->PcrsOutput());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FComparisonPossible
-//
-//	@doc:
-//		Check if given columns have available comparison operators
-//
-//---------------------------------------------------------------------------
+// check if given columns have available comparison operators
 BOOL
 CUtils::FComparisonPossible
 	(
@@ -4462,14 +3431,7 @@ CUtils::FComparisonPossible
 	return true;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlCountOperator
-//
-//	@doc:
-//		counts the number of times a certain operator appears
-//
-//---------------------------------------------------------------------------
+// counts the number of times a certain operator appears
 ULONG
 CUtils::UlCountOperator
 	(
@@ -4491,14 +3453,7 @@ CUtils::UlCountOperator
 	return ulOpCnt;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrHashablePrefix
-//
-//	@doc:
-//		Return the max prefix of hashable columns for the given columns
-//
-//---------------------------------------------------------------------------
+// return the max prefix of hashable columns for the given columns
 DrgPcr *
 CUtils::PdrgpcrHashablePrefix
 	(
@@ -4525,15 +3480,7 @@ CUtils::PdrgpcrHashablePrefix
 	return pdrgpcrHashable;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrHashableSubset
-//
-//	@doc:
-//		Return the max subset of hashable columns for the given columns
-//
-//---------------------------------------------------------------------------
+// return the max subset of hashable columns for the given columns
 DrgPcr *
 CUtils::PdrgpcrHashableSubset
 	(
@@ -4559,14 +3506,7 @@ CUtils::PdrgpcrHashableSubset
 	return pdrgpcrHashable;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHashable
-//
-//	@doc:
-//		Check if hashing is possible for the given columns
-//
-//---------------------------------------------------------------------------
+// check if hashing is possible for the given columns
 BOOL
 CUtils::FHashable
 	(
@@ -4590,15 +3530,7 @@ CUtils::FHashable
 	return true;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FLogicalDML
-//
-//	@doc:
-//		Check if given operator is a logical DML operator
-//
-//---------------------------------------------------------------------------
+// check if given operator is a logical DML operator
 BOOL
 CUtils::FLogicalDML
 	(
@@ -4614,15 +3546,7 @@ CUtils::FLogicalDML
 			COperator::EopLogicalUpdate == eopid;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::SzFromWsz
-//
-//	@doc:
-//		Return regular string from wide-character string
-//
-//---------------------------------------------------------------------------
+// return regular string from wide-character string
 CHAR *
 CUtils::SzFromWsz
 	(
@@ -4638,14 +3562,7 @@ CUtils::SzFromWsz
 	return sz;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FFunctionallyDependent
-//
-//	@doc:
-//		Is the given column functionally dependent on the given keyset
-//
-//---------------------------------------------------------------------------
+// is the given column functionally dependent on the given keyset
 BOOL
 CUtils::FFunctionallyDependent
 	(
@@ -4691,14 +3608,7 @@ CUtils::FFunctionallyDependent
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::Pdrgpul
-//
-//	@doc:
-//		Construct an array of colids from the given array of column references
-//
-//---------------------------------------------------------------------------
+// construct an array of colids from the given array of column references
 DrgPul *
 CUtils::Pdrgpul
 	(
@@ -4719,15 +3629,7 @@ CUtils::Pdrgpul
 	return pdrgpul;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::GenerateFileName
-//
-//	@doc:
-//		Generate a timestamp-based filename in the provided buffer.
-//
-//---------------------------------------------------------------------------
+// generate a timestamp-based filename in the provided buffer.
 void
 CUtils::GenerateFileName
 	(
@@ -4791,14 +3693,7 @@ CUtils::GenerateFileName
 
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrRemap
-//
-//	@doc:
-//		Return the mapping of the given colref based on the given hashmap
-//
-//---------------------------------------------------------------------------
+// return the mapping of the given colref based on the given hashmap
 CColRef *
 CUtils::PcrRemap
 	(
@@ -4826,15 +3721,7 @@ CUtils::PcrRemap
 	return const_cast<CColRef*>(pcr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrsRemap
-//
-//	@doc:
-//		Create a new colrefset corresponding to the given colrefset
-//		and based on the given mapping
-//
-//---------------------------------------------------------------------------
+// create a new colrefset corresponding to the given colrefset and based on the given mapping
 CColRefSet *
 CUtils::PcrsRemap
 	(
@@ -4860,15 +3747,8 @@ CUtils::PcrsRemap
 	return pcrsMapped;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrRemap
-//
-//	@doc:
-//		Create an array of column references corresponding to the given array
-//		and based on the given mapping
-//
-//---------------------------------------------------------------------------
+// create an array of column references corresponding to the given array
+// and based on the given mapping
 DrgPcr *
 CUtils::PdrgpcrRemap
 	(
@@ -4894,15 +3774,8 @@ CUtils::PdrgpcrRemap
 	return pdrgpcrNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrRemapAndCreate
-//
-//	@doc:
-//		Create an array of column references corresponding to the given array
-//		and based on the given mapping. Create new colrefs if necessary
-//
-//---------------------------------------------------------------------------
+// ceate an array of column references corresponding to the given array
+// and based on the given mapping. Create new colrefs if necessary
 DrgPcr *
 CUtils::PdrgpcrRemapAndCreate
 	(
@@ -4943,15 +3816,8 @@ CUtils::PdrgpcrRemapAndCreate
 	return pdrgpcrNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpdrgpcrRemap
-//
-//	@doc:
-//		Create an array of column arrays corresponding to the given array
-//		and based on the given mapping
-//
-//---------------------------------------------------------------------------
+// create an array of column arrays corresponding to the given array
+// and based on the given mapping
 DrgDrgPcr *
 CUtils::PdrgpdrgpcrRemap
 	(
@@ -4976,14 +3842,7 @@ CUtils::PdrgpdrgpcrRemap
 	return pdrgpdrgpcrNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpexprRemap
-//
-//	@doc:
-//		Remap given array of expressions with provided column mappings
-//
-//---------------------------------------------------------------------------
+// remap given array of expressions with provided column mappings
 DrgPexpr *
 CUtils::PdrgpexprRemap
 	(
@@ -5007,14 +3866,7 @@ CUtils::PdrgpexprRemap
 	return pdrgpexprNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PhmulcrMapping
-//
-//	@doc:
-//		Create col ID->ColRef mapping using the given ColRef arrays
-//
-//---------------------------------------------------------------------------
+// create col ID->ColRef mapping using the given ColRef arrays
 HMUlCr *
 CUtils::PhmulcrMapping
 	(
@@ -5032,16 +3884,7 @@ CUtils::PhmulcrMapping
 	return phmulcr;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::AddColumnMapping
-//
-//	@doc:
-//		Add col ID->ColRef mappings to the given hashmap based on the
-//		given ColRef arrays
-//
-//---------------------------------------------------------------------------
+// add col ID->ColRef mappings to the given hashmap based on the given ColRef arrays
 void
 CUtils::AddColumnMapping
 	(
@@ -5088,14 +3931,7 @@ CUtils::AddColumnMapping
 	}
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrExactCopy
-//
-//	@doc:
-//		Create a copy of the array of column references
-//
-//---------------------------------------------------------------------------
+// create a copy of the array of column references
 DrgPcr *
 CUtils::PdrgpcrExactCopy
 	(
@@ -5115,16 +3951,9 @@ CUtils::PdrgpcrExactCopy
 	return pdrgpcrNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpcrCopy
-//
-//	@doc:
-//		Create an array of new column references with the same names and types
-//		as the given column references. If the passed map is not null, mappings
-//		from old to copied variables are added to it.
-//
-//---------------------------------------------------------------------------
+// Create an array of new column references with the same names and types
+// as the given column references. If the passed map is not null, mappings
+// from old to copied variables are added to it.
 DrgPcr *
 CUtils::PdrgpcrCopy
 	(
@@ -5167,14 +3996,7 @@ CUtils::PdrgpcrCopy
 	return pdrgpcrNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FEqual
-//
-//	@doc:
-//		Equality check between two arrays of column refs. Inputs can be NULL
-//
-//---------------------------------------------------------------------------
+// equality check between two arrays of column refs. Inputs can be NULL
 BOOL
 CUtils::FEqual
 	(
@@ -5190,14 +4012,7 @@ CUtils::FEqual
 	return pdrgpcrFst->FEqual(pdrgpcrSnd);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlHashColArray
-//
-//	@doc:
-//		Compute hash value for an array of column references
-//
-//---------------------------------------------------------------------------
+// compute hash value for an array of column references
 ULONG
 CUtils::UlHashColArray
 	(
@@ -5217,15 +4032,8 @@ CUtils::UlHashColArray
 	return ulHash;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrsCTEProducerColumns
-//
-//	@doc:
-//		Return the set of column reference from the CTE Producer corresponding to the
-// 		subset of input columns from the CTE Consumer
-//
-//---------------------------------------------------------------------------
+// Return the set of column reference from the CTE Producer corresponding to the
+// subset of input columns from the CTE Consumer
 CColRefSet *
 CUtils::PcrsCTEProducerColumns
 	(
@@ -5252,15 +4060,8 @@ CUtils::PcrsCTEProducerColumns
 	return pcrsCTEProducer;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprConjINDFCond
-//
-//	@doc:
-//		Construct the join condition (AND-tree) of INDF condition
-//		from the array of input column reference arrays
-//
-//---------------------------------------------------------------------------
+// Construct the join condition (AND-tree) of INDF condition
+// from the array of input column reference arrays
 CExpression *
 CUtils::PexprConjINDFCond
 	(
@@ -5304,15 +4105,7 @@ CUtils::PexprConjINDFCond
 	return pexprScCond;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FBinaryCoercibleCastedScId
-//
-//	@doc:
-// 		Is the given expression a binary coercible cast of a scalar identifier
-//
-//---------------------------------------------------------------------------
+// is the given expression a binary coercible cast of a scalar identifier
 BOOL
 CUtils::FBinaryCoercibleCastedScId
 	(
@@ -5334,14 +4127,7 @@ CUtils::FBinaryCoercibleCastedScId
 		pcr == CScalarIdent::PopConvert(pexprChild->Pop())->Pcr();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FBinaryCoercibleCastedScId
-//
-//	@doc:
-// 		Is the given expression a binary coercible cast of a scalar identifier
-//
-//---------------------------------------------------------------------------
+// is the given expression a binary coercible cast of a scalar identifier
 BOOL
 CUtils::FBinaryCoercibleCastedScId
 	(
@@ -5361,15 +4147,7 @@ CUtils::FBinaryCoercibleCastedScId
 	return COperator::EopScalarIdent == pexprChild->Pop()->Eopid();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::UlPcrIndexContainingSet
-//
-//	@doc:
-//		Return index of the set containing given column;
-//		if column is not found, return ULONG_MAX
-//
-//---------------------------------------------------------------------------
+// return index of the set containing given column; if column is not found, return ULONG_MAX
 ULONG
 CUtils::UlPcrIndexContainingSet
 	(
@@ -5392,17 +4170,9 @@ CUtils::UlPcrIndexContainingSet
 	return ULONG_MAX;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrExtractFromScIdOrCastScId
-//
-//	@doc:
-// 		Extract the column reference if the given expression a scalar identifier
-// 		or a cast of a scalar identifier or a function that casts a scalar identifier.
-// 		Else return NULL.
-//
-//---------------------------------------------------------------------------
+// extract the column reference if the given expression a scalar identifier
+// or a cast of a scalar identifier or a function that casts a scalar identifier.
+// Else return NULL.
 const CColRef *
 CUtils::PcrExtractFromScIdOrCastScId
 	(
@@ -5434,15 +4204,7 @@ CUtils::PcrExtractFromScIdOrCastScId
 	return popScIdent->Pcr();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCast
-//
-//	@doc:
-//		Cast the input column reference to the destination mdid
-//
-//---------------------------------------------------------------------------
+// cast the input column reference to the destination mdid
 CExpression *
 CUtils::PexprCast
 	(
@@ -5466,14 +4228,7 @@ CUtils::PexprCast
 	return GPOS_NEW(pmp) CExpression(pmp, popCast, PexprScalarIdent(pmp, pcr));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCast
-//
-//	@doc:
-//		Cast the input expression to the destination mdid
-//
-//---------------------------------------------------------------------------
+// cast the input expression to the destination mdid
 CExpression *
 CUtils::PexprCast
 	(
@@ -5496,14 +4251,7 @@ CUtils::PexprCast
 	return GPOS_NEW(pmp) CExpression(pmp, popCast, pexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FBinaryCoercibleCast
-//
-//	@doc:
-//		Check whether the given expression is a binary coercible cast of something
-//
-//---------------------------------------------------------------------------
+// check whether the given expression is a binary coercible cast of something
 BOOL
 CUtils::FBinaryCoercibleCast
 	(
@@ -5517,15 +4265,8 @@ CUtils::FBinaryCoercibleCast
 			CScalarCast::PopConvert(pop)->FBinaryCoercible();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprRemoveRelabel
-//
-//	@doc:
-//		Return the given expression without any binary coercible casts
-// 		that exist on the top
-//
-//---------------------------------------------------------------------------
+// return the given expression without any binary coercible casts
+// that exist on the top
 CExpression *
 CUtils::PexprWithoutBinaryCoercibleCasts
 	(
@@ -5546,14 +4287,7 @@ CUtils::PexprWithoutBinaryCoercibleCasts
 	return pexprOutput;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FHasDuplicates
-//
-//	@doc:
-//		Check whether a colref array contains repeated items
-//
-//---------------------------------------------------------------------------
+// check whether a colref array contains repeated items
 BOOL
 CUtils::FHasDuplicates
 	(
@@ -5581,16 +4315,7 @@ CUtils::FHasDuplicates
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalJoin
-//
-//	@doc:
-// 		Construct a logical join expression operator of the given type, with
-//		the given children
-//
-//---------------------------------------------------------------------------
+// construct a logical join expression operator of the given type, with the given children
 CExpression *
 CUtils::PexprLogicalJoin
 	(
@@ -5629,15 +4354,7 @@ CUtils::PexprLogicalJoin
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PdrgpexprScalarIdents
-//
-//	@doc:
-// 		Construct an array of scalar ident expressions from the given array
-//		of column references
-//
-//---------------------------------------------------------------------------
+// construct an array of scalar ident expressions from the given array of column references
 DrgPexpr *
 CUtils::PdrgpexprScalarIdents
 	(
@@ -5660,14 +4377,7 @@ CUtils::PdrgpexprScalarIdents
 	return pdrgpexpr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrsExtractColumns
-//
-//	@doc:
-//		Return used columns by expressions in the given array
-//
-//---------------------------------------------------------------------------
+// return used columns by expressions in the given array
 CColRefSet *
 CUtils::PcrsExtractColumns
 	(
@@ -5688,15 +4398,9 @@ CUtils::PcrsExtractColumns
 	return pcrs;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PhmulcnstrBoolConstOnPartKeys
-//
-//	@doc:
-//		Create a hashmap of constraints corresponding to a bool const on the given partkeys
-//		true - unbounded intervals with nulls
-//		false - empty intervals with no nulls
-//---------------------------------------------------------------------------
+// Create a hashmap of constraints corresponding to a bool const on the given partkeys
+// true - unbounded intervals with nulls
+// false - empty intervals with no nulls
 HMUlCnstr *
 CUtils::PhmulcnstrBoolConstOnPartKeys
 	(
@@ -5737,13 +4441,7 @@ CUtils::PhmulcnstrBoolConstOnPartKeys
 	return phmulcnstr;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PbsAllSet
-//
-//	@doc:
-//		Returns a new bitset of the given length, where all the bits are set
-//---------------------------------------------------------------------------
+// returns a new bitset of the given length, where all the bits are set
 CBitSet *
 CUtils::PbsAllSet
 	(
@@ -5760,13 +4458,7 @@ CUtils::PbsAllSet
 	return pbs;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PbsAllSet
-//
-//	@doc:
-//		Returns a new bitset, setting the bits in the given array
-//---------------------------------------------------------------------------
+// returns a new bitset, setting the bits in the given array
 CBitSet *
 CUtils::Pbs
 	(
@@ -5787,14 +4479,7 @@ CUtils::Pbs
 	return pbs;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PpartcnstrFromMDPartCnstr
-//
-//	@doc:
-//		Extract part constraint from metadata
-//
-//---------------------------------------------------------------------------
+// extract part constraint from metadata
 CPartConstraint *
 CUtils::PpartcnstrFromMDPartCnstr
 	(
@@ -5872,15 +4557,8 @@ CUtils::PpartcnstrFromMDPartCnstr
 	return GPOS_NEW(pmp) CPartConstraint(pmp, phmulcnstr, pbsDefaultParts, pmdpartcnstr->FUnbounded(), pdrgpdrgpcrPartKey);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprLogicalCTGDummy
-//
-//	@doc:
-//		Helper to create a dummy constant table expression;
-//		the table has one boolean column with value True and one row
-//
-//---------------------------------------------------------------------------
+// Helper to create a dummy constant table expression;
+// the table has one boolean column with value True and one row
 CExpression *
 CUtils::PexprLogicalCTGDummy
 	(
@@ -5906,16 +4584,7 @@ CUtils::PexprLogicalCTGDummy
 	return GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CLogicalConstTableGet(pmp, pdrgpcrCTG, pdrgpdrgpdatum));
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PcrMap
-//
-//	@doc:
-//		Map a column from source array to destination array based on
-//		position
-//
-//---------------------------------------------------------------------------
+// map a column from source array to destination array based on position
 CColRef *
 CUtils::PcrMap
 	(
@@ -5939,15 +4608,8 @@ CUtils::PcrMap
 	return pcrTarget;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FMotionOverUnresolvedPartConsumers
-//
-//	@doc:
-//		Check if the given operator is a motion and the derived relational 
-//		properties contain a consumer which is not in the required part consumers
-//
-//---------------------------------------------------------------------------
+// check if the given operator is a motion and the derived relational
+// properties contain a consumer which is not in the required part consumers
 BOOL
 CUtils::FMotionOverUnresolvedPartConsumers
 	(
@@ -5989,19 +4651,9 @@ CUtils::FMotionOverUnresolvedPartConsumers
 	return fHasUnresolvedConsumers;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::FDuplicateHazardMotion
-//
-//	@doc:
-//		Check if duplicate values can be generated when executing the given
-//		Motion expression,
-//		duplicates occur if Motion's input has replicated/universal distribution,
-//		which means that we have exactly the same copy of input on each host,
-//
-//
-//---------------------------------------------------------------------------
+// Check if duplicate values can be generated when executing the given Motion expression,
+// duplicates occur if Motion's input has replicated/universal distribution,
+// which means that we have exactly the same copy of input on each host,
 BOOL
 CUtils::FDuplicateHazardMotion
 	(
@@ -6023,13 +4675,7 @@ CUtils::FDuplicateHazardMotion
 	return fReplicatedInput;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprCollapseProjects
-//
-//	@doc:
-//		Collapse the top two project nodes like this, if unable return NULL;
+// Collapse the top two project nodes like this, if unable return NULL;
 //
 //	+--CLogicalProject                                            <-- pexpr
 //		|--CLogicalProject                                        <-- pexprRel
@@ -6044,8 +4690,6 @@ CUtils::FDuplicateHazardMotion
 //			  +--CScalarFunc ()
 //				 |--CScalarIdent "b" (1)
 //				 +--CScalarConst ()
-//
-//---------------------------------------------------------------------------
 CExpression *
 CUtils::PexprCollapseProjects
 	(
@@ -6199,14 +4843,7 @@ CUtils::PexprCollapseProjects
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::AppendArrayExpr
-//
-//	@doc:
-//		Append expressions in the source array to destination array
-//
-//---------------------------------------------------------------------------
+// append expressions in the source array to destination array
 void CUtils::AppendArrayExpr
 		(
 		DrgPexpr *pdrgpexprSrc,
@@ -6225,14 +4862,7 @@ void CUtils::AppendArrayExpr
 	}
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::IDatumCmp
-//
-//	@doc:
-//		Compares two datums. Takes pointer pointer to a datums.
-//
-//---------------------------------------------------------------------------
+// compares two datums. Takes pointer pointer to a datums.
 INT CUtils::IDatumCmp
 		(
 		const void *pv1,

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -6448,4 +6448,24 @@ CUtils::ExecLocalityType
 	return eelt;
 }
 
+// generate a limit expression on top of the given relational child with the given offset and limit count
+CExpression *
+CUtils::PexprLimit
+       (
+       IMemoryPool *pmp,
+       CExpression *pexpr,
+       ULONG ulOffSet,
+       ULONG ulCount
+       )
+{
+       GPOS_ASSERT(pexpr);
+
+       COrderSpec *pos = GPOS_NEW(pmp) COrderSpec(pmp);
+       CLogicalLimit *popLimit = GPOS_NEW(pmp) CLogicalLimit(pmp, pos, true /* fGlobal */, true /* fHasCount */, false /*fTopLimitUnderDML*/);
+       CExpression *pexprLimitOffset = CUtils::PexprScalarConstInt8(pmp, ulOffSet);
+       CExpression *pexprLimitCount = CUtils::PexprScalarConstInt8(pmp, ulCount);
+
+       return GPOS_NEW(pmp) CExpression(pmp, popLimit, pexpr, pexprLimitOffset, pexprLimitCount);
+}
+
 // EOF

--- a/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -41,14 +41,7 @@ using namespace gpopt;
 // maximum number of equality predicates to be derived from existing equalities
 #define GPOPT_MAX_DERIVED_PREDS 50
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprEliminateSelfComparison
-//
-//	@doc:
-//		Eliminate self comparisons in the given expression
-//
-//---------------------------------------------------------------------------
+// eliminate self comparisons in the given expression
 CExpression *
 CExpressionPreprocessor::PexprEliminateSelfComparison
 	(
@@ -81,15 +74,7 @@ CExpressionPreprocessor::PexprEliminateSelfComparison
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprPruneSuperfluousEquality
-//
-//	@doc:
-//		Remove superfluous equality operations
-//
-//
-//---------------------------------------------------------------------------
+// remove superfluous equality operations
 CExpression *
 CExpressionPreprocessor::PexprPruneSuperfluousEquality
 	(
@@ -121,20 +106,13 @@ CExpressionPreprocessor::PexprPruneSuperfluousEquality
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprTrimExistentialSubqueries
-//
-//	@doc:
-//		An existential subquery whose inner expression is a GbAgg
-//		with no grouping columns is replaced with a Boolean constant
+// an existential subquery whose inner expression is a GbAgg
+// with no grouping columns is replaced with a Boolean constant
 //
 //		Example:
 //
 //			exists(select sum(i) from X) --> True
 //			not exists(select sum(i) from X) --> False
-//
-//---------------------------------------------------------------------------
 CExpression *
 CExpressionPreprocessor::PexprTrimExistentialSubqueries
 	(
@@ -315,22 +293,11 @@ CExpressionPreprocessor::PexprSimplifyExistentialPredicates
 	return pexprRes;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries
+// a quantified subquery with maxcard 1 is simplified as a scalar subquery
 //
-//	@doc:
-//		A quantified subquery with maxcard 1 is simplified as a scalar
-//		subquery
-//
-//		Example:
-//
-//			a = ANY (select sum(i) from X) --> a = (select sum(i) from X)
-//			a <> ALL (select sum(i) from X) --> a <> (select sum(i) from X)
-//
-//
-//---------------------------------------------------------------------------
+// Example:
+//		a = ANY (select sum(i) from X) --> a = (select sum(i) from X)
+//		a <> ALL (select sum(i) from X) --> a <> (select sum(i) from X)
 CExpression *
 CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries
 	(
@@ -400,22 +367,10 @@ CExpressionPreprocessor::PexprSimplifyQuantifiedSubqueries
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprUnnestScalarSubqueries
-//
-//	@doc:
-//		Preliminary unnesting of scalar subqueries
-//
-//
-//		Example:
-//			Input:   SELECT k, (SELECT (SELECT Y.i FROM Y WHERE Y.j=X.j)) from X
-//			Output:  SELECT k, (SELECT Y.i FROM Y WHERE Y.j=X.j) from X
-//
-//
-//
-//---------------------------------------------------------------------------
+// preliminary unnesting of scalar subqueries
+// Example:
+// 		Input:   SELECT k, (SELECT (SELECT Y.i FROM Y WHERE Y.j=X.j)) from X
+//		Output:  SELECT k, (SELECT Y.i FROM Y WHERE Y.j=X.j) from X
 CExpression *
 CExpressionPreprocessor::PexprUnnestScalarSubqueries
 	(
@@ -515,16 +470,7 @@ CExpressionPreprocessor::PexprUnnestScalarSubqueries
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprRemoveSuperfluousLimit
-//
-//	@doc:
-//		An intermediate limit is removed if it has neither row count
-//		nor offset
-//
-//---------------------------------------------------------------------------
+// an intermediate limit is removed if it has neither row count nor offset
 CExpression *
 CExpressionPreprocessor::PexprRemoveSuperfluousLimit
 	(
@@ -568,17 +514,11 @@ CExpressionPreprocessor::PexprRemoveSuperfluousLimit
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprRemoveSuperfluousOuterRefs
+//	Remove outer references from order spec inside limit, grouping columns
+//	in GbAgg, and Partition/Order columns in window operators
 //
-//	@doc:
-//		Remove outer references from order spec inside limit, grouping columns
-//		in GbAgg, and Partition/Order columns in window operators
-//
-//		Example, for the schema: t(a, b), s(i, j)
-//		The query:
+//	Example, for the schema: t(a, b), s(i, j)
+//	The query:
 //			select * from t where a < all (select i from s order by j, b limit 1);
 //		should be equivalent to:
 //			select * from t where a < all (select i from s order by j limit 1);
@@ -594,9 +534,6 @@ CExpressionPreprocessor::PexprRemoveSuperfluousLimit
 //			select * from t where a in (select row_number() over (partition by t.a order by t.b) from s);
 //		is equivalent to:
 //			select * from t where a in (select row_number() over () from s);
-//
-//
-//---------------------------------------------------------------------------
 CExpression *
 CExpressionPreprocessor::PexprRemoveSuperfluousOuterRefs
 	(
@@ -721,15 +658,8 @@ CExpressionPreprocessor::PexprRemoveSuperfluousOuterRefs
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CUtils::PexprScalarBoolOpConvert2In
-//
-//	@doc:
-//		Generate a ScalarBoolOp expression or simply return the only expression
-//		in the array if there is only one.
-//
-//---------------------------------------------------------------------------
+// generate a ScalarBoolOp expression or simply return the only expression
+// in the array if there is only one.
 CExpression *
 CExpressionPreprocessor::PexprScalarBoolOpConvert2In
 	(
@@ -758,16 +688,9 @@ CExpressionPreprocessor::PexprScalarBoolOpConvert2In
 			);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::FConvert2InIsConvertable
-//
-//	@doc:
-//		Checks if the given expression is likely to be simplified by the constraints
-//		framework during array conversion. eboolop is the CScalarBoolOp type
-//		of the expression which contains the argument expression
-//
-//---------------------------------------------------------------------------
+// checks if the given expression is likely to be simplified by the constraints
+// framework during array conversion. eboolop is the CScalarBoolOp type
+// of the expression which contains the argument expression
 BOOL
 CExpressionPreprocessor::FConvert2InIsConvertable(CExpression *pexpr, CScalarBoolOp::EBoolOperator eboolopParent)
 {
@@ -799,16 +722,9 @@ CExpressionPreprocessor::FConvert2InIsConvertable(CExpression *pexpr, CScalarBoo
 	return fConvertableExpression;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprConvert2In
-//
-//	@doc:
-//		Converts series of AND or OR comparisons into array IN expressions. For
-//		example, x = 1 OR x = 2 will convert to x IN (1,2). This stage assumes
-//		the expression has been unnested using CExpressionUtils::PexprUnnest.
-//
-//---------------------------------------------------------------------------
+// converts series of AND or OR comparisons into array IN expressions. For
+// example, x = 1 OR x = 2 will convert to x IN (1,2). This stage assumes
+// the expression has been unnested using CExpressionUtils::PexprUnnest.
 CExpression *
 CExpressionPreprocessor::PexprConvert2In
 	(
@@ -884,14 +800,7 @@ CExpressionPreprocessor::PexprConvert2In
 
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprCollapseInnerJoins
-//
-//	@doc:
-//		Collapse cascaded inner joins into NAry-joins
-//
-//---------------------------------------------------------------------------
+// collapse cascaded inner joins into NAry-joins
 CExpression *
 CExpressionPreprocessor::PexprCollapseInnerJoins
 	(
@@ -967,15 +876,7 @@ CExpressionPreprocessor::PexprCollapseInnerJoins
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprCollapseProjects
-//
-//	@doc:
-//		Collapse cascaded logical project operators
-//
-//---------------------------------------------------------------------------
+// collapse cascaded logical project operators
 CExpression *
 CExpressionPreprocessor::PexprCollapseProjects
 	(
@@ -1014,14 +915,8 @@ CExpressionPreprocessor::PexprCollapseProjects
 	return pexprCollapsed;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprProjBelowSubquery
-//
-//	@doc:
-//		Insert dummy project element below scalar subquery when the (a) the scalar
-//      subquery is below a project and (b) output column is an outer reference
-//---------------------------------------------------------------------------
+// insert dummy project element below scalar subquery when the (a) the scalar
+// subquery is below a project and (b) output column is an outer reference
 CExpression *
 CExpressionPreprocessor::PexprProjBelowSubquery
 	(
@@ -1118,14 +1013,7 @@ CExpressionPreprocessor::PexprProjBelowSubquery
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprCollapseUnionUnionAll
-//
-//	@doc:
-//		Collapse cascaded union/union all into an NAry union/union all operator
-//
-//---------------------------------------------------------------------------
+// collapse cascaded union/union all into an NAry union/union all operator
 CExpression *
 CExpressionPreprocessor::PexprCollapseUnionUnionAll
 	(
@@ -1217,15 +1105,7 @@ CExpressionPreprocessor::PexprCollapseUnionUnionAll
 	return GPOS_NEW(pmp) CExpression(pmp, popNew, pdrgpexprNew);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprOuterJoinToInnerJoin
-//
-//	@doc:
-//		Transform outer joins into inner joins
-//
-//---------------------------------------------------------------------------
+// transform outer joins into inner joins
 CExpression *
 CExpressionPreprocessor::PexprOuterJoinToInnerJoin
 	(
@@ -1295,16 +1175,7 @@ CExpressionPreprocessor::PexprOuterJoinToInnerJoin
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprConjEqualityPredicates
-//
-//	@doc:
-// 		Generate equality predicates between the columns in the given set,
-//		we cap the number of generated predicates by GPOPT_MAX_DERIVED_PREDS
-//
-//---------------------------------------------------------------------------
+// generate equality predicates between the columns in the given set,
 CExpression *
 CExpressionPreprocessor::PexprConjEqualityPredicates
 	(
@@ -1346,16 +1217,8 @@ CExpressionPreprocessor::PexprConjEqualityPredicates
 	return CPredicateUtils::PexprConjunction(pmp, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::FEquivClassFromChild
-//
-//	@doc:
-// 		Check if all columns in the given equivalent class come from one of the
-//		children of the given expression
-//
-//---------------------------------------------------------------------------
+// check if all columns in the given equivalent class come from one of the
+// children of the given expression
 BOOL
 CExpressionPreprocessor::FEquivClassFromChild
 	(
@@ -1385,15 +1248,8 @@ CExpressionPreprocessor::FEquivClassFromChild
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprAddEqualityPreds
-//
-//	@doc:
-// 		Additional equality predicates are generated based on the equivalence
-//		classes in the constraint properties of the expression.
-//
-//---------------------------------------------------------------------------
+// additional equality predicates are generated based on the equivalence
+// classes in the constraint properties of the expression.
 CExpression *
 CExpressionPreprocessor::PexprAddEqualityPreds
 	(
@@ -1473,16 +1329,9 @@ CExpressionPreprocessor::PexprAddEqualityPreds
 						);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprScalarPredicates
-//
-//	@doc:
-// 		Generate predicates for the given set of columns based on the given
-//		constraint property. Columns for which predicates are generated will be
-//		added to the set of processed columns
-//
-//---------------------------------------------------------------------------
+// generate predicates for the given set of columns based on the given
+// constraint property. Columns for which predicates are generated will be
+// added to the set of processed columns
 CExpression *
 CExpressionPreprocessor::PexprScalarPredicates
 	(
@@ -1528,17 +1377,9 @@ CExpressionPreprocessor::PexprScalarPredicates
 	return CPredicateUtils::PexprConjunction(pmp, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprFromConstraintsScalar
-//
-//	@doc:
-// 		Process scalar expressions for generating additional predicates based on
-//		derived constraints. This function is needed because scalar expressions
-//		can have relational children when there are subqueries
-//
-//---------------------------------------------------------------------------
+// process scalar expressions for generating additional predicates based on
+// derived constraints. This function is needed because scalar expressions
+// can have relational children when there are subqueries
 CExpression *
 CExpressionPreprocessor::PexprFromConstraintsScalar
 	(
@@ -1581,16 +1422,8 @@ CExpressionPreprocessor::PexprFromConstraintsScalar
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprWithImpliedPredsOnLOJInnerChild
-//
-//	@doc:
-// 		Imply new predicates on LOJ's inner child based on constraints derived
-//		from LOJ's outer child and join predicate
-//
-//---------------------------------------------------------------------------
+// Imply new predicates on LOJ's inner child based on constraints derived
+// from LOJ's outer child and join predicate
 CExpression *
 CExpressionPreprocessor::PexprWithImpliedPredsOnLOJInnerChild
 	(
@@ -1649,50 +1482,40 @@ CExpressionPreprocessor::PexprWithImpliedPredsOnLOJInnerChild
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pexprNewOuter, pexprNewInner, pexprOuterJoinPred);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprOuterJoinInferPredsFromOuterChildToInnerChild
+// Infer predicate from outer child to inner child of the outer join,
 //
-//	@doc:
-// 		Infer predicate from outer child to inner child of the outer join,
+//	for LOJ expressions with predicates on outer child, e.g.,
 //
-//		for LOJ expressions with predicates on outer child, e.g.,
+//		+-LOJ(x=y)
+//  		|---Select(x=5)
+// 	    	|   	+----X
+// 	   		+----Y
 //
-//			+-LOJ(x=y)
-//   			|---Select(x=5)
-// 		    	|   	+----X
-// 	       		+----Y
+//	this function implies an equivalent predicate (y=5) on the inner child of LOJ:
 //
-//		this function implies an equivalent predicate (y=5) on the inner child of LOJ:
+//		+-LOJ(x=y)
+//			|---Select(x=5)
+//			|		+----X
+//			+---Select(y=5)
+//					+----Y
 //
-//			+-LOJ(x=y)
-//				|---Select(x=5)
-//				|		+----X
-//				+---Select(y=5)
-//						+----Y
+//	the correctness of this rewrite can be proven as follows:
+//		- By removing all tuples from Y that do not satisfy (y=5), the LOJ
+//		results, where x=y, are retained. The reason is that any such join result
+//		must satisfy (x=5 ^ x=y) which implies that (y=5).
 //
-//		the correctness of this rewrite can be proven as follows:
-//			- By removing all tuples from Y that do not satisfy (y=5), the LOJ
-//			results, where x=y, are retained. The reason is that any such join result
-//			must satisfy (x=5 ^ x=y) which implies that (y=5).
+//		- LOJ results that correspond to tuples from X not joining with any tuple
+//		from Y are also retained. The reason is that such join results can only be
+//		produced if for all tuples in Y, we have (y!=5). By selecting Y tuples where (y=5),
+//		if we end up with no Y tuples, the LOJ results will be generated by joining X with empty Y.
+//		This is the same as joining with all tuples from Y with (y!=5). If we end up with
+//		any tuple in Y satisfying (y=5), no LOJ results corresponding to X tuples not joining
+//		with Y can be produced.
 //
-//			- LOJ results that correspond to tuples from X not joining with any tuple
-//			from Y are also retained. The reason is that such join results can only be
-//			produced if for all tuples in Y, we have (y!=5). By selecting Y tuples where (y=5),
-//			if we end up with no Y tuples, the LOJ results will be generated by joining X with empty Y.
-//			This is the same as joining with all tuples from Y with (y!=5). If we end up with
-//			any tuple in Y satisfying (y=5), no LOJ results corresponding to X tuples not joining
-//			with Y can be produced.
-//
-//		to implement this rewrite in a general form, we need to imply general constraints on
-//		LOJ's inner child from constraints that exist on LOJ's outer child. The generated predicate
-//		from this inference can only be inserted below LOJ (on top of the inner child), and cannot be
-//		inserted on top of LOJ, otherwise we may wrongly convert LOJ to inner-join.
-//
-//
-//
-//---------------------------------------------------------------------------
+//	to implement this rewrite in a general form, we need to imply general constraints on
+//	LOJ's inner child from constraints that exist on LOJ's outer child. The generated predicate
+//	from this inference can only be inserted below LOJ (on top of the inner child), and cannot be
+//	inserted on top of LOJ, otherwise we may wrongly convert LOJ to inner-join.
 CExpression *
 CExpressionPreprocessor::PexprOuterJoinInferPredsFromOuterChildToInnerChild
 	(
@@ -1724,18 +1547,10 @@ CExpressionPreprocessor::PexprOuterJoinInferPredsFromOuterChildToInnerChild
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprFromConstraints
-//
-//	@doc:
-// 		Additional predicates are generated based on the derived constraint
-//		properties of the expression. No predicates are generated for the columns
-//		in the already processed set. This set is expanded with more columns
-//		that get processed along the way
-//
-//---------------------------------------------------------------------------
+// additional predicates are generated based on the derived constraint
+// properties of the expression. No predicates are generated for the columns
+// in the already processed set. This set is expanded with more columns
+// that get processed along the way
 CExpression *
 CExpressionPreprocessor::PexprFromConstraints
 	(
@@ -1804,15 +1619,8 @@ CExpressionPreprocessor::PexprFromConstraints
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprPruneEmptySubtrees
-//
-//	@doc:
-// 		Eliminate subtrees that have a zero output cardinality, replacing them
-//		with a const table get with the same output schema and zero tuples
-//
-//---------------------------------------------------------------------------
+// eliminate subtrees that have a zero output cardinality, replacing them
+// with a const table get with the same output schema and zero tuples
 CExpression *
 CExpressionPreprocessor::PexprPruneEmptySubtrees
 	(
@@ -1855,15 +1663,7 @@ CExpressionPreprocessor::PexprPruneEmptySubtrees
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprRemoveUnusedCTEs
-//
-//	@doc:
-// 		Eliminate CTE Anchors for CTEs that have zero consumers
-//
-//---------------------------------------------------------------------------
+// eliminate CTE Anchors for CTEs that have zero consumers
 CExpression *
 CExpressionPreprocessor::PexprRemoveUnusedCTEs
 	(
@@ -1898,16 +1698,8 @@ CExpressionPreprocessor::PexprRemoveUnusedCTEs
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::CollectCTEPredicates
-//
-//	@doc:
-//		For all consumers of the same CTE, collect all selection predicates
-//		on top of these consumers, if any, and store them in hash map
-//
-//---------------------------------------------------------------------------
+// for all consumers of the same CTE, collect all selection predicates
+// on top of these consumers, if any, and store them in hash map
 void
 CExpressionPreprocessor::CollectCTEPredicates
 	(
@@ -1960,15 +1752,7 @@ CExpressionPreprocessor::CollectCTEPredicates
 	}
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::AddPredsToCTEProducers
-//
-//	@doc:
-//		Add CTE predicates collected from consumers to producer expressions
-//
-//---------------------------------------------------------------------------
+// add CTE predicates collected from consumers to producer expressions
 void
 CExpressionPreprocessor::AddPredsToCTEProducers
 	(
@@ -2023,16 +1807,7 @@ CExpressionPreprocessor::AddPredsToCTEProducers
 	phm->Release();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprAddPredicatesFromConstraints
-//
-//	@doc:
-//		Derive constraints on given expression, and add new predicates
-//		by implication
-//
-//---------------------------------------------------------------------------
+// derive constraints on given expression, and add new predicates by implication
 CExpression *
 CExpressionPreprocessor::PexprAddPredicatesFromConstraints
 	(
@@ -2062,15 +1837,7 @@ CExpressionPreprocessor::PexprAddPredicatesFromConstraints
 	return pexprDeduped;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprInferPredicates
-//
-//	@doc:
-//		 Driver for inferring predicates from constraints
-//
-//---------------------------------------------------------------------------
+// driver for inferring predicates from constraints
 CExpression *
 CExpressionPreprocessor::PexprInferPredicates
 	(
@@ -2100,34 +1867,28 @@ CExpressionPreprocessor::PexprInferPredicates
 	return pexprWithPreds;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprPruneUnusedComputedCols
+//	Workhorse for pruning unused computed columns
 //
-//	@doc:
-//		 Workhorse for pruning unused computed columns
+//	The required columns passed by the query is passed to this pre-processing
+//	stage and the list of columns are copied to a new list. This driver function
+//	calls the PexprPruneUnusedComputedColsRecursive function with the copied
+//	required column set. The original required columns set is not modified by
+//	this preprocessor.
 //
-//		 The required columns passed by the query is passed to this pre-processing
-//		 stage and the list of columns are copied to a new list. This driver function
-//		 calls the PexprPruneUnusedComputedColsRecursive function with the copied
-//		 required column set. The original required columns set is not modified by
-//		 this preprocessor.
+// 	Extra copy of the required columns set is avoided in each recursive call by
+//	creating a one-time copy and passing it by reference for all the recursive
+//	calls.
 //
-//		 Extra copy of the required columns set is avoided in each recursive call by
-//		 creating a one-time copy and passing it by reference for all the recursive
-//		 calls.
+//	The functional behavior of the PruneUnusedComputedCols changed slightly
+//	because we do not delete the required column set at the end of every
+//	call but pass it to the next and consecutive recursive calls. However,
+//	it is safe to add required columns by each operator we traverse, because non
+//	of the required columns from other child of a tree will appear on the project
+//	list of the other children.
 //
-//		 The functional behavior of the PruneUnusedComputedCols changed slightly
-//		 because we do not delete the required column set at the end of every
-//		 call but pass it to the next and consecutive recursive calls. However,
-//		 it is safe to add required columns by each operator we traverse, because non
-//		 of the required columns from other child of a tree will appear on the project
-//		 list of the other children.
-//
-//		 Therefore, the added columns to the required columns which is caused by
-//		 the recursive call and passing by reference will not have a bad affect
-//		 on the overall result.
-//---------------------------------------------------------------------------
+// Therefore, the added columns to the required columns which is caused by
+// the recursive call and passing by reference will not have a bad affect
+// on the overall result.
 CExpression *
 CExpressionPreprocessor::PexprPruneUnusedComputedCols
 	(
@@ -2151,14 +1912,7 @@ CExpressionPreprocessor::PexprPruneUnusedComputedCols
 	return pExprNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprPruneUnusedComputedColsRecursive
-//
-//	@doc:
-//		 Workhorse for pruning unused computed columns
-//
-//---------------------------------------------------------------------------
+// Workhorse for pruning unused computed columns
 CExpression *
 CExpressionPreprocessor::PexprPruneUnusedComputedColsRecursive
 	(
@@ -2229,16 +1983,8 @@ CExpressionPreprocessor::PexprPruneUnusedComputedColsRecursive
 
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprPruneProjListProjectOrGbAgg
-//
-//	@doc:
-//		Construct new Project or GroupBy operator without unused computed
-//		columns as project elements
-//
-//---------------------------------------------------------------------------
+// Construct new Project or GroupBy operator without unused computed
+// columns as project elements
 CExpression *
 CExpressionPreprocessor::PexprPruneProjListProjectOrGbAgg
 	(
@@ -2333,15 +2079,7 @@ CExpressionPreprocessor::PexprPruneProjListProjectOrGbAgg
 	return pexprResult;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CExpressionPreprocessor::PexprPreprocess
-//
-//	@doc:
-//		Main driver,
-//		preprocessing of input logical expression
-//
-//---------------------------------------------------------------------------
+// main driver, preprocessing of input logical expression
 CExpression *
 CExpressionPreprocessor::PexprPreprocess
 	(

--- a/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -175,8 +175,8 @@ CExpressionPreprocessor::PexprTrimExistentialSubqueries
 // Example 2:
 // select * from foo where exists (select * from bar) and  foo.a = 10 AND not exists (select * from x);
 // will be transformed to
-// select * from (select * from foo where foo.a = foo.b AND not exists (select * from x)), (select * from bar LIMIT 1), (select * from x) where true
-// In the above example, foo.a = foo.b AND not exists (select * from x) are applied directly on foo, and then joined with the exists subquery.
+// select * from (select * from foo where foo.a = 10 AND not exists (select * from x)), (select * from bar LIMIT 1), (select * from x) where true
+// In the above example, foo.a = 10 AND not exists (select * from x) are applied directly on foo, and then joined with the exists subquery.
 CExpression *
 CExpressionPreprocessor::PexprSimplifyExistentialPredicates
 	(

--- a/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -188,6 +188,133 @@ CExpressionPreprocessor::PexprTrimExistentialSubqueries
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprChildren);
 }
 
+// simply existential subquery in the WHERE CLAUSE example;
+// Example 1:
+// select * from foo where exists (select * from bar) ->
+// will be transformed to
+// select * from foo, (select * from bar LIMIT 1) where true
+
+// Example 2:
+// select * from foo where exists (select * from bar) and  foo.a = 10 AND not exists (select * from x);
+// will be transformed to
+// select * from (select * from foo where foo.a = foo.b AND not exists (select * from x)), (select * from bar LIMIT 1), (select * from x) where true
+// In the above example, foo.a = foo.b AND not exists (select * from x) are applied directly on foo, and then joined with the exists subquery.
+CExpression *
+CExpressionPreprocessor::PexprSimplifyExistentialPredicates
+	(
+	IMemoryPool *pmp,
+	CExpression *pexprOrig
+	)
+{
+	// protect against stack overflow during recursion
+	GPOS_CHECK_STACK_SIZE;
+	GPOS_ASSERT(NULL != pmp);
+	GPOS_ASSERT(NULL != pexprOrig);
+
+	// first recursively process children
+	const ULONG ulArity = pexprOrig->UlArity();
+	DrgPexpr *pdrgpexprNew = GPOS_NEW(pmp) DrgPexpr(pmp);
+	for (ULONG ul = 0; ul < ulArity; ul++)
+	{
+		CExpression *pexprChild = PexprSimplifyExistentialPredicates(pmp, (*pexprOrig)[ul]);
+		pdrgpexprNew->Append(pexprChild);
+	}
+
+	COperator *pop = pexprOrig->Pop();
+	if (COperator::EopLogicalSelect != pop->Eopid())
+	{
+		pop->AddRef();
+
+		return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprNew);
+	}
+
+	CExpression *pexprRel = (*pdrgpexprNew)[0];
+	CExpression *pexprScalar = (*pdrgpexprNew)[1];
+
+
+	DrgPexpr *pdrgpexprConjuncts = CPredicateUtils::PdrgpexprConjuncts(pmp, pexprScalar);
+
+	const ULONG ulArityConj = pdrgpexprConjuncts->UlLength();
+	DrgPexpr *pdrgpexprExists = GPOS_NEW(pmp) DrgPexpr(pmp);
+	DrgPexpr *pdrgpexprRemainder = GPOS_NEW(pmp) DrgPexpr(pmp);
+
+	for (ULONG ul2 = 0; ul2 < ulArityConj; ul2++)
+	{
+		CExpression *pexprPred = (*pdrgpexprConjuncts)[ul2];
+		BOOL fRemainder = true;
+		if (pexprPred->Pop()->Eopid() == COperator::EopScalarSubqueryExists)
+		{
+			CExpression *pexprPredChild = (*pexprPred)[0];
+
+			GPOS_ASSERT(pexprPredChild->Pop()->FLogical());
+
+			CColRefSet *pcrsOuterRefs = CDrvdPropRelational::Pdprel(pexprPredChild->PdpDerive())->PcrsOuter();
+
+			if (0 == pcrsOuterRefs->CElements())
+			{
+				pexprPredChild->AddRef();
+				pdrgpexprExists->Append(pexprPredChild);
+				fRemainder = false;
+			}
+		}
+
+		if (fRemainder)
+		{
+			pexprPred->AddRef();
+			pdrgpexprRemainder->Append(pexprPred);
+		}
+	}
+
+	CExpression *pexprRes = NULL;
+	if (0 == pdrgpexprExists->UlLength())
+	{
+		pop->AddRef();
+
+		pexprRes = GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexprNew);
+	}
+	else
+	{
+		DrgPexpr *pdrgpexprJoin = GPOS_NEW(pmp) DrgPexpr(pmp);
+
+		if (0 == pdrgpexprRemainder->UlLength())
+		{
+			pexprRel->AddRef();
+			pdrgpexprJoin->Append(pexprRel);
+		}
+		else
+		{
+			pexprRel->AddRef();
+			pdrgpexprRemainder->AddRef();
+			CExpression *pexprScalarNew = CPredicateUtils::PexprConjunction(pmp, pdrgpexprRemainder);
+			CExpression *pexprRelNew = GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CLogicalSelect(pmp), pexprRel, pexprScalarNew);
+
+			pdrgpexprJoin->Append(pexprRelNew);
+		}
+
+		const ULONG ulArityExists = pdrgpexprExists->UlLength();
+		for (ULONG ul3 = 0; ul3 < ulArityExists; ul3++)
+		{
+			CExpression *pexprExistsChild = (*pdrgpexprExists)[ul3];
+			pexprExistsChild->AddRef();
+			pdrgpexprJoin->Append(CUtils::PexprLimit(pmp, pexprExistsChild, 0, 1));
+		}
+
+		pdrgpexprJoin->Append(CUtils::PexprScalarConstBool(pmp, true));
+
+		pexprRes = GPOS_NEW(pmp) CExpression(pmp, GPOS_NEW(pmp) CLogicalNAryJoin(pmp), pdrgpexprJoin);
+
+		// clean up
+		pdrgpexprNew->Release();
+	}
+
+	// clean up
+	pdrgpexprConjuncts->Release();
+	pdrgpexprExists->Release();
+	pdrgpexprRemainder->Release();
+
+	return pexprRes;
+}
+
 
 //---------------------------------------------------------------------------
 //	@function:
@@ -2258,12 +2385,17 @@ CExpressionPreprocessor::PexprPreprocess
 	GPOS_CHECK_ABORT;
 	pexprTrimmed2->Release();
 
-	// (7) do preliminary unnesting of scalar subqueries
-	CExpression *pexprSubqUnnested = PexprUnnestScalarSubqueries(pmp, pexprSubqSimplified);
+	// (7) simplify exists subqueries
+	CExpression *pexprSimplifiedExists = PexprSimplifyExistentialPredicates(pmp, pexprSubqSimplified);
 	GPOS_CHECK_ABORT;
 	pexprSubqSimplified->Release();
 
-	// (8) unnest AND/OR/NOT predicates
+	// (8) do preliminary unnesting of scalar subqueries
+	CExpression *pexprSubqUnnested = PexprUnnestScalarSubqueries(pmp, pexprSimplifiedExists);
+	GPOS_CHECK_ABORT;
+	pexprSimplifiedExists->Release();
+
+	// (9) unnest AND/OR/NOT predicates
 	CExpression *pexprUnnested = CExpressionUtils::PexprUnnest(pmp, pexprSubqUnnested);
 	GPOS_CHECK_ABORT;
 	pexprSubqUnnested->Release();
@@ -2272,83 +2404,83 @@ CExpressionPreprocessor::PexprPreprocess
 
 	if (GPOS_FTRACE(EopttraceArrayConstraints))
 	{
-		// (8.5) ensure predicates are array IN or NOT IN where applicable
+		// (10) ensure predicates are array IN or NOT IN where applicable
 		pexprConvert2In = PexprConvert2In(pmp, pexprUnnested);
 		GPOS_CHECK_ABORT;
 		pexprUnnested->Release();
 	}
 
-	// (9) infer predicates from constraints
+	// (11) infer predicates from constraints
 	CExpression *pexprInferredPreds = PexprInferPredicates(pmp, pexprConvert2In);
 	GPOS_CHECK_ABORT;
 	pexprConvert2In->Release();
 
-	// (10) eliminate self comparisons
+	// (12) eliminate self comparisons
 	CExpression *pexprSelfCompEliminated = PexprEliminateSelfComparison(pmp, pexprInferredPreds);
 	GPOS_CHECK_ABORT;
 	pexprInferredPreds->Release();
 
-	// (11) remove duplicate AND/OR children
+	// (13) remove duplicate AND/OR children
 	CExpression *pexprDeduped = CExpressionUtils::PexprDedupChildren(pmp, pexprSelfCompEliminated);
 	GPOS_CHECK_ABORT;
 	pexprSelfCompEliminated->Release();
 
-	// (12) factorize common expressions
+	// (14) factorize common expressions
 	CExpression *pexprFactorized = CExpressionFactorizer::PexprFactorize(pmp, pexprDeduped);
 	GPOS_CHECK_ABORT;
 	pexprDeduped->Release();
 
-	// (13) infer filters out of components of disjunctive filters
+	// (15) infer filters out of components of disjunctive filters
 	CExpression *pexprPrefiltersExtracted =
 			CExpressionFactorizer::PexprExtractInferredFilters(pmp, pexprFactorized);
 	GPOS_CHECK_ABORT;
 	pexprFactorized->Release();
 
-	// (14) pre-process window functions
+	// (16) pre-process window functions
 	CExpression *pexprWindowPreprocessed = CWindowPreprocessor::PexprPreprocess(pmp, pexprPrefiltersExtracted);
 	GPOS_CHECK_ABORT;
 	pexprPrefiltersExtracted->Release();
 
-	// (15) collapse cascaded union / union all
+	// (17) collapse cascaded union / union all
 	CExpression *pexprNaryUnionUnionAll = PexprCollapseUnionUnionAll(pmp, pexprWindowPreprocessed);
 	pexprWindowPreprocessed->Release();
 
-	// (16) eliminate unused computed columns
+	// (18) eliminate unused computed columns
 	CExpression *pexprNoUnusedPrEl = PexprPruneUnusedComputedCols(pmp, pexprNaryUnionUnionAll, pcrsOutputAndOrderCols);
 	GPOS_CHECK_ABORT;
 	pexprNaryUnionUnionAll->Release();
 
-	// (17) normalize expression
+	// (19) normalize expression
 	CExpression *pexprNormalized = CNormalizer::PexprNormalize(pmp, pexprNoUnusedPrEl);
 	GPOS_CHECK_ABORT;
 	pexprNoUnusedPrEl->Release();
 
-	// (18) transform outer join into inner join whenever possible
+	// (20) transform outer join into inner join whenever possible
 	CExpression *pexprLOJToIJ = PexprOuterJoinToInnerJoin(pmp, pexprNormalized);
 	GPOS_CHECK_ABORT;
 	pexprNormalized->Release();
 
-	// (19) collapse cascaded inner joins
+	// (21) collapse cascaded inner joins
 	CExpression *pexprCollapsed = PexprCollapseInnerJoins(pmp, pexprLOJToIJ);
 	GPOS_CHECK_ABORT;
 	pexprLOJToIJ->Release();
 
-	// (20) after transforming outer joins to inner joins, we may be able to generate more predicates from constraints
+	// (22) after transforming outer joins to inner joins, we may be able to generate more predicates from constraints
 	CExpression *pexprWithPreds = PexprAddPredicatesFromConstraints(pmp, pexprCollapsed);
 	GPOS_CHECK_ABORT;
 	pexprCollapsed->Release();
 
-	// (21) eliminate empty subtrees
+	// (23) eliminate empty subtrees
 	CExpression *pexprPruned = PexprPruneEmptySubtrees(pmp, pexprWithPreds);
 	GPOS_CHECK_ABORT;
 	pexprWithPreds->Release();
 
-	// (22) collapse cascade of projects
+	// (24) collapse cascade of projects
 	CExpression *pexprCollapsedProjects = PexprCollapseProjects(pmp, pexprPruned);
 	GPOS_CHECK_ABORT;
 	pexprPruned->Release();
 
-	// (23) insert dummy project when the scalar subquery is under a project and returns an outer reference
+	// (25) insert dummy project when the scalar subquery is under a project and returns an outer reference
 	CExpression *pexprSubquery = PexprProjBelowSubquery(pmp, pexprCollapsedProjects, false /* fUnderPrList */);
 	GPOS_CHECK_ABORT;
 	pexprCollapsedProjects->Release();

--- a/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/libgpopt/src/operators/CPredicateUtils.cpp
@@ -37,14 +37,7 @@
 using namespace gpopt;
 using namespace gpmd;
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FNegatedBooleanScalarIdent
-//
-//	@doc:
-//		Check if the expression is a negated boolean scalar identifier
-//
-//---------------------------------------------------------------------------
+// check if the expression is a negated boolean scalar identifier
 BOOL
 CPredicateUtils::FNegatedBooleanScalarIdent
 	(
@@ -61,14 +54,7 @@ CPredicateUtils::FNegatedBooleanScalarIdent
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FBooleanScalarIdent
-//
-//	@doc:
-//		Check if the expression is a boolean scalar identifier
-//
-//---------------------------------------------------------------------------
+// check if the expression is a boolean scalar identifier
 BOOL
 CPredicateUtils::FBooleanScalarIdent
 	(
@@ -89,14 +75,7 @@ CPredicateUtils::FBooleanScalarIdent
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FEquality
-//
-//	@doc:
-//		Is the given expression an equality comparison
-//
-//---------------------------------------------------------------------------
+// is the given expression an equality comparison
 BOOL
 CPredicateUtils::FEquality
 	(
@@ -106,15 +85,7 @@ CPredicateUtils::FEquality
 	return FComparison(pexpr, IMDType::EcmptEq);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FComparison
-//
-//	@doc:
-//		Is the given expression a comparison
-//
-//---------------------------------------------------------------------------
+// is the given expression a comparison
 BOOL
 CPredicateUtils::FComparison
 	(
@@ -126,15 +97,7 @@ CPredicateUtils::FComparison
 	return COperator::EopScalarCmp == pexpr->Pop()->Eopid();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FComparison
-//
-//	@doc:
-//		Is the given expression a comparison of the given type
-//
-//---------------------------------------------------------------------------
+// is the given expression a comparison of the given type
 BOOL
 CPredicateUtils::FComparison
 	(
@@ -157,18 +120,10 @@ CPredicateUtils::FComparison
 	return ecmpt == popScCmp->Ecmpt();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FComparison
-//
-//	@doc:
-//		Is the given expression a comparison over the given column. A comparison
-//		can only be between the given column and an expression involving only
-//		the allowed columns. If the allowed columns set is NULL, then we only want
-//		constant comparisons.
-//
-//---------------------------------------------------------------------------
+// Is the given expression a comparison over the given column. A comparison
+// can only be between the given column and an expression involving only
+// the allowed columns. If the allowed columns set is NULL, then we only want
+// constant comparisons.
 BOOL
 CPredicateUtils::FComparison
 	(
@@ -200,16 +155,9 @@ CPredicateUtils::FComparison
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FValidRefsOnly
-//
-//	@doc:
-//		Check whether the given expression contains references to only the given
-//		columns. If pcrsAllowedRefs is NULL, then check whether the expression has
-//		no column references and no volatile functions
-//
-//---------------------------------------------------------------------------
+// Check whether the given expression contains references to only the given
+// columns. If pcrsAllowedRefs is NULL, then check whether the expression has
+// no column references and no volatile functions
 BOOL
 CPredicateUtils::FValidRefsOnly
 	(
@@ -227,14 +175,7 @@ CPredicateUtils::FValidRefsOnly
 			IMDFunction::EfsVolatile != pdpscalar->Pfp()->Efs();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FConjunctionOfEqComparisons
-//
-//	@doc:
-//		Is the given expression a conjunction of equality comparisons
-//
-//---------------------------------------------------------------------------
+// is the given expression a conjunction of equality comparisons
 BOOL 
 CPredicateUtils::FConjunctionOfEqComparisons
 	(
@@ -265,14 +206,7 @@ CPredicateUtils::FConjunctionOfEqComparisons
 	return true;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FHasNegatedChild
-//
-//	@doc:
-//		Does the given expression have any NOT children?
-//
-//---------------------------------------------------------------------------
+// does the given expression have any NOT children?
 BOOL
 CPredicateUtils::FHasNegatedChild
 	(
@@ -293,16 +227,7 @@ CPredicateUtils::FHasNegatedChild
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::CollectChildren
-//
-//	@doc:
-//		Append logical and scalar children of the given expression to
-//		the given arrays
-//
-//---------------------------------------------------------------------------
+// append logical and scalar children of the given expression to the given arrays
 void
 CPredicateUtils::CollectChildren
 	(
@@ -331,15 +256,7 @@ CPredicateUtils::CollectChildren
 	}
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::CollectConjuncts
-//
-//	@doc:
-//		Recursively collect conjuncts
-//
-//---------------------------------------------------------------------------
+// recursively collect conjuncts
 void
 CPredicateUtils::CollectConjuncts
 	(
@@ -364,15 +281,7 @@ CPredicateUtils::CollectConjuncts
 	}
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::CollectDisjuncts
-//
-//	@doc:
-//		Recursively collect disjuncts
-//
-//---------------------------------------------------------------------------
+// recursively collect disjuncts
 void
 CPredicateUtils::CollectDisjuncts
 	(
@@ -397,15 +306,7 @@ CPredicateUtils::CollectDisjuncts
 	}
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprConjuncts
-//
-//	@doc:
-//		Extract conjuncts from a predicate
-//
-//---------------------------------------------------------------------------
+// extract conjuncts from a predicate
 DrgPexpr *
 CPredicateUtils::PdrgpexprConjuncts
 	(
@@ -419,15 +320,7 @@ CPredicateUtils::PdrgpexprConjuncts
 	return pdrgpexpr;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprDisjuncts
-//
-//	@doc:
-//		Extract disjuncts from a predicate
-//
-//---------------------------------------------------------------------------
+// extract disjuncts from a predicate
 DrgPexpr *
 CPredicateUtils::PdrgpexprDisjuncts
 	(
@@ -441,17 +334,9 @@ CPredicateUtils::PdrgpexprDisjuncts
 	return pdrgpexpr;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprExpandDisjuncts
-//
-//	@doc:
-//		This function expects an array of disjuncts (children of OR operator),
-//		the function expands disjuncts in the given array by converting
-//		ArrayComparison to AND/OR tree and deduplicating resulting disjuncts
-//
-//---------------------------------------------------------------------------
+// This function expects an array of disjuncts (children of OR operator),
+// the function expands disjuncts in the given array by converting
+// ArrayComparison to AND/OR tree and deduplicating resulting disjuncts
 DrgPexpr *
 CPredicateUtils::PdrgpexprExpandDisjuncts
 	(
@@ -504,16 +389,9 @@ CPredicateUtils::PdrgpexprExpandDisjuncts
 	return pdrgpexprResult;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprExpandConjuncts
-//
-//	@doc:
-//		This function expects an array of conjuncts (children of AND operator),
-//		the function expands conjuncts in the given array by converting
-//		ArrayComparison to AND/OR tree and deduplicating resulting conjuncts
-//
-//---------------------------------------------------------------------------
+// This function expects an array of conjuncts (children of AND operator),
+// the function expands conjuncts in the given array by converting
+// ArrayComparison to AND/OR tree and deduplicating resulting conjuncts
 DrgPexpr *
 CPredicateUtils::PdrgpexprExpandConjuncts
 	(
@@ -566,15 +444,7 @@ CPredicateUtils::PdrgpexprExpandConjuncts
 	return pdrgpexprResult;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FSkippable
-//
-//	@doc:
-//		Check if a conjunct/disjunct can be skipped
-//
-//---------------------------------------------------------------------------
+// check if a conjunct/disjunct can be skipped
 BOOL
 CPredicateUtils::FSkippable
 	(
@@ -586,15 +456,8 @@ CPredicateUtils::FSkippable
 			&& CUtils::FScalarConstFalse(pexpr)));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FReducible
-//
-//	@doc:
-//		Check if a conjunction/disjunction can be reduced to a constant
-//		True/False based on the given conjunct/disjunct
-//
-//---------------------------------------------------------------------------
+// check if a conjunction/disjunction can be reduced to a constant
+// True/False based on the given conjunct/disjunct
 BOOL
 CPredicateUtils::FReducible
 	(
@@ -606,14 +469,7 @@ CPredicateUtils::FReducible
 			|| (!fConjunction && CUtils::FScalarConstTrue(pexpr)));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::EcmptReverse
-//
-//	@doc:
-//		Reverse the given operator type, for example > => <, <= => >=
-//
-//---------------------------------------------------------------------------
+// reverse the given operator type, for example > => <, <= => >=
 IMDType::ECmpType
 CPredicateUtils::EcmptReverse
 	(
@@ -650,14 +506,7 @@ CPredicateUtils::EcmptReverse
 	return IMDType::EcmptOther;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FLikePredicate
-//
-//	@doc:
-//		Is the condition a LIKE predicate
-//---------------------------------------------------------------------------
+// is the condition a LIKE predicate
 BOOL
 CPredicateUtils::FLikePredicate
 	(
@@ -682,14 +531,7 @@ CPredicateUtils::FLikePredicate
 	return true;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FLikePredicate
-//
-//	@doc:
-//		Is the condition a LIKE predicate
-//---------------------------------------------------------------------------
+// is the condition a LIKE predicate
 BOOL
 CPredicateUtils::FLikePredicate
 	(
@@ -708,15 +550,7 @@ CPredicateUtils::FLikePredicate
 	return FLikePredicate(pmdid);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::ExtractLikePredComponents
-//
-//	@doc:
-//		Extract the components of a LIKE predicate
-//
-//---------------------------------------------------------------------------
+// extract the components of a LIKE predicate
 void
 CPredicateUtils::ExtractLikePredComponents
 	(
@@ -767,15 +601,7 @@ CPredicateUtils::ExtractLikePredComponents
 	}
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::ExtractComponents
-//
-//	@doc:
-//		Extract components in a comparison expression on the given key
-//
-//---------------------------------------------------------------------------
+// extract components in a comparison expression on the given key
 void
 CPredicateUtils::ExtractComponents
 	(
@@ -815,15 +641,7 @@ CPredicateUtils::ExtractComponents
 	GPOS_ASSERT(NULL != *ppexprKey && NULL != *ppexprOther);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprConjDisj
-//
-//	@doc:
-//		Create conjunction/disjunction from array of components;
-//		Takes ownership over the given array of expressions
-//
-//---------------------------------------------------------------------------
+// create conjunction/disjunction from array of components; Takes ownership over the given array of expressions
 CExpression *
 CPredicateUtils::PexprConjDisj
 	(
@@ -894,14 +712,7 @@ CPredicateUtils::PexprConjDisj
 	return pexprResult;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprConjunction
-//
-//	@doc:
-//		Create conjunction from array of components;
-//
-//---------------------------------------------------------------------------
+// create conjunction from array of components;
 CExpression *
 CPredicateUtils::PexprConjunction
 	(
@@ -912,14 +723,7 @@ CPredicateUtils::PexprConjunction
 	return PexprConjDisj(pmp, pdrgpexpr, true /*fConjunction*/);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprDisjunction
-//
-//	@doc:
-//		Create disjunction from array of components;
-//
-//---------------------------------------------------------------------------
+// create disjunction from array of components;
 CExpression *
 CPredicateUtils::PexprDisjunction
 	(
@@ -930,16 +734,7 @@ CPredicateUtils::PexprDisjunction
 	return PexprConjDisj(pmp, pdrgpexpr, false /*fConjunction*/);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprConjDisj
-//
-//	@doc:
-//		Create a conjunction/disjunction of two components;
-//		Does *not* take ownership over given expressions
-//
-//---------------------------------------------------------------------------
+// create a conjunction/disjunction of two components; Does *not* take ownership over given expressions
 CExpression *
 CPredicateUtils::PexprConjDisj
 	(
@@ -982,15 +777,7 @@ CPredicateUtils::PexprConjDisj
 	return PexprConjDisj(pmp, pdrgpexpr, fConjunction);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprConjunction
-//
-//	@doc:
-//		Create a conjunction of two components;
-//
-//---------------------------------------------------------------------------
+// create a conjunction of two components;
 CExpression *
 CPredicateUtils::PexprConjunction
 	(
@@ -1002,15 +789,7 @@ CPredicateUtils::PexprConjunction
 	return PexprConjDisj(pmp, pexprOne, pexprTwo, true /*fConjunction*/);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprDisjunction
-//
-//	@doc:
-//		Create a disjunction of two components;
-//
-//---------------------------------------------------------------------------
+// create a disjunction of two components;
 CExpression *
 CPredicateUtils::PexprDisjunction
 	(
@@ -1022,15 +801,7 @@ CPredicateUtils::PexprDisjunction
 	return PexprConjDisj(pmp, pexprOne, pexprTwo, false /*fConjunction*/);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprPlainEqualities
-//
-//	@doc:
-//		Extract equality predicates over scalar identifiers
-//
-//---------------------------------------------------------------------------
+// extract equality predicates over scalar identifiers
 DrgPexpr *
 CPredicateUtils::PdrgpexprPlainEqualities
 	(
@@ -1053,14 +824,7 @@ CPredicateUtils::PdrgpexprPlainEqualities
 	return pdrgpexprEqualities;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FPlainEquality
-//
-//	@doc:
-//		Is an expression an equality over scalar identifiers
-//
-//---------------------------------------------------------------------------
+// is an expression an equality over scalar identifiers
 BOOL
 CPredicateUtils::FPlainEquality
 	(
@@ -1082,15 +846,7 @@ CPredicateUtils::FPlainEquality
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FSelfComparison
-//
-//	@doc:
-//		Is an expression a self comparison on some column
-//
-//---------------------------------------------------------------------------
+// is an expression a self comparison on some column
 BOOL
 CPredicateUtils::FSelfComparison
 	(
@@ -1127,15 +883,7 @@ CPredicateUtils::FSelfComparison
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprEliminateSelfComparison
-//
-//	@doc:
-//		Eliminate self comparison and replace it with True or False if possible
-//
-//---------------------------------------------------------------------------
+// eliminate self comparison and replace it with True or False if possible
 CExpression *
 CPredicateUtils::PexprEliminateSelfComparison
 	(
@@ -1175,14 +923,7 @@ CPredicateUtils::PexprEliminateSelfComparison
 	return pexprNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FINDFScalarIdents
-//
-//	@doc:
-//		Is the given expression in the form (col1 Is NOT DISTINCT FROM col2)
-//
-//---------------------------------------------------------------------------
+// is the given expression in the form (col1 Is NOT DISTINCT FROM col2)
 BOOL
 CPredicateUtils::FINDFScalarIdents
 	(
@@ -1207,15 +948,7 @@ CPredicateUtils::FINDFScalarIdents
 			&& COperator::EopScalarIdent == pexprInner->Pop()->Eopid());
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FIDFScalarIdents
-//
-//	@doc:
-//		Is the given expression in the form (col1 Is DISTINCT FROM col2)
-//
-//---------------------------------------------------------------------------
+// is the given expression in the form (col1 Is DISTINCT FROM col2)
 BOOL
 CPredicateUtils::FIDFScalarIdents
 	(
@@ -1234,15 +967,7 @@ CPredicateUtils::FIDFScalarIdents
 			&& COperator::EopScalarIdent == pexprInner->Pop()->Eopid());
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FIDFFalse
-//
-//	@doc:
-//		Is the given expression in the form 'expr IS DISTINCT FROM false)'
-//
-//---------------------------------------------------------------------------
+// is the given expression in the form 'expr IS DISTINCT FROM false)'
 BOOL
 CPredicateUtils::FIDFFalse
 	(
@@ -1258,14 +983,7 @@ CPredicateUtils::FIDFFalse
 			CUtils::FScalarConstFalse((*pexpr)[1]);
 }
   
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FIDF
-//
-//	@doc:
-//		Is the given expression in the form (expr IS DISTINCT FROM expr)
-//
-//---------------------------------------------------------------------------
+// is the given expression in the form (expr IS DISTINCT FROM expr)
 BOOL
 CPredicateUtils::FIDF
 	(
@@ -1275,14 +993,7 @@ CPredicateUtils::FIDF
 	return (COperator::EopScalarIsDistinctFrom == pexpr->Pop()->Eopid());
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FINDF
-//
-//	@doc:
-//		Is the given expression in the form (expr Is NOT DISTINCT FROM expr)
-//
-//---------------------------------------------------------------------------
+// is the given expression in the form (expr Is NOT DISTINCT FROM expr)
 BOOL
 CPredicateUtils::FINDF
 	(
@@ -1292,16 +1003,7 @@ CPredicateUtils::FINDF
 	return (FNot(pexpr) && FIDF((*pexpr)[0]));
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprINDFConjunction
-//
-//	@doc:
-//		Generate a conjunction of INDF expressions between corresponding
-//		columns in the given arrays
-//
-//---------------------------------------------------------------------------
+// generate a conjunction of INDF expressions between corresponding columns in the given arrays
 CExpression *
 CPredicateUtils::PexprINDFConjunction
 	(
@@ -1325,15 +1027,7 @@ CPredicateUtils::PexprINDFConjunction
 	return PexprConjunction(pmp, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FRangeOrEqComp
-//
-//	@doc:
-// 		Is the given expression a scalar range or equality comparison
-//
-//---------------------------------------------------------------------------
+// is the given expression a scalar range or equality comparison
 BOOL
 CPredicateUtils::FRangeOrEqComp
 	(
@@ -1358,15 +1052,7 @@ CPredicateUtils::FRangeOrEqComp
 	return true;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCompareIdentToConst
-//
-//	@doc:
-// 		Is the given expression a comparison between a scalar ident and a constant
-//
-//---------------------------------------------------------------------------
+// is the given expression a comparison between a scalar ident and a constant
 BOOL
 CPredicateUtils::FCompareIdentToConst
 	(
@@ -1454,15 +1140,7 @@ CPredicateUtils::FIdentCompareConstIgnoreCast
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FIdentINDFConstIgnoreCast
-//
-//	@doc:
-// 		Is the given expression of the form NOT (col IS DISTINCT FROM const)
-//		ignoring cast on either sides
-//---------------------------------------------------------------------------
+// is the given expression of the form NOT (col IS DISTINCT FROM const) ignoring cast on either sides
 BOOL
 CPredicateUtils::FIdentINDFConstIgnoreCast
 	(
@@ -1477,15 +1155,7 @@ CPredicateUtils::FIdentINDFConstIgnoreCast
 	return FIdentCompareConstIgnoreCast((*pexpr)[0], COperator::EopScalarIsDistinctFrom);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCompareIdentToConstArray
-//
-//	@doc:
-// 		Is the given expression a comparison between a scalar ident
-//		and a constant array
-//
-//---------------------------------------------------------------------------
+// is the given expression a comparison between a scalar ident and a constant array
 BOOL
 CPredicateUtils::FCompareIdentToConstArray
 	(
@@ -1505,19 +1175,11 @@ CPredicateUtils::FCompareIdentToConstArray
 	return CUtils::FScalarConstArray(pexprArray);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprPartPruningPredicate
-//
-//	@doc:
-// 		Find a predicate that can be used for partition pruning with the given
-//		part key in the array of expressions if one exists. Relevant predicates
-//		are those that compare the partition key to expressions involving only
-//		the allowed columns. If the allowed columns set is NULL, then we only want
-//		constant comparisons.
-//
-//---------------------------------------------------------------------------
+// Find a predicate that can be used for partition pruning with the given
+// part key in the array of expressions if one exists. Relevant predicates
+// are those that compare the partition key to expressions involving only
+// the allowed columns. If the allowed columns set is NULL, then we only want
+// constant comparisons.
 CExpression *
 CPredicateUtils::PexprPartPruningPredicate
 	(
@@ -1574,15 +1236,8 @@ CPredicateUtils::PexprPartPruningPredicate
 	return PexprConjunction(pmp, pdrgpexprResult);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprAppendConjunctsDedup
-//
-//	@doc:
-//		Append the conjuncts from the given expression to the given array, removing
-//		any duplicates, and return the resulting array
-//
-//---------------------------------------------------------------------------
+// append the conjuncts from the given expression to the given array, removing
+// any duplicates, and return the resulting array
 DrgPexpr *
 CPredicateUtils::PdrgpexprAppendConjunctsDedup
 	(
@@ -1607,15 +1262,8 @@ CPredicateUtils::PdrgpexprAppendConjunctsDedup
 	return pdrgpexprNew;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FBoolPredicateOnColumn
-//
-//	@doc:
-//		Check if the given expression is a boolean expression on the
-//		given column, e.g. if its of the form "ScalarIdent(pcr)" or "Not(ScalarIdent(pcr))"
-//
-//---------------------------------------------------------------------------
+// check if the given expression is a boolean expression on the
+// given column, e.g. if its of the form "ScalarIdent(pcr)" or "Not(ScalarIdent(pcr))"
 BOOL
 CPredicateUtils::FBoolPredicateOnColumn
 	(
@@ -1635,15 +1283,8 @@ CPredicateUtils::FBoolPredicateOnColumn
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FNullCheckOnColumn
-//
-//	@doc:
-//		Check if the given expression is a null check on the given column
-// 		i.e. "is null" or "is not null"
-//
-//---------------------------------------------------------------------------
+// check if the given expression is a null check on the given column
+// i.e. "is null" or "is not null"
 BOOL
 CPredicateUtils::FNullCheckOnColumn
 	(
@@ -1669,15 +1310,8 @@ CPredicateUtils::FNullCheckOnColumn
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FScArrayCmpOnColumn
-//
-//	@doc:
-//		Check if the given expression is a scalar array cmp expression on the
-//		given column
-//
-//---------------------------------------------------------------------------
+// check if the given expression is a scalar array cmp expression on the
+// given column
 BOOL
 CPredicateUtils::FScArrayCmpOnColumn
 	(
@@ -1716,16 +1350,8 @@ CPredicateUtils::FScArrayCmpOnColumn
 	return fSupported;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FDisjunctionOnColumn
-//
-//	@doc:
-//		Check if the given expression is a disjunction of scalar cmp expression 
-//		on the given column
-//
-//---------------------------------------------------------------------------
+// check if the given expression is a disjunction of scalar cmp expression
+// on the given column
 BOOL
 CPredicateUtils::FDisjunctionOnColumn
 	(
@@ -1756,16 +1382,8 @@ CPredicateUtils::FDisjunctionOnColumn
 	return true;	
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FRangeComparison
-//
-//	@doc:
-//		Check if the given comparison type is one of the range comparisons, i.e. 
-//		LT, GT, LEq, GEq, Eq
-//
-//---------------------------------------------------------------------------
+// Check if the given comparison type is one of the range comparisons, i.e.
+// LT, GT, LEq, GEq, Eq
 BOOL
 CPredicateUtils::FRangeComparison
 	(
@@ -1775,18 +1393,11 @@ CPredicateUtils::FRangeComparison
 	return (IMDType::EcmptOther != ecmpt && IMDType::EcmptNEq != ecmpt);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprExtractPredicatesOnPartKeys
-//
-//	@doc:
-//		Extract interesting expressions involving the partitioning keys;
-//		the function Add-Refs the returned copy if not null. Relevant predicates
-//		are those that compare the partition keys to expressions involving only
-//		the allowed columns. If the allowed columns set is NULL, then we only want
-//		constant filters.
-//
-//---------------------------------------------------------------------------
+// extract interesting expressions involving the partitioning keys;
+// the function Add-Refs the returned copy if not null. Relevant predicates
+// are those that compare the partition keys to expressions involving only
+// the allowed columns. If the allowed columns set is NULL, then we only want
+// constant filters.
 CExpression *
 CPredicateUtils::PexprExtractPredicatesOnPartKeys
 	(
@@ -1876,15 +1487,7 @@ CPredicateUtils::PexprExtractPredicatesOnPartKeys
 	return PexprConjunction(pmp, pdrgpexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprPredicateCol
-//
-//	@doc:
-//		Extract the constraint on the given column and return the corresponding
-//		scalar expression
-//
-//---------------------------------------------------------------------------
+// extract the constraint on the given column and return the corresponding scalar expression
 CExpression *
 CPredicateUtils::PexprPredicateCol
 	(
@@ -1921,14 +1524,7 @@ CPredicateUtils::PexprPredicateCol
 	return pexprCol;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCompareColToConstOrCol
-//
-//	@doc:
-// 		Checks if comparison is between two columns, or a column and a const
-//
-//---------------------------------------------------------------------------
+// checks if comparison is between two columns, or a column and a const
 BOOL
 CPredicateUtils::FCompareColToConstOrCol
 	(
@@ -1953,14 +1549,7 @@ CPredicateUtils::FCompareColToConstOrCol
 			(fConstLeft && fColRight);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FConstColumn
-//
-//	@doc:
-// 		Checks if the given constraint specifies a constant column
-//
-//---------------------------------------------------------------------------
+// checks if the given constraint specifies a constant column
 BOOL
 CPredicateUtils::FConstColumn
 	(
@@ -1998,14 +1587,7 @@ CPredicateUtils::FConstColumn
 	return prng->FPoint() && !pcnstrInterval->FIncludesNull();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FColumnDisjunctionOfConst
-//
-//	@doc:
-// 		Checks if the given constraint specifies a set of constants for a column
-//
-//---------------------------------------------------------------------------
+// checks if the given constraint specifies a set of constants for a column
 BOOL
 CPredicateUtils::FColumnDisjunctionOfConst
 	(
@@ -2032,14 +1614,7 @@ CPredicateUtils::FColumnDisjunctionOfConst
 	return FColumnDisjunctionOfConst(pcnstrInterval, pcr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FColumnDisjunctionOfConst
-//
-//	@doc:
-// 		Checks if the given constraint specifies a set of constants for a column
-//
-//---------------------------------------------------------------------------
+// checks if the given constraint specifies a set of constants for a column
 BOOL
 CPredicateUtils::FColumnDisjunctionOfConst
 	(
@@ -2075,15 +1650,7 @@ CPredicateUtils::FColumnDisjunctionOfConst
 	return true;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprIndexLookupKeyOnLeft
-//
-//	@doc:
-// 		Helper to create index lookup comparison predicate with index key
-//		on left side
-//
-//---------------------------------------------------------------------------
+// helper to create index lookup comparison predicate with index key on left side
 CExpression *
 CPredicateUtils::PexprIndexLookupKeyOnLeft
 	(
@@ -2139,16 +1706,7 @@ CPredicateUtils::PexprIndexLookupKeyOnLeft
 	return NULL;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprIndexLookupKeyOnRight
-//
-//	@doc:
-// 		Helper to create index lookup comparison predicate with index key
-//		on right side
-//
-//---------------------------------------------------------------------------
+// helper to create index lookup comparison predicate with index key on right side
 CExpression *
 CPredicateUtils::PexprIndexLookupKeyOnRight
 	(
@@ -2191,22 +1749,14 @@ CPredicateUtils::PexprIndexLookupKeyOnRight
 	return NULL;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprIndexLookup
-//
-//	@doc:
-// 		Check if given expression is a valid index lookup predicate, and
-//		return modified (as needed) expression to be used for index lookup,
-//		a scalar expression is a valid index lookup predicate if it is in one
-//		the two forms:
-//			[index-key CMP expr]
-//			[expr CMP index-key]
-//		where expr is a scalar expression that is free of index keys and
-//		may have outer references (in the case of index nested loops)
-//
-//---------------------------------------------------------------------------
+// Check if given expression is a valid index lookup predicate, and
+// return modified (as needed) expression to be used for index lookup,
+// a scalar expression is a valid index lookup predicate if it is in one
+// the two forms:
+//	[index-key CMP expr]
+//	[expr CMP index-key]
+// where expr is a scalar expression that is free of index keys and
+// may have outer references (in the case of index nested loops)
 CExpression *
 CPredicateUtils::PexprIndexLookup
 	(
@@ -2254,16 +1804,7 @@ CPredicateUtils::PexprIndexLookup
 	return NULL;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::ExtractIndexPredicates
-//
-//	@doc:
-// 		Split predicates into those that refer to an index key, and those that 
-//		don't 
-//
-//---------------------------------------------------------------------------
+// split predicates into those that refer to an index key, and those that don't
 void
 CPredicateUtils::ExtractIndexPredicates
 	(
@@ -2340,16 +1881,8 @@ CPredicateUtils::ExtractIndexPredicates
 	pcrsIndex->Release();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::SeparateOuterRefs
-//
-//	@doc:
-// 		Split given scalar expression into two conjunctions; without outer
-//		references and with outer references
-//
-//---------------------------------------------------------------------------
+// split given scalar expression into two conjunctions; without outer
+// references and with outer references
 void
 CPredicateUtils::SeparateOuterRefs
 	(
@@ -2400,17 +1933,9 @@ CPredicateUtils::SeparateOuterRefs
 	*ppexprOuterRef = PexprConjunction(pmp, pdrgpexprOuterRefs);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprAddCast
-//
-//	@doc:
-// 		Add explicit casting to left child of given equality or INDF predicate
-//		and return resulting casted expression;
-//		the function returns NULL if operation failed
-//
-//---------------------------------------------------------------------------
+// add explicit casting to left child of given equality or INDF predicate
+// and return resulting casted expression;
+// the function returns NULL if operation failed
 CExpression *
 CPredicateUtils::PexprAddCast
 	(
@@ -2477,14 +2002,7 @@ CPredicateUtils::PexprAddCast
 	return pexprNewPred;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprCast
-//
-//	@doc:
-// 		Add explicit casting on the input expression to the destination type
-//
-//---------------------------------------------------------------------------
+// add explicit casting on the input expression to the destination type
 CExpression *
 CPredicateUtils::PexprCast
 	(
@@ -2504,14 +2022,7 @@ CPredicateUtils::PexprCast
 	return GPOS_NEW(pmp) CExpression(pmp, popCast, pexpr);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PdrgpexprCastEquality
-//
-//	@doc:
-// 		Add explicit casting to equality operations between compatible types
-//
-//---------------------------------------------------------------------------
+// add explicit casting to equality operations between compatible types
 DrgPexpr *
 CPredicateUtils::PdrgpexprCastEquality
 	(
@@ -2548,16 +2059,8 @@ CPredicateUtils::PdrgpexprCastEquality
 	return pdrgpexprNew;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprInverseComparison
-//
-//	@doc:
-// 		Convert predicates of the form (a Cmp b) into (a InvCmp b);
-//		where InvCmp is the inverse comparison (e.g., '=' --> '<>')
-//
-//---------------------------------------------------------------------------
+// convert predicates of the form (a Cmp b) into (a InvCmp b);
+// where InvCmp is the inverse comparison (e.g., '=' --> '<>')
 CExpression *
 CPredicateUtils::PexprInverseComparison
 	(
@@ -2579,16 +2082,8 @@ CPredicateUtils::PexprInverseComparison
 	return CUtils::PexprScalarCmp(pmp, (*pexprCmp)[0], (*pexprCmp)[1], *pstrFirst, pmdidInverseOp);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprPruneSuperfluosEquality
-//
-//	@doc:
-// 		Convert predicates of the form (true = (a Cmp b)) into (a Cmp b);
-//		do this operation recursively on deep expression tree
-//
-//---------------------------------------------------------------------------
+// convert predicates of the form (true = (a Cmp b)) into (a Cmp b);
+// do this operation recursively on deep expression tree
 CExpression *
 CPredicateUtils::PexprPruneSuperfluosEquality
 	(
@@ -2664,16 +2159,7 @@ CPredicateUtils::PexprPruneSuperfluosEquality
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCheckPredicateImplication
-//
-//	@doc:
-//		Determine if we should test predicate implication for stats
-//		computation
-//
-//---------------------------------------------------------------------------
+// determine if we should test predicate implication for statistics computation
 BOOL
 CPredicateUtils::FCheckPredicateImplication
 	(
@@ -2687,17 +2173,8 @@ CPredicateUtils::FCheckPredicateImplication
 		COperator::EopScalarIdent == (*pexprPred)[1]->Pop()->Eopid();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FImpliedPredicate
-//
-//	@doc:
-//		Given a predicate and a list of equivalence classes,
-//		return true if that predicate is implied by given equivalence
-//		classes
-//
-//---------------------------------------------------------------------------
+// Given a predicate and a list of equivalence classes, return true if that predicate is
+// implied by given equivalence classes
 BOOL
 CPredicateUtils::FImpliedPredicate
 	(
@@ -2723,22 +2200,13 @@ CPredicateUtils::FImpliedPredicate
 	return false;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprRemoveImpliedConjuncts
+// Remove conjuncts that are implied based on child equivalence classes,
+// the main use case is minimizing join/selection predicates to avoid
+// cardinality under-estimation,
 //
-//	@doc:
-//		Remove conjuncts that are implied based on child equivalence
-//		classes,
-//		the main use case is minimizing join/selection predicates to avoid
-//		cardinality under-estimation,
-//
-//		for example, in the expression ((a=b) AND (a=c)), if a child
-//		equivalence class is {b,c}, then we remove the conjunct (a=c)
-//		since it can be implied from {b,c}, {a,b}
-//
-//---------------------------------------------------------------------------
+// for example, in the expression ((a=b) AND (a=c)), if a child
+// equivalence class is {b,c}, then we remove the conjunct (a=c)
+// since it can be implied from {b,c}, {a,b}
 CExpression *
 CPredicateUtils::PexprRemoveImpliedConjuncts
 	(
@@ -2786,16 +2254,9 @@ CPredicateUtils::PexprRemoveImpliedConjuncts
 	return PexprConjunction(pmp, pdrgpexprNewConjuncts);
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FValidSemiJoinCorrelations
-//
-//	@doc:
-//		Check if given correlations are valid for (anti)semi-joins;
-//		we disallow correlations referring to inner child, since inner
-//		child columns are not visible above (anti)semi-join
-//
-//---------------------------------------------------------------------------
+// check if given correlations are valid for (anti)semi-joins;
+// we disallow correlations referring to inner child, since inner
+// child columns are not visible above (anti)semi-join
 BOOL
 CPredicateUtils::FValidSemiJoinCorrelations
 	(
@@ -2832,16 +2293,8 @@ CPredicateUtils::FValidSemiJoinCorrelations
 	return fValid;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FSimpleEqualityUsingCols
-//
-//	@doc:
-//		Check if given expression is (a conjunction of) simple column
-//		equality that use columns from the given column set
-//
-//---------------------------------------------------------------------------
+// check if given expression is (a conjunction of) simple column
+// equality that use columns from the given column set
 BOOL
 CPredicateUtils::FSimpleEqualityUsingCols
 	(
@@ -2874,16 +2327,7 @@ CPredicateUtils::FSimpleEqualityUsingCols
 	return fSuccess;
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::PexprReplaceColsWithNulls
-//
-//	@doc:
-//		For all columns in the given expression and are members
-//		of the given column set, replace columns with NULLs
-//
-//---------------------------------------------------------------------------
+// for all columns in the given expression and are members of the given column set, replace columns with NULLs
 CExpression *
 CPredicateUtils::PexprReplaceColsWithNulls
 	(
@@ -2925,17 +2369,9 @@ CPredicateUtils::PexprReplaceColsWithNulls
 	return GPOS_NEW(pmp) CExpression(pmp, pop, pdrgpexpr);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FNullRejecting
-//
-//	@doc:
-//		Check if scalar expression evaluates to (NOT TRUE) when
-//		all columns in the given set that are included in the expression
-//		are set to NULL
-//
-//---------------------------------------------------------------------------
+// check if scalar expression evaluates to (NOT TRUE) when
+// all columns in the given set that are included in the expression
+// are set to NULL
 BOOL
 CPredicateUtils::FNullRejecting
 	(
@@ -2973,16 +2409,7 @@ CPredicateUtils::FNullRejecting
 	return (CScalar::EberNull == eber || CScalar::EberFalse == eber);
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FNotIdent
-//
-//	@doc:
-// 		Returns true iff the given expression is a Not operator whose child is an
-//		identifier
-//
-//---------------------------------------------------------------------------
+// returns true iff the given expression is a Not operator whose child is an identifier
 BOOL
 CPredicateUtils::FNotIdent
 	(
@@ -2992,15 +2419,7 @@ CPredicateUtils::FNotIdent
 	return FNot(pexpr) && COperator::EopScalarIdent == (*pexpr)[0]->Pop()->Eopid();
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCompatiblePredicates
-//
-//	@doc:
-//		Returns true iff all predicates in the given array are compatible with
-//		the given index.
-//
-//---------------------------------------------------------------------------
+// returns true iff all predicates in the given array are compatible with the given index.
 BOOL
 CPredicateUtils::FCompatiblePredicates
 	(
@@ -3025,15 +2444,7 @@ CPredicateUtils::FCompatiblePredicates
 	return true;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCompatibleIndexPredicates
-//
-//	@doc:
-//		Returns true iff the given predicate 'pexprPred' is compatible with the
-//		given index 'pmdindex'.
-//
-//---------------------------------------------------------------------------
+// returns true iff the given predicate 'pexprPred' is compatible with the given index 'pmdindex'.
 BOOL
 CPredicateUtils::FCompatibleIndexPredicate
 	(
@@ -3073,13 +2484,7 @@ CPredicateUtils::FCompatibleIndexPredicate
 	return (pmdindex->FCompatible(pmdobjScCmp, ulKeyPos));
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FContainsVolatileFunction
-//
-//	@doc:
-//		Check if given array of expressions contain a volatile function like random().
-//---------------------------------------------------------------------------
+// check if given array of expressions contain a volatile function like random().
 BOOL
 CPredicateUtils::FContainsVolatileFunction
 	(
@@ -3102,13 +2507,7 @@ CPredicateUtils::FContainsVolatileFunction
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FContainsVolatileFunction
-//
-//	@doc:
-//		Check if the expression contains a volatile function like random().
-//---------------------------------------------------------------------------
+// check if the expression contains a volatile function like random().
 BOOL
 CPredicateUtils::FContainsVolatileFunction
 	(
@@ -3142,14 +2541,7 @@ CPredicateUtils::FContainsVolatileFunction
 	return false;
 }
 
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FConvertToCNF
-//
-//	@doc:
-//		Check if the expensive CNF conversion is beneficial in finding
-//		predicate for hash join
-//---------------------------------------------------------------------------
+// check if the expensive CNF conversion is beneficial in finding predicate for hash join
 BOOL
 CPredicateUtils::FConvertToCNF
 	(
@@ -3204,16 +2596,9 @@ CPredicateUtils::FConvertToCNF
 	}
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::CollectGrandChildrenUnionUnionAll
-//
-//	@doc:
-// 		If the nth child of the given union/union all expression is also a
-// 		union / union all expression, then collect the latter's children and
-//		set the input columns of the new n-ary union/unionall operator
-//---------------------------------------------------------------------------
+// if the nth child of the given union/union all expression is also a
+// union / union all expression, then collect the latter's children and
+// set the input columns of the new n-ary union/unionall operator
 void
 CPredicateUtils::CollectGrandChildrenUnionUnionAll
 	(
@@ -3286,14 +2671,7 @@ CPredicateUtils::CollectGrandChildrenUnionUnionAll
 	pdrgpul->Release();
 }
 
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CPredicateUtils::FCollapsibleChildUnionUnionAll
-//
-//	@doc:
-//		Check if we can collapse the nth child of the given union / union all operator
-//---------------------------------------------------------------------------
+// check if we can collapse the nth child of the given union / union all operator
 BOOL
 CPredicateUtils::FCollapsibleChildUnionUnionAll
 	(

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -71,6 +71,8 @@ add_executable(gporca_test
                src/unittest/gpopt/search/CSearchStrategyTest.cpp
                include/unittest/gpopt/minidump/CAggTest.h
                src/unittest/gpopt/minidump/CAggTest.cpp
+               include/unittest/gpopt/minidump/CExistsSubqueryTest.h
+               src/unittest/gpopt/minidump/CExistsSubqueryTest.cpp
                include/unittest/gpopt/minidump/CCollapseProjectTest.h
                src/unittest/gpopt/minidump/CCollapseProjectTest.cpp
                include/unittest/gpopt/minidump/CArrayExpansionTest.h
@@ -230,6 +232,7 @@ add_orca_test(CDirectDispatchTest)
 add_orca_test(CTVFTest)
 add_orca_test(CPullUpProjectElementTest)
 add_orca_test(CAggTest)
+add_orca_test(CExistsSubqueryTest)
 add_orca_test(CCollapseProjectTest)
 add_orca_test(CPruneColumnsTest)
 add_orca_test(CMissingStatsTest)

--- a/server/include/unittest/gpopt/minidump/CExistsSubqueryTest.h
+++ b/server/include/unittest/gpopt/minidump/CExistsSubqueryTest.h
@@ -1,0 +1,41 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal, Inc.
+//
+//	@filename:
+//		CExistsSubqueryTest.h
+//
+//	@doc:
+//		Test for exists and not exists subquery optimization
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CExistsSubqueryTest_H
+#define GPOPT_CExistsSubqueryTest_H
+
+#include "gpos/base.h"
+
+namespace gpopt
+{
+	class CExistsSubqueryTest
+	{
+		private:
+
+			// counter used to mark last successful test
+			static
+			gpos::ULONG m_ulExistsSubQueryTestCounter;
+
+		public:
+
+			// unittests
+			static
+			gpos::GPOS_RESULT EresUnittest();
+
+			static
+			gpos::GPOS_RESULT EresUnittest_RunTests();
+
+	}; // class CExistsSubqueryTest
+}
+
+#endif // !GPOPT_CExistsSubqueryTest_H
+
+// EOF
+

--- a/server/src/startup/main.cpp
+++ b/server/src/startup/main.cpp
@@ -83,6 +83,7 @@
 #include "unittest/gpopt/minidump/CTVFTest.h"
 #include "unittest/gpopt/minidump/CDMLTest.h"
 #include "unittest/gpopt/minidump/CAggTest.h"
+#include "unittest/gpopt/minidump/CExistsSubqueryTest.h"
 #include "unittest/gpopt/minidump/CCollapseProjectTest.h"
 #include "unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.h"
 #include "unittest/gpopt/minidump/CPruneColumnsTest.h"
@@ -149,6 +150,7 @@ static gpos::CUnittest rgut[] =
 	GPOS_UNITTEST_STD(CDirectDispatchTest),
 	GPOS_UNITTEST_STD(CTVFTest),
 	GPOS_UNITTEST_STD(CAggTest),
+	GPOS_UNITTEST_STD(CExistsSubqueryTest),
 	GPOS_UNITTEST_STD(CCollapseProjectTest),
 	GPOS_UNITTEST_STD(CPruneColumnsTest),
 	GPOS_UNITTEST_STD(CPhysicalParallelUnionAllTest),

--- a/server/src/unittest/gpopt/minidump/CExistsSubqueryTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CExistsSubqueryTest.cpp
@@ -1,0 +1,92 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal, Inc.
+//
+//	@filename:
+//		CExistsSubqueryTest.cpp
+//
+//	@doc:
+//		Test for exists and not exists subquery optimization
+//---------------------------------------------------------------------------
+
+#include "unittest/gpopt/minidump/CExistsSubqueryTest.h"
+#include "gpos/base.h"
+#include "gpos/memory/CAutoMemoryPool.h"
+#include "gpos/task/CAutoTraceFlag.h"
+#include "gpos/test/CUnittest.h"
+
+#include "gpopt/exception.h"
+#include "gpopt/minidump/CMinidumperUtils.h"
+
+#include "unittest/gpopt/CTestUtils.h"
+
+
+using namespace gpopt;
+
+ULONG CExistsSubqueryTest::m_ulExistsSubQueryTestCounter = 0;  // start from first test
+
+// minidump files
+const CHAR *rgszExistsFileNames[] =
+	{
+		"../data/dxl/minidump/SubqExists-With-External-Corrs.mdp",
+		"../data/dxl/minidump/SubqExists-Without-External-Corrs.mdp",
+		"../data/dxl/minidump/Exists-SuperfluousEquality.mdp",
+		"../data/dxl/minidump/NotExists-SuperfluousEquality.mdp",
+	};
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CExistsSubqueryTest::EresUnittest
+//
+//	@doc:
+//		Unittest for expressions
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CExistsSubqueryTest::EresUnittest()
+{
+
+#ifdef GPOS_DEBUG
+	// disable extended asserts before running test
+	fEnableExtendedAsserts = false;
+#endif // GPOS_DEBUG
+
+	CUnittest rgut[] =
+		{
+		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
+		};
+
+	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
+
+#ifdef GPOS_DEBUG
+	// enable extended asserts after running test
+	fEnableExtendedAsserts = true;
+#endif // GPOS_DEBUG
+
+	// reset metadata cache
+	CMDCache::Reset();
+
+	return eres;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CExistsSubqueryTest::EresUnittest_RunTests
+//
+//	@doc:
+//		Run all Minidump-based tests with plan matching
+//
+//---------------------------------------------------------------------------
+GPOS_RESULT
+CExistsSubqueryTest::EresUnittest_RunTests()
+{
+	return CTestUtils::EresUnittest_RunTests
+						(
+						rgszExistsFileNames,
+						&m_ulExistsSubQueryTestCounter,
+						GPOS_ARRAY_SIZE(rgszExistsFileNames)
+						);
+}
+
+// EOF

--- a/server/src/unittest/gpopt/minidump/CExistsSubqueryTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CExistsSubqueryTest.cpp
@@ -32,6 +32,7 @@ const CHAR *rgszExistsFileNames[] =
 		"../data/dxl/minidump/SubqExists-Without-External-Corrs.mdp",
 		"../data/dxl/minidump/Exists-SuperfluousEquality.mdp",
 		"../data/dxl/minidump/NotExists-SuperfluousEquality.mdp",
+		"../data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp",
 	};
 
 

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -40,6 +40,7 @@ ULONG CICGTest::m_ulNegativeIndexApplyTestCounter = 0;
 // minidump files
 const CHAR *rgszFileNames[] =
 	{
+		"../data/dxl/minidump/SubqExists-Without-External-Corrs.mdp",
 		"../data/dxl/minidump/ArrayCoerceExpr.mdp",
 		"../data/dxl/minidump/DisableLargeTableBroadcast.mdp",
 		"../data/dxl/minidump/InferPredicatesForLimit.mdp",

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -40,7 +40,6 @@ ULONG CICGTest::m_ulNegativeIndexApplyTestCounter = 0;
 // minidump files
 const CHAR *rgszFileNames[] =
 	{
-		"../data/dxl/minidump/SubqExists-Without-External-Corrs.mdp",
 		"../data/dxl/minidump/ArrayCoerceExpr.mdp",
 		"../data/dxl/minidump/DisableLargeTableBroadcast.mdp",
 		"../data/dxl/minidump/InferPredicatesForLimit.mdp",
@@ -108,8 +107,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/EquivClassesLimit.mdp",
 		"../data/dxl/minidump/Date-TimeStamp-HashJoin.mdp",
 		"../data/dxl/minidump/TimeStamp-Date-HashJoin.mdp",
-		"../data/dxl/minidump/Exists-SuperfluousEquality.mdp",
-		"../data/dxl/minidump/NotExists-SuperfluousEquality.mdp",
 		"../data/dxl/minidump/MultiLevel-CorrelatedExec.mdp",
 		"../data/dxl/minidump/OneLevel-CorrelatedExec.mdp",
 		"../data/dxl/minidump/MultiLevel-IN-Subquery.mdp",
@@ -147,8 +144,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/SubqAll-To-ScalarSubq.mdp",
 		"../data/dxl/minidump/SubqAll-Limit1.mdp",
 		"../data/dxl/minidump/ProjectUnderSubq.mdp",
-		"../data/dxl/minidump/SubqExists-With-External-Corrs.mdp",
-		"../data/dxl/minidump/SubqExists-Without-External-Corrs.mdp",
 #ifndef GPOS_DEBUG
 		"../data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp",
 		"../data/dxl/minidump/TPCH-Partitioned-256GB.mdp",


### PR DESCRIPTION
Consider the following exists subquery, `(select 1 from bar)`. GPORCA generates an elaborate count based implementation of this subquery. If bar is a fact table, the count is going to be expensive.

```
vraghavan=# explain select count(*) from foo where foo.a = foo.b and exists (select 1 from bar);
                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..1331807.20 rows=1 width=8)
   ->  Result  (cost=0.00..1331807.20 rows=1 width=1)
         ->  Nested Loop  (cost=0.00..1331807.20 rows=1 width=1)
               Join Filter: true
               ->  Result  (cost=0.00..438.59 rows=1 width=1)
                     Filter: (count((count()))) > 0::bigint
                     ->  Aggregate  (cost=0.00..438.59 rows=1 width=8)
                           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..438.59 rows=1 width=8)
                                 ->  Aggregate  (cost=0.00..438.59 rows=1 width=8)
                                       ->  Table Scan on bar  (cost=0.00..437.97 rows=333603 width=1)
               ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                           ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=1)
                                 Filter: a = b
 Optimizer status: PQO version 2.34.0
(15 rows)
```
Planner on the other hand uses LIMIT as shown in the INIT plan.

```
vraghavan=# explain select count(*) from foo where foo.a = foo.b and exists (select 1 from bar);
                                        QUERY PLAN
------------------------------------------------------------------------------------------
 Aggregate  (cost=1.11..1.12 rows=1 width=8)
   InitPlan  (slice3)
     ->  Limit  (cost=0.00..0.03 rows=1 width=0)
           ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..0.03 rows=1 width=0)
                 ->  Limit  (cost=0.00..0.01 rows=1 width=0)
                       ->  Seq Scan on bar  (cost=0.00..11109.09 rows=333603 width=0)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..1.07 rows=1 width=8)
         ->  Aggregate  (cost=1.02..1.03 rows=1 width=8)
               ->  Result  (cost=0.00..1.01 rows=1 width=8)
                     One-Time Filter: $0
                     ->  Seq Scan on foo  (cost=0.00..1.01 rows=1 width=8)
                           Filter: a = b
 Settings:  optimizer=off
 Optimizer status: legacy query optimizer
(14 rows)
```

While GPORCA doesnot support init-plan, we can nevertheless generate a better plan by using LIMIT instead of count. After this PR, GPORCA will generate the following plan with LIMIT clause.

```
vraghavan=#  explain select count(*) from foo where foo.a = foo.b and exists (select 1 from bar);
                                                    QUERY PLAN
------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=0.00..1357263.96 rows=1 width=8)
   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1357263.96 rows=1 width=8)
         ->  Aggregate  (cost=0.00..1357263.96 rows=1 width=8)
               ->  Nested Loop  (cost=0.00..1357263.96 rows=133442 width=1)
                     Join Filter: true
                     ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.76 rows=3 width=1)
                           ->  Limit  (cost=0.00..431.76 rows=1 width=1)
                                 ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.76 rows=1 width=1)
                                       ->  Limit  (cost=0.00..431.76 rows=1 width=1)
                                             ->  Table Scan on bar  (cost=0.00..431.69 rows=33190 width=1)
                     ->  Table Scan on foo  (cost=0.00..461.91 rows=133442 width=1)
                           Filter: foo.a = foo.b
 Optimizer status: PQO version 2.34.0
(13 rows)
```