### PR TITLE
Update README with shared library tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ Build and install:
 ninja install -C build
 ```
 
+### Common Issues
+
+Note that because Red Hat-based systems do not normally look for shared libraries in `/usr/local/lib`, it is suggested to add `/usr/local/lib` to the /etc/ld.so.conf if developing on one of these Linux distributions.
 
 ## Cleanup
 


### PR DESCRIPTION
A GPDB developer who uses CentOS 6 recently requested we add a tip to our README about adding /usr/local/lib to the list of directories in which the program loader looks.