### PR TITLE
WIP: Introduce a new graph-based join enumeration algorithm MinCutBranch

### DIFF
--- a/libgpopt/include/gpopt/xforms/CJoinOrder.h
+++ b/libgpopt/include/gpopt/xforms/CJoinOrder.h
@@ -109,6 +109,9 @@ namespace gpopt
 			// number of components
 			ULONG m_ulComps;
 			
+			// neighbors array
+			CBitSet **m_rgpbsAdj;
+
 			// compute cover of each edge
 			void ComputeEdgeCover();
 			

--- a/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
+++ b/libgpopt/include/gpopt/xforms/CJoinOrderDP.h
@@ -166,6 +166,18 @@ namespace gpopt
 			// add expression to cost map
 			void InsertExpressionCost(CExpression *pexpr, CDouble dCost, BOOL fValidateInsert);
 
+			CBitSet *PbsNeighbours(ULONG v);
+
+			CBitSet *PbsNeighbours(CBitSet *C);
+
+			CBitSet *PbsReachable(CBitSet *S, CBitSet *C, ULONG L);
+
+			// implementation of min cut branch partitioning algorithm
+			CBitSet *PbsMinCutBranch(DrgPbs *subsets, CBitSet *S, CBitSet *C, CBitSet *X, ULONG L);
+
+			// generate all subsets of connected components
+			DrgPbs *PdrgpbsMinCutBranch(CBitSet *pbs);
+
 			// generate all subsets of the given array of elements
 			static
 			void GenerateSubsets(IMemoryPool *pmp, CBitSet *pbsCurrent, ULONG *pulElems, ULONG ulSize, ULONG ulIndex, DrgPbs *pdrgpbsSubsets);

--- a/libgpos/include/gpos/common/CBitSet.h
+++ b/libgpos/include/gpos/common/CBitSet.h
@@ -104,9 +104,6 @@ namespace gpos
 			// find link with offset less or equal to given value
 			CBitSetLink *PbslLocate(ULONG, CBitSetLink * = NULL) const;
 			
-			// reset set
-			void Clear();
-			
 			// compute target offset
 			ULONG UlOffset(ULONG) const;
 			
@@ -131,6 +128,9 @@ namespace gpos
 			// clear given bit; return previous value
 			BOOL FExchangeClear(ULONG ulBit);
 			
+			// reset set
+			void Clear();
+
 			// union sets
 			void Union(const CBitSet *);
 			


### PR DESCRIPTION
This PR is more of a RFC, not intended to merge into master yet.

This recursive implementation is based on branch partitioning algorithm
described in paper "A New, Highly Efficient, and Easy To Implement Top-Down
Join Enumeration Algorithm". Maybe we can improve it by implementing it in
iterative way to prevent stack overflow for super large join graph.

The new algorithm gives us 8x optimizer performance improvement for chain
query with 10 relations (I haven't tested on other types of query):
```sql
explain 
select * from r0, r1, r2, r3, r4, r5, r6, r7, r8, r9 
where r3.c = r1.c and r1.a = r0.a 
and r0.b = r2.b and r2.c = r4.c 
and r4.a = r5.a and r5.b = r6.b 
and r6.c = r7.c and r7.a = r8.a 
and r8.b = r9.b;
```
Without this patch, Orca takes 1600ms to generate plan; with this patch, it
only takes 230ms to generate plan, and the generated plan are same.

Signed-off-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>