### PR TITLE
Constant fold quantified subquery under SELECT clause

### DIFF
--- a/data/dxl/minidump/NULLComparisonInProject.mdp
+++ b/data/dxl/minidump/NULLComparisonInProject.mdp
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ create table foo(a int, b int);
+ create table bar(c int, d int);
+ insert into bar values (1,1);
+ select NULL in (select f2.a from foo f2) from bar;
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/data/dxl/minidump/NULLComparisonInProject.mdp
+++ b/data/dxl/minidump/NULLComparisonInProject.mdp
@@ -1,0 +1,670 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:Relation Mdid="0.16385.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16388.1.0" Name="bar" Rows="1.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16388.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16388.1.0.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1980.1.0"/>
+          <dxl:OpClass Mdid="0.3028.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.2799.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.27.1.0"/>
+        <dxl:RightType Mdid="0.27.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.2791.1.0"/>
+        <dxl:Commutator Mdid="0.2800.1.0"/>
+        <dxl:InverseOp Mdid="0.2802.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.16.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="19" Alias="?column?">
+            <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="10">
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:SubqueryAny>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="27">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001675" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="18" Alias="?column?">
+            <dxl:Ident ColId="18" ColName="?column?" TypeMdid="0.16.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001671" Rows="1.000000" Width="1"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="18" Alias="?column?">
+              <dxl:If TypeMdid="0.16.1.0">
+                <dxl:Not>
+                  <dxl:IsNull>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                  </dxl:IsNull>
+                </dxl:Not>
+                <dxl:If TypeMdid="0.16.1.0">
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                    <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:If TypeMdid="0.16.1.0">
+                    <dxl:Not>
+                      <dxl:IsNull>
+                        <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
+                      </dxl:IsNull>
+                    </dxl:Not>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="false"/>
+                  </dxl:If>
+                </dxl:If>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+              </dxl:If>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001671" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:GroupingColumns>
+              <dxl:GroupingColumn ColId="0"/>
+              <dxl:GroupingColumn ColId="1"/>
+              <dxl:GroupingColumn ColId="2"/>
+              <dxl:GroupingColumn ColId="8"/>
+            </dxl:GroupingColumns>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Final">
+                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="ColRef_0021">
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final">
+                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                </dxl:AggFunc>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="0" Alias="c">
+                <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="d">
+                <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="ctid">
+                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001634" Rows="1.000000" Width="34"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="c">
+                  <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="d">
+                  <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="ctid">
+                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.001634" Rows="1.000000" Width="34"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="c">
+                    <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="d">
+                    <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="ctid">
+                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                    <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.001527" Rows="1.000000" Width="34"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="c">
+                      <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="d">
+                      <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="ctid">
+                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                      <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.001527" Rows="1.000000" Width="34"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="0"/>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="2"/>
+                      <dxl:GroupingColumn ColId="8"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Partial"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial">
+                          <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="0" Alias="c">
+                        <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="d">
+                        <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="ctid">
+                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.001354" Rows="7.000000" Width="22"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="c">
+                          <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="d">
+                          <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="ctid">
+                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                          <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:JoinFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                      </dxl:JoinFilter>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="18"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="c">
+                            <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="d">
+                            <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="ctid">
+                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="18"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="c">
+                              <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="d">
+                              <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="ctid">
+                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+                            <dxl:Columns>
+                              <dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:Sort>
+                      <dxl:Materialize Eager="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000685" Rows="18.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                            <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000661" Rows="18.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                              <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000231" Rows="6.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="19" Alias="ColRef_0019">
+                                <dxl:If TypeMdid="0.23.1.0">
+                                  <dxl:IsNull>
+                                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:IsNull>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                                </dxl:If>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000223" Rows="6.000000" Width="8"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="a">
+                                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:Or>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:Comparison>
+                                  <dxl:IsNull>
+                                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                                  </dxl:IsNull>
+                                </dxl:Or>
+                              </dxl:Filter>
+                              <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Result>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:NestedLoopJoin>
+                  </dxl:Aggregate>
+                </dxl:Result>
+              </dxl:RedistributeMotion>
+            </dxl:Sort>
+          </dxl:Aggregate>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/NULLComparisonInWhereClause.mdp
+++ b/data/dxl/minidump/NULLComparisonInWhereClause.mdp
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="2147483647" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
+      <dxl:TraceFlags Value="102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="0.16385.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Relation Mdid="0.16388.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:Indexes/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="d" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="10">
+          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.16385.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:SubqueryAny>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000662" Rows="8.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="c">
+            <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="d">
+            <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:TableScan>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000185" Rows="8.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="c">
+              <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="d">
+              <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="1" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:TableScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/NULLComparisonInWhereClause.mdp
+++ b/data/dxl/minidump/NULLComparisonInWhereClause.mdp
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ create table foo(a int, b int);
+ create table bar(c int, d int);
+ insert into bar values (1,1);
+ select * from bar where NULL in (select f2.a from foo f2);
+-->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>

