### PR TITLE
Remove GPOPT_DP_JOIN_ORDERING_SIZE_THRESHOLD

### DIFF
--- a/libgpopt/src/xforms/CJoinOrderDP.cpp
+++ b/libgpopt/src/xforms/CJoinOrderDP.cpp
@@ -29,7 +29,6 @@
 
 using namespace gpopt;
 
-#define GPOPT_DP_JOIN_ORDERING_SIZE_THRESHOLD	10
 #define GPOPT_DP_JOIN_ORDERING_CONNECTEDNESS_THRESHOLD	0.5
 #define GPOPT_DP_JOIN_ORDERING_TOPK	10
 
@@ -1056,8 +1055,7 @@ CJoinOrderDP::PexprExpand()
 		(void) pbs->FExchangeSet(ul);
 	}
 
-	if (GPOPT_DP_JOIN_ORDERING_SIZE_THRESHOLD < m_ulComps &&
-		GPOPT_DP_JOIN_ORDERING_CONNECTEDNESS_THRESHOLD < DMaxConnectedness(pbs))
+	if (GPOPT_DP_JOIN_ORDERING_CONNECTEDNESS_THRESHOLD < DMaxConnectedness(pbs))
 	{
 		// terminate early if computation cost is expected to be large
 		pbs->Release();


### PR DESCRIPTION
We already have GPDB GUC optimizer_join_order_threshold to control the maximum
number of relations that we can do join reordering using DP. The macro being removed
here is redundant.

Fixes issue #268