### PR TITLE
Fix compilation errors, caused by NULL-checks on a C++ reference.

### DIFF
--- a/libgpopt/src/base/CCTEMap.cpp
+++ b/libgpopt/src/base/CCTEMap.cpp
@@ -424,12 +424,7 @@ namespace gpopt {
 
   IOstream &operator << (IOstream &os, CCTEMap &cm)
   {
-    // FIXME(chasseur): in well-formed C++ code, references can never be bound
-    // to NULL; however, some callers may dereference a (possibly-NULL) pointer
-    // with the '*' operator and try to print it into an IOStream; callers
-    // should be modified to explicitly do NULL-checks on pointers so that this
-    // function does not rely on undefined behavior
-    return (NULL == &cm) ? os : cm.OsPrint(os);
+    return cm.OsPrint(os);
   }
 
 }

--- a/libgpopt/src/base/CCTEReq.cpp
+++ b/libgpopt/src/base/CCTEReq.cpp
@@ -561,12 +561,7 @@ namespace gpopt {
 
   IOstream &operator << (IOstream &os, CCTEReq &cter)
   {
-    // FIXME(chasseur): in well-formed C++ code, references can never be bound
-    // to NULL; however, some callers may dereference a (possibly-NULL) pointer
-    // with the '*' operator and try to print it into an IOStream; callers
-    // should be modified to explicitly do NULL-checks on pointers so that this
-    // function does not rely on undefined behavior
-    return (NULL == &cter) ? os : cter.OsPrint(os);
+    return cter.OsPrint(os);
   }
 
 }

--- a/libgpopt/src/base/CDrvdProp.cpp
+++ b/libgpopt/src/base/CDrvdProp.cpp
@@ -29,12 +29,7 @@ namespace gpopt {
 
   IOstream &operator << (IOstream &os, CDrvdProp &drvdprop)
   {
-    // FIXME(chasseur): in well-formed C++ code, references can never be bound
-    // to NULL; however, some callers may dereference a (possibly-NULL) pointer
-    // with the '*' operator and try to print it into an IOStream; callers
-    // should be modified to explicitly do NULL-checks on pointers so that this
-    // function does not rely on undefined behavior
-    return (NULL == &drvdprop) ? os : drvdprop.OsPrint(os);
+    return drvdprop.OsPrint(os);
   }
 
 }

--- a/libgpopt/src/base/CDrvdPropCtxt.cpp
+++ b/libgpopt/src/base/CDrvdPropCtxt.cpp
@@ -17,12 +17,7 @@ namespace gpopt {
 
   IOstream &operator << (IOstream &os, CDrvdPropCtxt &drvdpropctxt)
   {
-    // FIXME(chasseur): in well-formed C++ code, references can never be bound
-    // to NULL; however, some callers may dereference a (possibly-NULL) pointer
-    // with the '*' operator and try to print it into an IOStream; callers
-    // should be modified to explicitly do NULL-checks on pointers so that this
-    // function does not rely on undefined behavior
-    return (NULL == &drvdpropctxt) ? os : drvdpropctxt.OsPrint(os);
+    return drvdpropctxt.OsPrint(os);
   }
 
 }

--- a/libgpopt/src/base/CEnfdProp.cpp
+++ b/libgpopt/src/base/CEnfdProp.cpp
@@ -17,12 +17,7 @@ namespace gpopt {
 
   IOstream &operator << (IOstream &os, CEnfdProp &efdprop)
   {
-    // FIXME(chasseur): in well-formed C++ code, references can never be bound
-    // to NULL; however, some callers may dereference a (possibly-NULL) pointer
-    // with the '*' operator and try to print it into an IOStream; callers
-    // should be modified to explicitly do NULL-checks on pointers so that this
-    // function does not rely on undefined behavior
-    return (NULL == &efdprop) ? os : efdprop.OsPrint(os);
+    return efdprop.OsPrint(os);
   }
 
 }

--- a/libgpopt/src/base/CPartIndexMap.cpp
+++ b/libgpopt/src/base/CPartIndexMap.cpp
@@ -1066,12 +1066,7 @@ namespace gpopt {
 
   IOstream &operator << (IOstream &os, CPartIndexMap &pim)
   {
-    // FIXME(chasseur): in well-formed C++ code, references can never be bound
-    // to NULL; however, some callers may dereference a (possibly-NULL) pointer
-    // with the '*' operator and try to print it into an IOStream; callers
-    // should be modified to explicitly do NULL-checks on pointers so that this
-    // function does not rely on undefined behavior
-    return (NULL == &pim) ? os : pim.OsPrint(os);
+    return pim.OsPrint(os);
   }
 
 }


### PR DESCRIPTION
GCC 6.3 is giving errors like this:

error: the compiler can assume that the address of ‘cter’ will never be NULL [-Werror=address]

I haven't gone through all the code to check if any of the callers might
try to pass a NULL, but I've been running with this patch on my laptop for
quite a long time and haven't seen any issues. All the tests pass.