### PR TITLE
Add Check for existing tag before publishing

### DIFF
--- a/concourse/check_existing_tag.py
+++ b/concourse/check_existing_tag.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import subprocess
+import sys
+from packaging import version
+
+
+if __name__ == "__main__":
+  cmd = subprocess.Popen(['env', 'GIT_DIR=orca_src/.git', 'git', 'describe', '--abbrev=0', '--tags'], stdout=subprocess.PIPE)
+  existing_tag = cmd.stdout.read()
+  print ("Latest Tag of ORCA: {0}".format(existing_tag.strip()))
+
+  tag_to_be_published = ''
+  with open('orca_github_release_stage/tag.txt', 'r') as fh:
+    tag_to_be_published = fh.read().strip()
+
+  if tag_to_be_published == '':
+     sys.exit('Unable to read the tag from tag.txt')
+
+  print ("Tag from this commit: {0}".format(tag_to_be_published))
+
+  if (version.parse(existing_tag) >= version.parse(tag_to_be_published)):
+    print ("Tag {0} already present on ORCA repository".format(tag_to_be_published))
+    print ("Please BUMP the ORCA version")
+    sys.exit(1)

--- a/concourse/check_existing_tag.yml
+++ b/concourse/check_existing_tag.yml
@@ -1,0 +1,12 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: yolo/orcadev
+    tag: centos5
+inputs:
+  - name: orca_src
+  - name: orca_github_release_stage
+outputs:
+run:
+  path: orca_src/concourse/check_existing_tag.py

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -112,6 +112,8 @@ jobs:
       - orca_centos5_debug
   - task: orca_publish_tag
     file: orca_src/concourse/publish_tag.yml
+  - task: check_existing_tag
+    file: orca_src/concourse/check_existing_tag.yml
   - put: orca_github_release
     params:
       name: orca_github_release_stage/tag.txt


### PR DESCRIPTION
Each ORCA commit must BUMP the version. If the version is not bumped new releases will not be pushed to the ORCA repository. This commit adds the check to validate the version of the current commit with the tag version existing on the repository.