### PR TITLE
Remove fEnableExtendedAsserts, which is useless

### DIFF
--- a/libgpos/include/gpos/_api.h
+++ b/libgpos/include/gpos/_api.h
@@ -25,11 +25,6 @@ extern "C"
 #include <stddef.h>
 #endif /* __cplusplus */
 
-#ifdef GPOS_DEBUG
-extern
-bool fEnableExtendedAsserts;   // flag to control extended (time consuming) asserts
-#endif // GPOS_DEBUG
-
 /*
  * struct with configuration parameters for task execution;
  * this needs to be in sync with the corresponding structure in optserver.h

--- a/libgpos/include/gpos/common/CList.h
+++ b/libgpos/include/gpos/common/CList.h
@@ -227,11 +227,6 @@ namespace gpos
                 GPOS_ASSERT(NULL != m_ptTail);
                 GPOS_ASSERT(0 != m_ulSize);
 
-                // ensure this element is actually member of the list,
-                // this assert is expensive as it traverses the list to make sure
-                // that an entry is accessible by following entries' next pointers
-                GPOS_ASSERT_IMP(fEnableExtendedAsserts, GPOS_OK == EresFind(pt));
-
                 SLink &sl = Link(pt);
 
                 if (sl.m_pvNext)

--- a/libgpos/src/_api.cpp
+++ b/libgpos/src/_api.cpp
@@ -26,10 +26,6 @@
 
 using namespace gpos;
 
-#ifdef GPOS_DEBUG
-bool fEnableExtendedAsserts = false;  // by default, extended asserts are disabled
-#endif // GPOS_DEBUG
-
 //---------------------------------------------------------------------------
 //	@function:
 //		gpos_init

--- a/libgpos/src/test/CUnittest.cpp
+++ b/libgpos/src/test/CUnittest.cpp
@@ -584,11 +584,6 @@ CUnittest::Init
 
 	// disable allocations using global new operator
 	CMemoryPoolManager::Pmpm()->DisableGlobalNew();
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts before running any unittest
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 }
 
 // EOF

--- a/server/src/unittest/gpopt/minidump/CAggTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CAggTest.cpp
@@ -96,22 +96,12 @@ GPOS_RESULT
 CAggTest::EresUnittest()
 {
 
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CBitmapTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CBitmapTest.cpp
@@ -66,22 +66,12 @@ const CHAR *rgszBitmapFileNames[] =
 GPOS_RESULT
 CBitmapTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CCTETest.cpp
+++ b/server/src/unittest/gpopt/minidump/CCTETest.cpp
@@ -72,22 +72,12 @@ const CHAR *rgszCTEFileNames[] =
 GPOS_RESULT
 CCTETest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CCastTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CCastTest.cpp
@@ -47,23 +47,12 @@ const CHAR *rgszCastMdpFiles[] =
 GPOS_RESULT
 CCastTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CCollapseProjectTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CCollapseProjectTest.cpp
@@ -52,23 +52,12 @@ const CHAR *rgszCollapseProjectFileNames[] =
 GPOS_RESULT
 CCollapseProjectTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CConstTblGetTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CConstTblGetTest.cpp
@@ -37,23 +37,12 @@ const CHAR *rgszCTGMdpFiles[] =
 GPOS_RESULT
 CConstTblGetTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -87,22 +87,12 @@ const CHAR *rgszDMLFileNames[] =
 GPOS_RESULT
 CDMLTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CDirectDispatchTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CDirectDispatchTest.cpp
@@ -51,22 +51,12 @@ const CHAR *rgszDirectDispatchFileNames[] =
 GPOS_RESULT
 CDirectDispatchTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CEscapeMechanismTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CEscapeMechanismTest.cpp
@@ -44,22 +44,12 @@ const CHAR *rgszEscapeMechanismFileNames[] =
 GPOS_RESULT
 CEscapeMechanismTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CExternalTableTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CExternalTableTest.cpp
@@ -56,23 +56,12 @@ const CHAR *rgszExternalTableFileNames[] =
 GPOS_RESULT
 CExternalTableTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(CExternalTableTest::EresUnittest_RunMinidumpTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CICGTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CICGTest.cpp
@@ -143,12 +143,6 @@ const CHAR *rgszPreferHashJoinVersusIndexJoin[] =
 GPOS_RESULT
 CICGTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		// keep test for testing partially supported operators/xforms
@@ -164,11 +158,6 @@ CICGTest::EresUnittest()
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CIndexTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CIndexTest.cpp
@@ -120,23 +120,12 @@ const CHAR *rgszIndexFileNames[] =
 GPOS_RESULT
 CIndexTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CMinidumpWithConstExprEvaluatorTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CMinidumpWithConstExprEvaluatorTest.cpp
@@ -56,11 +56,6 @@ const CHAR *rgszConstExprEvaluatorOnFileNames[] =
 GPOS_RESULT
 CMinidumpWithConstExprEvaluatorTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(
@@ -68,11 +63,6 @@ CMinidumpWithConstExprEvaluatorTest::EresUnittest()
 		};
 
 	GPOS_RESULT eres =  CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	return eres;
 }

--- a/server/src/unittest/gpopt/minidump/CMissingStatsTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CMissingStatsTest.cpp
@@ -40,23 +40,12 @@ ULONG CMissingStatsTest::m_ulMissingStatsTestCounter = 0;  // start from first t
 GPOS_RESULT
 CMissingStatsTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/COuterJoinTest.cpp
+++ b/server/src/unittest/gpopt/minidump/COuterJoinTest.cpp
@@ -50,23 +50,12 @@ const CHAR *rgszOJMdpFiles[] =
 GPOS_RESULT
 COuterJoinTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPartTblTest.cpp
@@ -119,23 +119,12 @@ const CHAR *rgszPartTblFileNames[] =
 GPOS_RESULT
 CPartTblTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CPredicateTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPredicateTest.cpp
@@ -60,23 +60,12 @@ const CHAR *rgszPredMdpFiles[] =
 GPOS_RESULT
 CPredicateTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CPruneColumnsTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CPruneColumnsTest.cpp
@@ -55,23 +55,12 @@ const CHAR *rgszPruneColumnsFileNames[] =
 GPOS_RESULT
 CPruneColumnsTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CScalarArrayCmpTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CScalarArrayCmpTest.cpp
@@ -31,23 +31,12 @@ const CHAR *rgszScalarArrayCmpMdpFiles[] =
 GPOS_RESULT
 CScalarArrayCmpTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CSemiJoinTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CSemiJoinTest.cpp
@@ -51,23 +51,12 @@ const CHAR *rgszSemiMdpFiles[] =
 GPOS_RESULT
 CSemiJoinTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CSetopTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CSetopTest.cpp
@@ -88,22 +88,12 @@ const CHAR *rgszSetOpFileNames[] =
 GPOS_RESULT
 CSetopTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CSubqueryTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CSubqueryTest.cpp
@@ -70,23 +70,12 @@ const CHAR *rgszSubqueryFileNames[] =
 GPOS_RESULT
 CSubqueryTest::EresUnittest()
 {
-
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/minidump/CTVFTest.cpp
+++ b/server/src/unittest/gpopt/minidump/CTVFTest.cpp
@@ -49,22 +49,12 @@ const CHAR *rgszTVFFileNames[] =
 GPOS_RESULT
 CTVFTest::EresUnittest()
 {
-#ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
 	CUnittest rgut[] =
 		{
 		GPOS_UNITTEST_FUNC(EresUnittest_RunTests),
 		};
 
 	GPOS_RESULT eres = CUnittest::EresExecute(rgut, GPOS_ARRAY_SIZE(rgut));
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();

--- a/server/src/unittest/gpopt/translate/CTpchTest.cpp
+++ b/server/src/unittest/gpopt/translate/CTpchTest.cpp
@@ -117,11 +117,6 @@ CTpchTest::EresSubtest(ULONG ulQueryNum)
 	IMemoryPool *pmp = amp.Pmp();
 
 #ifdef GPOS_DEBUG
-	// disable extended asserts before running test
-	fEnableExtendedAsserts = false;
-#endif // GPOS_DEBUG
-
-#ifdef GPOS_DEBUG
 	const ULONG ulTests = GPOS_ARRAY_SIZE(rgszTpch);
 	GPOS_ASSERT(ulQueryNum > 0);
 	GPOS_ASSERT(ulQueryNum - 1 < ulTests);
@@ -169,11 +164,6 @@ CTpchTest::EresSubtest(ULONG ulQueryNum)
 			false  // fTestSpacePruning
 			);
 	}
-
-#ifdef GPOS_DEBUG
-	// enable extended asserts after running test
-	fEnableExtendedAsserts = true;
-#endif // GPOS_DEBUG
 
 	// reset metadata cache
 	CMDCache::Reset();


### PR DESCRIPTION
It is adding a lot of debug test runtime overhead without adding any value.