### PR TITLE
Suggest additional hint in common issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ ninja install -C build
 
 ### Common Issues
 
-Note that because Red Hat-based systems do not normally look for shared libraries in `/usr/local/lib`, it is suggested to add `/usr/local/lib` to the /etc/ld.so.conf if developing on one of these Linux distributions.
+Note that because Red Hat-based systems do not normally look for shared libraries in `/usr/local/lib`, it is suggested to add `/usr/local/lib` to the /etc/ld.so.conf and run `ldconfig` to rebuild the shared library cache if developing on one of these Linux distributions.
 
 ## Cleanup
 


### PR DESCRIPTION
Add a hint to rebuild the shared library cache if the user follows the suggestion to add the 
usr/local/lib path to /etc/ld.so.conf file.