### PR TITLE
Fix a typo in comment.

### DIFF
--- a/libgpopt/src/base/CCostContext.cpp
+++ b/libgpopt/src/base/CCostContext.cpp
@@ -461,7 +461,7 @@ CCostContext::FBetterThan
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CCostContext::ComputeCost
+//		CCostContext::CostCompute
 //
 //	@doc:
 //		Compute cost of current context,


### PR DESCRIPTION
In `CCostContext.cpp`, the function name in comment should be 'CostCompute' but `ComputeCost`. 