### PR TITLE
Add doc link to orca build using conan

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ gives instructions for building and installing.
 
 ## Build GPORCA
 
+#### Using conan dependency manager
+Refer to the steps at: https://github.com/greenplum-db/conan
+
+#### Manually
 Go into `gporca` directory:
 
 ```


### PR DESCRIPTION
This PR achieves the following
- Updates the readme to refer to docs to use conan to build gporca and xerces