--- a/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -91,7 +91,7 @@ namespace gpopt
 
 			// simplify quantified subqueries
 			static
-			CExpression *PexprSimplifyQuantifiedSubqueries(IMemoryPool *pmp, CExpression *pexpr);
+			CExpression *PexprSimplifyQuantifiedSubqueries(IMemoryPool *pmp, CExpression *pexpr, BOOL fUnderPrList);
 
 			// preliminary unnesting of scalar  subqueries
 			static

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -73,6 +73,8 @@ add_executable(gporca_test
                src/unittest/gpopt/minidump/CAggTest.cpp
                include/unittest/gpopt/minidump/CExistsSubqueryTest.h
                src/unittest/gpopt/minidump/CExistsSubqueryTest.cpp
+               include/unittest/gpopt/minidump/CQuantifiedSubqueryTest.h
+               src/unittest/gpopt/minidump/CQuantifiedSubqueryTest.cpp
                include/unittest/gpopt/minidump/CCollapseProjectTest.h
                src/unittest/gpopt/minidump/CCollapseProjectTest.cpp
                include/unittest/gpopt/minidump/CArrayExpansionTest.h
@@ -233,6 +235,7 @@ add_orca_test(CTVFTest)
 add_orca_test(CPullUpProjectElementTest)
 add_orca_test(CAggTest)
 add_orca_test(CExistsSubqueryTest)
+add_orca_test(CQuantifiedSubqueryTest)
 add_orca_test(CCollapseProjectTest)
 add_orca_test(CPruneColumnsTest)
 add_orca_test(CMissingStatsTest)

--- a/server/include/unittest/gpopt/minidump/CQuantifiedSubqueryTest.h
+++ b/server/include/unittest/gpopt/minidump/CQuantifiedSubqueryTest.h
@@ -1,0 +1,41 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal, Inc.
+//
+//	@filename:
+//		CQuantifiedSubqueryTest.h
+//
+//	@doc:
+//		Test for exists and not exists subquery optimization
+//---------------------------------------------------------------------------
+#ifndef GPOPT_CQuantifiedSubqueryTest_H
+#define GPOPT_CQuantifiedSubqueryTest_H
+
+#include "gpos/base.h"
+
+namespace gpopt
+{
+	class CQuantifiedSubqueryTest
+	{
+		private:
+
+			// counter used to mark last successful test
+			static
+			gpos::ULONG m_ulQuantifiedSubQueryTestCounter;
+
+		public:
+
+			// unittests
+			static
+			gpos::GPOS_RESULT EresUnittest();
+
+			static
+			gpos::GPOS_RESULT EresUnittest_RunTests();
+
+	}; // class CQuantifiedSubqueryTest
+}
+
+#endif // !GPOPT_CQuantifiedSubqueryTest_H
+
+// EOF
+

--- a/server/src/startup/main.cpp
+++ b/server/src/startup/main.cpp
@@ -84,6 +84,7 @@
 #include "unittest/gpopt/minidump/CDMLTest.h"
 #include "unittest/gpopt/minidump/CAggTest.h"
 #include "unittest/gpopt/minidump/CExistsSubqueryTest.h"
+#include "unittest/gpopt/minidump/CQuantifiedSubqueryTest.h"
 #include "unittest/gpopt/minidump/CCollapseProjectTest.h"
 #include "unittest/gpopt/minidump/CPhysicalParallelUnionAllTest.h"
 #include "unittest/gpopt/minidump/CPruneColumnsTest.h"
@@ -151,6 +152,7 @@ static gpos::CUnittest rgut[] =
 	GPOS_UNITTEST_STD(CTVFTest),
 	GPOS_UNITTEST_STD(CAggTest),
 	GPOS_UNITTEST_STD(CExistsSubqueryTest),
+	GPOS_UNITTEST_STD(CQuantifiedSubqueryTest),
 	GPOS_UNITTEST_STD(CCollapseProjectTest),
 	GPOS_UNITTEST_STD(CPruneColumnsTest),
 	GPOS_UNITTEST_STD(CPhysicalParallelUnionAllTest),

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -77,13 +77,8 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/NOT-IN-NotNullBoth.mdp",
 		"../data/dxl/minidump/NOT-IN-NullInner.mdp",
 		"../data/dxl/minidump/NOT-IN-NullOuter.mdp",
-		"../data/dxl/minidump/Correlated-LASJ-With-Outer-Const.mdp",
-		"../data/dxl/minidump/Correlated-LASJ-With-Outer-Col.mdp",
-		"../data/dxl/minidump/Correlated-LASJ-With-Outer-Expr.mdp",
 		"../data/dxl/minidump/Correlated-SemiJoin.mdp",
 		"../data/dxl/minidump/CorrelatedSemiJoin-True.mdp",
-		"../data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp",
-		"../data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp",
 		"../data/dxl/minidump/Correlated-AntiSemiJoin.mdp",
 		"../data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp",
 		"../data/dxl/minidump/Correlation-With-Casting-1.mdp",
@@ -95,7 +90,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/FullOuterJoin.mdp",
 		"../data/dxl/minidump/FullOuterJoin2.mdp",
 		"../data/dxl/minidump/AddEqualityPredicates.mdp",
-		"../data/dxl/minidump/AddPredsInSubqueries.mdp",
 		"../data/dxl/minidump/DeduplicatePredicates.mdp",
 		"../data/dxl/minidump/LeftJoin-With-Pred-On-Inner.mdp",
 		"../data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp",
@@ -109,10 +103,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/EquivClassesLimit.mdp",
 		"../data/dxl/minidump/Date-TimeStamp-HashJoin.mdp",
 		"../data/dxl/minidump/TimeStamp-Date-HashJoin.mdp",
-		"../data/dxl/minidump/MultiLevel-CorrelatedExec.mdp",
-		"../data/dxl/minidump/OneLevel-CorrelatedExec.mdp",
-		"../data/dxl/minidump/MultiLevel-IN-Subquery.mdp",
-		"../data/dxl/minidump/Join-With-Subq-Preds-1.mdp",
 
 #ifndef GPOS_32BIT
 		// TODO:  - 05/14/2014: the plan generates a different plan only for
@@ -132,10 +122,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/SemiJoin2InnerJoin.mdp",
 		"../data/dxl/minidump/SemiJoin2Select-1.mdp",
 		"../data/dxl/minidump/SemiJoin2Select-2.mdp",
-		"../data/dxl/minidump/AntiSemiJoin2Select-1.mdp",
-		"../data/dxl/minidump/AntiSemiJoin2Select-2.mdp",
-		"../data/dxl/minidump/Subq-On-OuterRef.mdp",
-		"../data/dxl/minidump/Subq-With-OuterRefCol.mdp",
 		"../data/dxl/minidump/ConstTblGetUnderSubqWithOuterRef.mdp",
 		"../data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp",
 		"../data/dxl/minidump/ConstTblGetUnderSubqUnderProjectNoOuterRef.mdp",
@@ -143,8 +129,6 @@ const CHAR *rgszFileNames[] =
 
 		"../data/dxl/minidump/Subq-NoParams.mdp",
 		"../data/dxl/minidump/Subq-JoinWithOuterRef.mdp",
-		"../data/dxl/minidump/SubqAll-To-ScalarSubq.mdp",
-		"../data/dxl/minidump/SubqAll-Limit1.mdp",
 		"../data/dxl/minidump/ProjectUnderSubq.mdp",
 #ifndef GPOS_DEBUG
 		"../data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp",
@@ -165,7 +149,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/ProjectWithTextConstant.mdp",
 		"../data/dxl/minidump/Join_OuterChild_DistUniversal.mdp",
 		"../data/dxl/minidump/Nested-Or-Predicates.mdp",
-		"../data/dxl/minidump/OrderByOuterRef.mdp",
 		"../data/dxl/minidump/CTG-Filter.mdp",
 		"../data/dxl/minidump/CTG-Join.mdp",
 		"../data/dxl/minidump/UDA-AnyElement-1.mdp",
@@ -218,7 +201,6 @@ const CHAR *rgszFileNames[] =
 		"../data/dxl/minidump/EffectOfLocalPredOnJoin3.mdp",
 		"../data/dxl/minidump/ProjectSetFunction.mdp",
 		"../data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp",
-		"../data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp",
 		"../data/dxl/minidump/EstimateJoinRowsForCastPredicates.mdp",
 		"../data/dxl/minidump/MissingBoolColStats.mdp",
 #ifndef GPOS_DEBUG

--- a/server/src/unittest/gpopt/minidump/CQuantifiedSubqueryTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CQuantifiedSubqueryTest.cpp
@@ -1,0 +1,94 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2017 Pivotal, Inc.
+//
+//	@filename:
+//		CQuantifiedSubqueryTest.cpp
+//
+//	@doc:
+//		Test for exists and not exists subquery optimization
+//---------------------------------------------------------------------------
+
+#include "unittest/gpopt/minidump/CQuantifiedSubqueryTest.h"
+#include "gpos/base.h"
+#include "gpos/memory/CAutoMemoryPool.h"
+#include "gpos/task/CAutoTraceFlag.h"
+#include "gpos/test/CUnittest.h"
+
+#include "gpopt/exception.h"
+#include "gpopt/minidump/CMinidumperUtils.h"
+
+#include "unittest/gpopt/CTestUtils.h"
+
+
+using namespace gpopt;
+
+ULONG CQuantifiedSubqueryTest::m_ulQuantifiedSubQueryTestCounter = 0;  // start from first test
+
+// minidump files
+const CHAR *rgszQuantifiedFileNames[] =
+	{
+		"../data/dxl/minidump/NULLComparisonInProject.mdp",
+		"../data/dxl/minidump/NULLComparisonInWhereClause.mdp",
+		"../data/dxl/minidump/OrderByOuterRef.mdp",
+		"../data/dxl/minidump/SubqAll-To-ScalarSubq.mdp",
+		"../data/dxl/minidump/SubqAll-Limit1.mdp",
+		"../data/dxl/minidump/Subq-On-OuterRef.mdp",
+		"../data/dxl/minidump/Subq-With-OuterRefCol.mdp",
+		"../data/dxl/minidump/SemiJoin2Select-EnforceSubplan.mdp",
+		"../data/dxl/minidump/Join-With-Subq-Preds-1.mdp",
+		"../data/dxl/minidump/MultiLevel-CorrelatedExec.mdp",
+		"../data/dxl/minidump/OneLevel-CorrelatedExec.mdp",
+		"../data/dxl/minidump/MultiLevel-IN-Subquery.mdp",
+		"../data/dxl/minidump/Correlated-LASJ-With-Outer-Const.mdp",
+		"../data/dxl/minidump/Correlated-LASJ-With-Outer-Col.mdp",
+		"../data/dxl/minidump/Correlated-LASJ-With-Outer-Expr.mdp",
+		"../data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp",
+		"../data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp",
+		"../data/dxl/minidump/AddPredsInSubqueries.mdp",
+		"../data/dxl/minidump/AntiSemiJoin2Select-1.mdp",
+		"../data/dxl/minidump/AntiSemiJoin2Select-2.mdp",
+	};
+
+
+// unittest for expressions
+GPOS_RESULT
+CQuantifiedSubqueryTest::EresUnittest()
+{
+
+#ifdef GPOS_DEBUG
+	// disable extended asserts before running test
+	fEnableExtendedAsserts = false;
+#endif // GPOS_DEBUG
+
+	CUnittest rgut[] =
+		{
+		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
+		};
+
+	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
+
+#ifdef GPOS_DEBUG
+	// enable extended asserts after running test
+	fEnableExtendedAsserts = true;
+#endif // GPOS_DEBUG
+
+	// reset metadata cache
+	CMDCache::Reset();
+
+	return eres;
+}
+
+// run all Minidump-based tests with plan matching
+GPOS_RESULT
+CQuantifiedSubqueryTest::EresUnittest_RunTests()
+{
+	return CTestUtils::EresUnittest_RunTests
+						(
+						rgszQuantifiedFileNames,
+						&m_ulQuantifiedSubQueryTestCounter,
+						GPOS_ARRAY_SIZE(rgszQuantifiedFileNames)
+						);
+}
+
+// EOF


### PR DESCRIPTION
Consider two table foo (a, b) and bar (c, d) and the following SQL query.

```
select * from bar where NULL in (select f2.a from foo f2);
+--CLogicalSelect
   |--CLogicalGet "bar" ("bar"), Columns: ["c" (0), "d" (1), "ctid" (2), "xmin" (3), "cmin" (4), "xmax" (5), "cmax" (6), "tableoid" (7), "gp_segment_id" (8)] Key sets: {[2,8]}
   +--CScalarSubqueryAny(=)["a" (9)]
      |--CLogicalGet "foo" ("foo"), Columns: ["a" (9), "b" (10), "ctid" (11), "xmin" (12), "cmin" (13), "xmax" (14), "cmax" (15), "tableoid" (16), "gp_segment_id" (17)] Key sets: {[2,8]}
      +--CScalarConst (null)
```

Here we are comparing a NULL constant to a result of subquery. Since
cannot to compared to any other value, the result of such a subquery
will always be NULL.