### PR TITLE
Fix broken CAutoPTest & make pipeline green

### DIFF
--- a/libgpos/server/include/unittest/gpos/common/CAutoPTest.h
+++ b/libgpos/server/include/unittest/gpos/common/CAutoPTest.h
@@ -41,11 +41,6 @@ namespace gpos
 			// unittests
 			static GPOS_RESULT EresUnittest();
 			static GPOS_RESULT EresUnittest_Basics();
-#ifdef GPOS_DEBUG
-#if (GPOS_i386 || GPOS_i686 || GPOS_x86_64)
-			static GPOS_RESULT EresUnittest_Allocation();
-#endif // (GPOS_i386 || GPOS_i686 || GPOS_x86_64)
-#endif // GPOS_DEBUG
 
 	}; // class CAutoPTest
 

--- a/libgpos/server/src/unittest/gpos/common/CAutoPTest.cpp
+++ b/libgpos/server/src/unittest/gpos/common/CAutoPTest.cpp
@@ -34,12 +34,6 @@ CAutoPTest::EresUnittest()
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(CAutoPTest::EresUnittest_Basics)
-#ifdef GPOS_DEBUG
-#if (GPOS_i386 || GPOS_i686 || GPOS_x86_64)
-		,
-		GPOS_UNITTEST_FUNC_ASSERT(CAutoPTest::EresUnittest_Allocation)
-#endif // (GPOS_i386 || GPOS_i686 || GPOS_x86_64)
-#endif // GPOS_DEBUG
 		};
 
 	return CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
@@ -106,34 +100,6 @@ CAutoPTest::EresUnittest_Basics()
 
 	return GPOS_OK;
 }
-
-#ifdef GPOS_DEBUG
-#if (GPOS_i386 || GPOS_i686 || GPOS_x86_64)
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CAutoPTest::EresUnittest_Allocation
-//
-//	@doc:
-//		Attempt illegal allocation of auto pointer outside of stack
-//
-//---------------------------------------------------------------------------
-GPOS_RESULT
-CAutoPTest::EresUnittest_Allocation()
-{
-	// create memory pool
-	CAutoMemoryPool amp;
-	IMemoryPool *pmp = amp.Pmp();
-
-	// allocating auto object on heap must assert
-	CAutoP<ULONG> *papt = GPOS_NEW(pmp) CAutoP<ULONG>;
-	GPOS_DELETE(papt);
-
-	return GPOS_FAILED;
-}
-
-#endif // (GPOS_i386 || GPOS_i686 || GPOS_x86_64)
-#endif // GPOS_DEBUG
 
 // EOF
 


### PR DESCRIPTION
Previous to c09a0ac, `CStackObject()` constructor did a validity check if the pointer is on the stack using `FOnStack()`. Since the function is removed; the following test in `CAutoPTest` is invalid :

CAutoPTest::EresUnittest_Allocation()

This causes test failure in debug build. Hence this commit removes the test.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>