### PR TITLE
Fix issues in dxl.xsd that didn't meet XSD standard

### DIFF
--- a/server/dxl.xsd
+++ b/server/dxl.xsd
@@ -1188,7 +1188,7 @@
 		</xsd:complexContent>	
 	</xsd:complexType>
 
-	<xsd:complexType name="dxl:SubPlanTestExpr">
+	<xsd:complexType name="SubPlanTestExpr">
 		<xsd:sequence>
 			<xsd:group ref="dxl:ScalarOp" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>

--- a/server/dxl.xsd
+++ b/server/dxl.xsd
@@ -676,7 +676,6 @@
 	</xsd:complexType>
 	
 	<xsd:complexType name="LogicalCTASType">
-	<xsd:complexContent>
 		<xsd:sequence>
 			<xsd:element name="Columns" type="dxl:ColumnsType"/>
 			<xsd:element name="CTASOptions" type="dxl:CTASOptionsType"/>
@@ -708,8 +707,6 @@
 		<xsd:attribute name="DistributionColumns" type="xsd:string" use="optional"/>
 		<xsd:attribute name="InsertColumns" type="xsd:string" use="required"/>
 		<xsd:attribute name="VarTypeModList" type="xsd:string" use="required"/>
-	</xsd:complexContent>
-		
 	</xsd:complexType>
 
 	<xsd:complexType name="TableScanType">
@@ -753,8 +750,8 @@
 					<xsd:group ref="dxl:PhysicalBitmapAccessPathType" minOccurs="1" maxOccurs="1"/>
 					<xsd:group ref="dxl:PhysicalBitmapAccessPathType" minOccurs="1" maxOccurs="1"/>
 				</xsd:sequence>
+				<xsd:attribute name="TypeId" type="xsd:string" use="optional"/>
 			</xsd:extension>
-			<xsd:attribute name="TypeId" type="xsd:string" use="optional"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 
@@ -1191,7 +1188,7 @@
 		</xsd:complexContent>	
 	</xsd:complexType>
 
-	<xsd:complexType name="SubPlanTestExpr">
+	<xsd:complexType name="dxl:SubPlanTestExpr">
 		<xsd:sequence>
 			<xsd:group ref="dxl:ScalarOp" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>
@@ -1465,7 +1462,7 @@
 	
 	<xsd:complexType name="SubPlanType">
 		<xsd:sequence>
-			<xsd:element name="TestExpr" type="SubPlanTestExpr"/>
+			<xsd:element name="TestExpr" type="dxl:SubPlanTestExpr"/>
 			<xsd:element name="ParamList" type="dxl:SubPlanParamListType"/>
 			<xsd:group ref="dxl:PhysicalOp"/>
 		</xsd:sequence>


### PR DESCRIPTION
I try to generate DXL parser according dxl.xsd in golang, and find some non-compliant issues in this file:
- complexContent should only include (restriction|extension)
- SubPlanTestExpr:  add "dxl:" space prefix