### PR TITLE
HashJoin rewindability should be identical to its outer child

### DIFF
--- a/data/dxl/minidump/AddPredsInSubqueries.mdp
+++ b/data/dxl/minidump/AddPredsInSubqueries.mdp
@@ -334,7 +334,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="414">
+    <dxl:Plan Id="0" SpaceSize="424">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="5.587891" Rows="1.000000" Width="108"/>

--- a/data/dxl/minidump/AnySubqueryWithAllSubqueryInScalar.mdp
+++ b/data/dxl/minidump/AnySubqueryWithAllSubqueryInScalar.mdp
@@ -435,7 +435,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="356">
+    <dxl:Plan Id="0" SpaceSize="466">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
 	<dxl:Properties>
 	  <dxl:Cost StartupCost="0" TotalCost="8620.003395" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
+++ b/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
@@ -346,7 +346,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="420">
+    <dxl:Plan Id="0" SpaceSize="550">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
 	<dxl:Properties>
 	  <dxl:Cost StartupCost="0" TotalCost="6896.001505" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp
+++ b/data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp
@@ -466,7 +466,7 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="27">
+    <dxl:Plan Id="0" SpaceSize="28">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1377.995318" Rows="1000000.000000" Width="16"/>

--- a/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1468,10 +1468,10 @@ WHERE
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22510866">
+    <dxl:Plan Id="0" SpaceSize="26606090">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="606.982943" Rows="72.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="606.981966" Rows="72.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="cd_gender">
@@ -1482,7 +1482,7 @@ WHERE
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="605.947786" Rows="72.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="605.946810" Rows="72.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="26" Alias="cd_gender">
@@ -1495,59 +1495,115 @@ WHERE
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="532.943880" Rows="18.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1.011719" Rows="16.000000" Width="1"/>
             </dxl:Properties>
-            <dxl:ProjList/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="26" Alias="cd_gender">
+                <dxl:Ident ColId="26" ColName="cd_gender" TypeMdid="0.1042.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="8.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="26" Alias="cd_gender">
+                  <dxl:Ident ColId="26" ColName="cd_gender" TypeMdid="0.1042.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.1096173.1.1" TableName="customer_demographics">
+                <dxl:Columns>
+                  <dxl:Column ColId="25" Attno="1" ColName="cd_demo_sk" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="26" Attno="2" ColName="cd_gender" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="27" Attno="3" ColName="cd_marital_status" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                  <dxl:Column ColId="28" Attno="4" ColName="cd_education_status" TypeMdid="0.1042.1.0" ColWidth="20"/>
+                  <dxl:Column ColId="29" Attno="5" ColName="cd_purchase_estimate" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="30" Attno="6" ColName="cd_credit_rating" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                  <dxl:Column ColId="31" Attno="7" ColName="cd_dep_count" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="32" Attno="8" ColName="cd_dep_employed_count" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="33" Attno="9" ColName="cd_dep_college_count" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:BroadcastMotion>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="531.935091" Rows="9.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                  <dxl:Coalesce TypeMdid="0.20.1.0">
+                    <dxl:Ident ColId="201" ColName="ColRef_0201" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                  </dxl:Coalesce>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
+                  <dxl:Coalesce TypeMdid="0.20.1.0">
+                    <dxl:Ident ColId="202" ColName="ColRef_0202" TypeMdid="0.20.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                  </dxl:Coalesce>
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
+                </dxl:Comparison>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="531.935091" Rows="9.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="530.926302" Rows="10.000000" Width="16"/>
               </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:Filter>
-                <dxl:Or>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                    <dxl:Coalesce TypeMdid="0.20.1.0">
-                      <dxl:Ident ColId="201" ColName="ColRef_0201" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                    </dxl:Coalesce>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                  </dxl:Comparison>
-                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                    <dxl:Coalesce TypeMdid="0.20.1.0">
-                      <dxl:Ident ColId="202" ColName="ColRef_0202" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                    </dxl:Coalesce>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="false" IsByValue="true" Value="0"/>
-                  </dxl:Comparison>
-                </dxl:Or>
-              </dxl:Filter>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="201" Alias="ColRef_0201">
+                  <dxl:Ident ColId="199" ColName="ColRef_0199" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="202" Alias="ColRef_0202">
+                  <dxl:Ident ColId="200" ColName="ColRef_0200" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
               <dxl:OneTimeFilter/>
-              <dxl:Result>
+              <dxl:HashJoin JoinType="Left">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="530.926302" Rows="10.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="529.770052" Rows="10.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="201" Alias="ColRef_0201">
+                  <dxl:ProjElem ColId="199" Alias="ColRef_0199">
                     <dxl:Ident ColId="199" ColName="ColRef_0199" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="202" Alias="ColRef_0202">
+                  <dxl:ProjElem ColId="200" Alias="ColRef_0200">
                     <dxl:Ident ColId="200" ColName="ColRef_0200" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
                 <dxl:HashJoin JoinType="Left">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="529.770052" Rows="10.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="8.516146" Rows="9.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="c_customer_sk">
+                      <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="199" Alias="ColRef_0199">
                       <dxl:Ident ColId="199" ColName="ColRef_0199" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="200" Alias="ColRef_0200">
-                      <dxl:Ident ColId="200" ColName="ColRef_0200" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
@@ -1555,88 +1611,84 @@ WHERE
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                       <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
-                  <dxl:HashJoin JoinType="Left">
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="8.516146" Rows="9.000000" Width="16"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.031250" Rows="8.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="c_customer_sk">
                         <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.1107804.1.1" TableName="customer">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="c_customer_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                        <dxl:Column ColId="2" Attno="3" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="3" Attno="4" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="4" Attno="5" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="5" Attno="6" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="6" Attno="7" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="7" Attno="8" ColName="c_salutation" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                        <dxl:Column ColId="8" Attno="9" ColName="c_first_name" TypeMdid="0.1042.1.0" ColWidth="20"/>
+                        <dxl:Column ColId="9" Attno="10" ColName="c_last_name" TypeMdid="0.1042.1.0" ColWidth="30"/>
+                        <dxl:Column ColId="10" Attno="11" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                        <dxl:Column ColId="11" Attno="12" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="12" Attno="13" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="13" Attno="14" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="14" Attno="15" ColName="c_birth_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
+                        <dxl:Column ColId="15" Attno="16" ColName="c_login" TypeMdid="0.1042.1.0" ColWidth="13"/>
+                        <dxl:Column ColId="16" Attno="17" ColName="c_email_address" TypeMdid="0.1042.1.0" ColWidth="50"/>
+                        <dxl:Column ColId="17" Attno="18" ColName="c_last_review_date" TypeMdid="0.1042.1.0" ColWidth="10"/>
+                        <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="6.797396" Rows="8.000000" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="45"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
                       <dxl:ProjElem ColId="199" Alias="ColRef_0199">
-                        <dxl:Ident ColId="199" ColName="ColRef_0199" TypeMdid="0.20.1.0"/>
+                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
+                        <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:JoinFilter/>
-                    <dxl:HashCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:HashCondList>
-                    <dxl:TableScan>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.031250" Rows="8.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="5.547396" Rows="8.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="c_customer_sk">
-                          <dxl:Ident ColId="0" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.1107804.1.1" TableName="customer">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="c_customer_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="c_customer_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="2" Attno="3" ColName="c_current_cdemo_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="3" Attno="4" ColName="c_current_hdemo_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="4" Attno="5" ColName="c_current_addr_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="5" Attno="6" ColName="c_first_shipto_date_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="6" Attno="7" ColName="c_first_sales_date_sk" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="7" Attno="8" ColName="c_salutation" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                          <dxl:Column ColId="8" Attno="9" ColName="c_first_name" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                          <dxl:Column ColId="9" Attno="10" ColName="c_last_name" TypeMdid="0.1042.1.0" ColWidth="30"/>
-                          <dxl:Column ColId="10" Attno="11" ColName="c_preferred_cust_flag" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                          <dxl:Column ColId="11" Attno="12" ColName="c_birth_day" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="12" Attno="13" ColName="c_birth_month" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="13" Attno="14" ColName="c_birth_year" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="14" Attno="15" ColName="c_birth_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                          <dxl:Column ColId="15" Attno="16" ColName="c_login" TypeMdid="0.1042.1.0" ColWidth="13"/>
-                          <dxl:Column ColId="16" Attno="17" ColName="c_email_address" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                          <dxl:Column ColId="17" Attno="18" ColName="c_last_review_date" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                          <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                    <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.797396" Rows="8.000000" Width="16"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="45"/>
-                      </dxl:GroupingColumns>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="199" Alias="ColRef_0199">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
                           <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="5.547396" Rows="8.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="4.516146" Rows="8.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
@@ -1644,28 +1696,26 @@ WHERE
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
-                            <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+                        <dxl:JoinFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                        </dxl:JoinFilter>
+                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="4.516146" Rows="8.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="2.312500" Rows="16.000000" Width="16"/>
                           </dxl:Properties>
                           <dxl:ProjList>
+                            <dxl:ProjElem ColId="41" Alias="ws_sold_date_sk">
+                              <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
                               <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:JoinFilter>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                          </dxl:JoinFilter>
-                          <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                          <dxl:SortingColumnList/>
+                          <dxl:Sequence>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="2.312500" Rows="16.000000" Width="16"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.062500" Rows="8.000000" Width="16"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="41" Alias="ws_sold_date_sk">
@@ -1675,9 +1725,28 @@ WHERE
                                 <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Sequence>
+                            <dxl:PartitionSelector RelationMdid="0.1109526.1.1" PartitionLevels="1" ScanId="1">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList/>
+                              <dxl:PartEqFilters>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                              </dxl:PartEqFilters>
+                              <dxl:PartFilters>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                              </dxl:PartFilters>
+                              <dxl:ResidualFilter>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                              </dxl:ResidualFilter>
+                              <dxl:PropagationExpression>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                              </dxl:PropagationExpression>
+                              <dxl:PrintableFilter>
+                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                              </dxl:PrintableFilter>
+                            </dxl:PartitionSelector>
+                            <dxl:DynamicTableScan PartIndexId="1">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="0.062500" Rows="8.000000" Width="16"/>
                               </dxl:Properties>
@@ -1689,297 +1758,50 @@ WHERE
                                   <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
-                              <dxl:PartitionSelector RelationMdid="0.1109526.1.1" PartitionLevels="1" ScanId="1">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList/>
-                                <dxl:PartEqFilters>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                                </dxl:PartEqFilters>
-                                <dxl:PartFilters>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                                </dxl:PartFilters>
-                                <dxl:ResidualFilter>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                                </dxl:ResidualFilter>
-                                <dxl:PropagationExpression>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                                </dxl:PropagationExpression>
-                                <dxl:PrintableFilter>
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                                </dxl:PrintableFilter>
-                              </dxl:PartitionSelector>
-                              <dxl:DynamicTableScan PartIndexId="1">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.062500" Rows="8.000000" Width="16"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="41" Alias="ws_sold_date_sk">
-                                    <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="45" Alias="ws_bill_customer_sk">
-                                    <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.1109526.1.1" TableName="web_sales">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="41" Attno="1" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="42" Attno="2" ColName="ws_sold_time_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="43" Attno="3" ColName="ws_ship_date_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="44" Attno="4" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="45" Attno="5" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="46" Attno="6" ColName="ws_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="47" Attno="7" ColName="ws_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="48" Attno="8" ColName="ws_bill_addr_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="49" Attno="9" ColName="ws_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="50" Attno="10" ColName="ws_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="51" Attno="11" ColName="ws_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="52" Attno="12" ColName="ws_ship_addr_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="53" Attno="13" ColName="ws_web_page_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="54" Attno="14" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="55" Attno="15" ColName="ws_ship_mode_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="56" Attno="16" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="57" Attno="17" ColName="ws_promo_sk" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="58" Attno="18" ColName="ws_order_number" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="59" Attno="19" ColName="ws_quantity" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="60" Attno="20" ColName="ws_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="61" Attno="21" ColName="ws_list_price" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="62" Attno="22" ColName="ws_sales_price" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="63" Attno="23" ColName="ws_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="64" Attno="24" ColName="ws_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="65" Attno="25" ColName="ws_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="66" Attno="26" ColName="ws_ext_list_price" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="67" Attno="27" ColName="ws_ext_tax" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="68" Attno="28" ColName="ws_coupon_amt" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="69" Attno="29" ColName="ws_ext_ship_cost" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="70" Attno="30" ColName="ws_net_paid" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="71" Attno="31" ColName="ws_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="72" Attno="32" ColName="ws_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="73" Attno="33" ColName="ws_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="74" Attno="34" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
-                                    <dxl:Column ColId="75" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="76" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="77" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="78" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="79" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="80" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="81" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:DynamicTableScan>
-                            </dxl:Sequence>
-                          </dxl:BroadcastMotion>
-                          <dxl:Sequence>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.133333" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:PartitionSelector RelationMdid="0.1096216.1.1" PartitionLevels="1" ScanId="2">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:PartEqFilters>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:PartEqFilters>
-                              <dxl:PartFilters>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:PartFilters>
-                              <dxl:ResidualFilter>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:ResidualFilter>
-                              <dxl:PropagationExpression>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
-                              </dxl:PropagationExpression>
-                              <dxl:PrintableFilter>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:PrintableFilter>
-                            </dxl:PartitionSelector>
-                            <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.133333" Rows="1.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
                               <dxl:Filter/>
-                              <dxl:IndexCondList>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="82" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="88" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2002"/>
-                                </dxl:Comparison>
-                              </dxl:IndexCondList>
-                              <dxl:IndexDescriptor Mdid="0.1096283.1.0" IndexName="date_dim_1_prt_p1_1_pkey"/>
-                              <dxl:TableDescriptor Mdid="0.1096216.1.1" TableName="date_dim">
+                              <dxl:TableDescriptor Mdid="0.1109526.1.1" TableName="web_sales">
                                 <dxl:Columns>
-                                  <dxl:Column ColId="82" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="83" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                                  <dxl:Column ColId="84" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
-                                  <dxl:Column ColId="85" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="86" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="87" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="88" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="89" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="90" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="91" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="92" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="93" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="94" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="95" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="96" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
-                                  <dxl:Column ColId="97" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="98" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="99" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="100" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="101" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="102" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="103" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="104" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="105" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="106" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="107" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="108" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="109" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="110" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="111" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="112" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="113" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="114" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="115" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="116" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:DynamicIndexScan>
-                          </dxl:Sequence>
-                        </dxl:NestedLoopJoin>
-                      </dxl:RedistributeMotion>
-                    </dxl:Aggregate>
-                  </dxl:HashJoin>
-                  <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="519.488281" Rows="8.000000" Width="16"/>
-                    </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="124"/>
-                    </dxl:GroupingColumns>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="200" Alias="ColRef_0200">
-                        <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
-                        <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="517.363281" Rows="64.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
-                          <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
-                          <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="516.113281" Rows="64.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
-                            <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                        </dxl:JoinFilter>
-                        <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2.019531" Rows="16.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:SortingColumnList/>
-                          <dxl:Sequence>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="8.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList/>
-                            <dxl:PartitionSelector RelationMdid="0.1096216.1.1" PartitionLevels="1" ScanId="4">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:PartEqFilters>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:PartEqFilters>
-                              <dxl:PartFilters>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:PartFilters>
-                              <dxl:ResidualFilter>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:ResidualFilter>
-                              <dxl:PropagationExpression>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
-                              </dxl:PropagationExpression>
-                              <dxl:PrintableFilter>
-                                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                              </dxl:PrintableFilter>
-                            </dxl:PartitionSelector>
-                            <dxl:DynamicTableScan PartIndexId="4">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="8.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.1096216.1.1" TableName="date_dim">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="158" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="159" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                                  <dxl:Column ColId="160" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
-                                  <dxl:Column ColId="161" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="162" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="163" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="164" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="165" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="166" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="167" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="168" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="169" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="170" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="171" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="172" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
-                                  <dxl:Column ColId="173" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="174" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="175" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="176" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="177" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="178" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="179" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="180" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="181" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="182" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="183" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="184" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="185" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                                  <dxl:Column ColId="186" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="187" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="188" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="189" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="190" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="191" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="192" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="41" Attno="1" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="42" Attno="2" ColName="ws_sold_time_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="43" Attno="3" ColName="ws_ship_date_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="44" Attno="4" ColName="ws_item_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="45" Attno="5" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="46" Attno="6" ColName="ws_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="47" Attno="7" ColName="ws_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="48" Attno="8" ColName="ws_bill_addr_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="49" Attno="9" ColName="ws_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="50" Attno="10" ColName="ws_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="51" Attno="11" ColName="ws_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="52" Attno="12" ColName="ws_ship_addr_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="53" Attno="13" ColName="ws_web_page_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="54" Attno="14" ColName="ws_web_site_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="55" Attno="15" ColName="ws_ship_mode_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="56" Attno="16" ColName="ws_warehouse_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="57" Attno="17" ColName="ws_promo_sk" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="58" Attno="18" ColName="ws_order_number" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="59" Attno="19" ColName="ws_quantity" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="60" Attno="20" ColName="ws_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="61" Attno="21" ColName="ws_list_price" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="62" Attno="22" ColName="ws_sales_price" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="63" Attno="23" ColName="ws_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="64" Attno="24" ColName="ws_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="65" Attno="25" ColName="ws_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="66" Attno="26" ColName="ws_ext_list_price" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="67" Attno="27" ColName="ws_ext_tax" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="68" Attno="28" ColName="ws_coupon_amt" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="69" Attno="29" ColName="ws_ext_ship_cost" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="70" Attno="30" ColName="ws_net_paid" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="71" Attno="31" ColName="ws_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="72" Attno="32" ColName="ws_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="73" Attno="33" ColName="ws_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="74" Attno="34" ColName="ws_net_profit" TypeMdid="0.1700.1.0"/>
+                                  <dxl:Column ColId="75" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="76" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="77" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="78" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="79" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="80" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="81" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:DynamicTableScan>
@@ -1987,14 +1809,10 @@ WHERE
                         </dxl:BroadcastMotion>
                         <dxl:Sequence>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="0.031250" Rows="8.000000" Width="8"/>
+                            <dxl:Cost StartupCost="0" TotalCost="0.133333" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
-                              <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:PartitionSelector RelationMdid="0.1109906.1.1" PartitionLevels="1" ScanId="3">
+                          <dxl:ProjList/>
+                          <dxl:PartitionSelector RelationMdid="0.1096216.1.1" PartitionLevels="1" ScanId="2">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
                             </dxl:Properties>
@@ -2009,107 +1827,293 @@ WHERE
                               <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
                             </dxl:ResidualFilter>
                             <dxl:PropagationExpression>
-                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
                             </dxl:PropagationExpression>
                             <dxl:PrintableFilter>
                               <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
                             </dxl:PrintableFilter>
                           </dxl:PartitionSelector>
-                          <dxl:DynamicTableScan PartIndexId="3">
+                          <dxl:DynamicIndexScan IndexScanDirection="Forward" PartIndexId="2">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.031250" Rows="8.000000" Width="8"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.133333" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
-                                <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
+                            <dxl:ProjList/>
                             <dxl:Filter/>
-                            <dxl:TableDescriptor Mdid="0.1109906.1.1" TableName="catalog_sales">
+                            <dxl:IndexCondList>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="82" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                <dxl:Ident ColId="88" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2002"/>
+                              </dxl:Comparison>
+                            </dxl:IndexCondList>
+                            <dxl:IndexDescriptor Mdid="0.1096283.1.0" IndexName="date_dim_1_prt_p1_1_pkey"/>
+                            <dxl:TableDescriptor Mdid="0.1096216.1.1" TableName="date_dim">
                               <dxl:Columns>
-                                <dxl:Column ColId="117" Attno="1" ColName="cs_sold_date_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="118" Attno="2" ColName="cs_sold_time_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="119" Attno="3" ColName="cs_ship_date_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="120" Attno="4" ColName="cs_bill_customer_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="121" Attno="5" ColName="cs_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="122" Attno="6" ColName="cs_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="123" Attno="7" ColName="cs_bill_addr_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="124" Attno="8" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="125" Attno="9" ColName="cs_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="126" Attno="10" ColName="cs_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="127" Attno="11" ColName="cs_ship_addr_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="128" Attno="12" ColName="cs_call_center_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="129" Attno="13" ColName="cs_catalog_page_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="130" Attno="14" ColName="cs_ship_mode_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="131" Attno="15" ColName="cs_warehouse_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="132" Attno="16" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="133" Attno="17" ColName="cs_promo_sk" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="134" Attno="18" ColName="cs_order_number" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="135" Attno="19" ColName="cs_quantity" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="136" Attno="20" ColName="cs_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="137" Attno="21" ColName="cs_list_price" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="138" Attno="22" ColName="cs_sales_price" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="139" Attno="23" ColName="cs_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="140" Attno="24" ColName="cs_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="141" Attno="25" ColName="cs_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="142" Attno="26" ColName="cs_ext_list_price" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="143" Attno="27" ColName="cs_ext_tax" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="144" Attno="28" ColName="cs_coupon_amt" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="145" Attno="29" ColName="cs_ext_ship_cost" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="146" Attno="30" ColName="cs_net_paid" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="147" Attno="31" ColName="cs_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="148" Attno="32" ColName="cs_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="149" Attno="33" ColName="cs_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="150" Attno="34" ColName="cs_net_profit" TypeMdid="0.1700.1.0"/>
-                                <dxl:Column ColId="151" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="152" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="153" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="154" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="155" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="156" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="157" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="82" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="83" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                                <dxl:Column ColId="84" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
+                                <dxl:Column ColId="85" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="86" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="87" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="88" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="89" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="90" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="91" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="92" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="93" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="94" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="95" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="96" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
+                                <dxl:Column ColId="97" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="98" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="99" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="100" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="101" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="102" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="103" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="104" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="105" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="106" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="107" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="108" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="109" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="110" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="111" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="112" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="113" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="114" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="115" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="116" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                               </dxl:Columns>
                             </dxl:TableDescriptor>
-                          </dxl:DynamicTableScan>
+                          </dxl:DynamicIndexScan>
                         </dxl:Sequence>
                       </dxl:NestedLoopJoin>
                     </dxl:RedistributeMotion>
                   </dxl:Aggregate>
                 </dxl:HashJoin>
-              </dxl:Result>
+                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="519.488281" Rows="8.000000" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="124"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="200" Alias="ColRef_0200">
+                      <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
+                      <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="517.363281" Rows="64.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
+                        <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="516.113281" Rows="64.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
+                          <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:JoinFilter>
+                        <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                      </dxl:JoinFilter>
+                      <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="2.019531" Rows="16.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:Sequence>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="8.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:PartitionSelector RelationMdid="0.1096216.1.1" PartitionLevels="1" ScanId="4">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:PartEqFilters>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                            </dxl:PartEqFilters>
+                            <dxl:PartFilters>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                            </dxl:PartFilters>
+                            <dxl:ResidualFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                            </dxl:ResidualFilter>
+                            <dxl:PropagationExpression>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="4"/>
+                            </dxl:PropagationExpression>
+                            <dxl:PrintableFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                            </dxl:PrintableFilter>
+                          </dxl:PartitionSelector>
+                          <dxl:DynamicTableScan PartIndexId="4">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="8.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.1096216.1.1" TableName="date_dim">
+                              <dxl:Columns>
+                                <dxl:Column ColId="158" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="159" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
+                                <dxl:Column ColId="160" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
+                                <dxl:Column ColId="161" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="162" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="163" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="164" Attno="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="165" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="166" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="167" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="168" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="169" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="170" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="171" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="172" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" ColWidth="9"/>
+                                <dxl:Column ColId="173" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="174" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="175" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="176" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="177" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="178" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="179" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="180" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="181" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="182" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="183" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="184" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="185" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" ColWidth="1"/>
+                                <dxl:Column ColId="186" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="187" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="188" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="189" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="190" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="191" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="192" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:DynamicTableScan>
+                        </dxl:Sequence>
+                      </dxl:BroadcastMotion>
+                      <dxl:Sequence>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.031250" Rows="8.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
+                            <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:PartitionSelector RelationMdid="0.1109906.1.1" PartitionLevels="1" ScanId="3">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList/>
+                          <dxl:PartEqFilters>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                          </dxl:PartEqFilters>
+                          <dxl:PartFilters>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                          </dxl:PartFilters>
+                          <dxl:ResidualFilter>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                          </dxl:ResidualFilter>
+                          <dxl:PropagationExpression>
+                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+                          </dxl:PropagationExpression>
+                          <dxl:PrintableFilter>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                          </dxl:PrintableFilter>
+                        </dxl:PartitionSelector>
+                        <dxl:DynamicTableScan PartIndexId="3">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.031250" Rows="8.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="124" Alias="cs_ship_customer_sk">
+                              <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="0.1109906.1.1" TableName="catalog_sales">
+                            <dxl:Columns>
+                              <dxl:Column ColId="117" Attno="1" ColName="cs_sold_date_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="118" Attno="2" ColName="cs_sold_time_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="119" Attno="3" ColName="cs_ship_date_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="120" Attno="4" ColName="cs_bill_customer_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="121" Attno="5" ColName="cs_bill_cdemo_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="122" Attno="6" ColName="cs_bill_hdemo_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="123" Attno="7" ColName="cs_bill_addr_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="124" Attno="8" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="125" Attno="9" ColName="cs_ship_cdemo_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="126" Attno="10" ColName="cs_ship_hdemo_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="127" Attno="11" ColName="cs_ship_addr_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="128" Attno="12" ColName="cs_call_center_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="129" Attno="13" ColName="cs_catalog_page_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="130" Attno="14" ColName="cs_ship_mode_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="131" Attno="15" ColName="cs_warehouse_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="132" Attno="16" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="133" Attno="17" ColName="cs_promo_sk" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="134" Attno="18" ColName="cs_order_number" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="135" Attno="19" ColName="cs_quantity" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="136" Attno="20" ColName="cs_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="137" Attno="21" ColName="cs_list_price" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="138" Attno="22" ColName="cs_sales_price" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="139" Attno="23" ColName="cs_ext_discount_amt" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="140" Attno="24" ColName="cs_ext_sales_price" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="141" Attno="25" ColName="cs_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="142" Attno="26" ColName="cs_ext_list_price" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="143" Attno="27" ColName="cs_ext_tax" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="144" Attno="28" ColName="cs_coupon_amt" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="145" Attno="29" ColName="cs_ext_ship_cost" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="146" Attno="30" ColName="cs_net_paid" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="147" Attno="31" ColName="cs_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="148" Attno="32" ColName="cs_net_paid_inc_ship" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="149" Attno="33" ColName="cs_net_paid_inc_ship_tax" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="150" Attno="34" ColName="cs_net_profit" TypeMdid="0.1700.1.0"/>
+                              <dxl:Column ColId="151" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="152" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="153" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="154" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="155" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="156" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="157" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:DynamicTableScan>
+                      </dxl:Sequence>
+                    </dxl:NestedLoopJoin>
+                  </dxl:RedistributeMotion>
+                </dxl:Aggregate>
+              </dxl:HashJoin>
             </dxl:Result>
-          </dxl:BroadcastMotion>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.003906" Rows="8.000000" Width="1"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="26" Alias="cd_gender">
-                <dxl:Ident ColId="26" ColName="cd_gender" TypeMdid="0.1042.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.1096173.1.1" TableName="customer_demographics">
-              <dxl:Columns>
-                <dxl:Column ColId="25" Attno="1" ColName="cd_demo_sk" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="26" Attno="2" ColName="cd_gender" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                <dxl:Column ColId="27" Attno="3" ColName="cd_marital_status" TypeMdid="0.1042.1.0" ColWidth="1"/>
-                <dxl:Column ColId="28" Attno="4" ColName="cd_education_status" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                <dxl:Column ColId="29" Attno="5" ColName="cd_purchase_estimate" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="30" Attno="6" ColName="cd_credit_rating" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                <dxl:Column ColId="31" Attno="7" ColName="cd_dep_count" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="32" Attno="8" ColName="cd_dep_employed_count" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="33" Attno="9" ColName="cd_dep_college_count" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
+          </dxl:Result>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/data/dxl/minidump/EquivClassesAndOr.mdp
+++ b/data/dxl/minidump/EquivClassesAndOr.mdp
@@ -344,7 +344,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="576">
+    <dxl:Plan Id="0" SpaceSize="590">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="4.560547" Rows="1.000000" Width="60"/>

--- a/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -865,7 +865,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2350">
+    <dxl:Plan Id="0" SpaceSize="2450">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="274377996915268.812500" Rows="100.000000" Width="128"/>

--- a/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -14557,7 +14557,7 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
         </dxl:LogicalProject>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6408">
+    <dxl:Plan Id="0" SpaceSize="6678">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1858510.030318" Rows="20169.272000" Width="76"/>

--- a/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -446,7 +446,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6280">
+    <dxl:Plan Id="0" SpaceSize="6490">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9.843750" Rows="1.000000" Width="64"/>

--- a/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -358,7 +358,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1272">
+    <dxl:Plan Id="0" SpaceSize="1300">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="4.390625" Rows="1.000000" Width="32"/>

--- a/data/dxl/minidump/HashJoinIsRewindableWhenOuterChildIsRewindable.mdp
+++ b/data/dxl/minidump/HashJoinIsRewindableWhenOuterChildIsRewindable.mdp
@@ -1,0 +1,587 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+CREATE TABLE t1(a int, b int);
+CREATE TABLE t2(c int, d int);
+CREATE TABLE t3(e int, f int);
+
+EXPLAIN SELECT * FROM t1 INNER JOIN (SELECT d+f AS g, * FROM t2 INNER JOIN t3 ON c = f) AS t4 ON b < g;
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1765376.97 rows=1 width=28)
+   ->  Nested Loop  (cost=0.00..1765376.97 rows=1 width=28)
+         Join Filter: t1.b < (t2.d + t3.f)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Table Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Result  (cost=0.00..862.00 rows=1 width=20)
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+                     Hash Cond: t2.c = t3.f
+                     ->  Table Scan on t2  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                 Hash Key: t3.f
+                                 ->  Table Scan on t3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: PQO version 2.55.2
+-->
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
+      <dxl:TraceFlags Value="102002,102003,102073,102074,102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.90162.1.0.1" Name="f" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.90162.1.0.0" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.551.1.0" Name="+" ComparisonType="Other" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.23.1.0"/>
+        <dxl:OpFunc Mdid="0.177.1.0"/>
+        <dxl:Commutator Mdid="0.551.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.90159.1.0" Name="t2" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.90159.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.90156.1.0" Name="t1" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.90156.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.90162.1.0" Name="t3" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.90162.1.0" Name="t3" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="e" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="f" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.7027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.7027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.90159.1.0.1" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.90159.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.90156.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.90156.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="28" ColName="g" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="d" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="19" ColName="e" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="20" ColName="f" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.90156.1.0" TableName="t1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="28" Alias="g">
+              <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                <dxl:Ident ColId="11" ColName="d" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="20" ColName="f" TypeMdid="0.23.1.0"/>
+              </dxl:OpExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.90159.1.0" TableName="t2">
+                <dxl:Columns>
+                  <dxl:Column ColId="10" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.90162.1.0" TableName="t3">
+                <dxl:Columns>
+                  <dxl:Column ColId="19" Attno="1" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="2" ColName="f" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="20" ColName="f" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:LogicalJoin>
+        </dxl:LogicalProject>
+        <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="28" ColName="g" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="41">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1724.001055" Rows="1.000000" Width="28"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="27" Alias="g">
+            <dxl:Ident ColId="27" ColName="g" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="c">
+            <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="d">
+            <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="18" Alias="e">
+            <dxl:Ident ColId="18" ColName="e" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="19" Alias="f">
+            <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000950" Rows="1.000000" Width="28"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="27" Alias="g">
+              <dxl:Ident ColId="27" ColName="g" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="c">
+              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="d">
+              <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="18" Alias="e">
+              <dxl:Ident ColId="18" ColName="e" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="19" Alias="f">
+              <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="27" ColName="g" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="3.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.90156.1.0" TableName="t1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:BroadcastMotion>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000546" Rows="1.000000" Width="20"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="27" Alias="g">
+                <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                  <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                </dxl:OpExpr>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="c">
+                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="d">
+                <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="e">
+                <dxl:Ident ColId="18" ColName="e" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="f">
+                <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000539" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="c">
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="d">
+                  <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="e">
+                  <dxl:Ident ColId="18" ColName="e" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="f">
+                  <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="c">
+                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="d">
+                    <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.90159.1.0" TableName="t2">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="18" Alias="e">
+                    <dxl:Ident ColId="18" ColName="e" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="19" Alias="f">
+                    <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="18" Alias="e">
+                      <dxl:Ident ColId="18" ColName="e" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="f">
+                      <dxl:Ident ColId="19" ColName="f" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.90162.1.0" TableName="t3">
+                    <dxl:Columns>
+                      <dxl:Column ColId="18" Attno="1" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="19" Attno="2" ColName="f" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
+          </dxl:Result>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1410,7 +1410,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10075">
+    <dxl:Plan Id="0" SpaceSize="10525">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="17.551612" Rows="77.229878" Width="16"/>

--- a/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -978,7 +978,7 @@ OR
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="23016">
+    <dxl:Plan Id="0" SpaceSize="22992">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="17244.738281" Rows="521.833333" Width="246"/>

--- a/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
+++ b/data/dxl/minidump/MultiLevel-IN-Subquery.mdp
@@ -683,7 +683,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2701">
+    <dxl:Plan Id="0" SpaceSize="2773">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="244.269531" Rows="999.000000" Width="12"/>

--- a/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
+++ b/data/dxl/minidump/PartTbl-JoinOverExcept.mdp
@@ -1280,7 +1280,7 @@ select * from (select * from p1 except select * from p2) as p, tt where p.b=tt.b
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="216">
+    <dxl:Plan Id="0" SpaceSize="224">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1298.385913" Rows="4000.000000" Width="16"/>

--- a/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
+++ b/data/dxl/minidump/PartTbl-JoinOverIntersect.mdp
@@ -1280,7 +1280,7 @@ select * from (select * from p1 intersect select * from p2) as p, tt where p.b=t
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4038">
+    <dxl:Plan Id="0" SpaceSize="4203">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1301.575209" Rows="10000.000000" Width="16"/>

--- a/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -403,7 +403,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
         </dxl:LogicalJoin>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="59868">
+    <dxl:Plan Id="0" SpaceSize="66728">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.018711" Rows="1.000000" Width="8"/>

--- a/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
+++ b/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE-2.mdp
@@ -1349,7 +1349,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1023">
+    <dxl:Plan Id="0" SpaceSize="1035">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2531098.435121" Rows="5111.442548" Width="246"/>

--- a/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -3255,7 +3255,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="35704">
+    <dxl:Plan Id="0" SpaceSize="38701">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1580699161.203015" Rows="2777513851522853.000000" Width="355"/>

--- a/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -379,7 +379,7 @@
       </dxl:LogicalGroupBy>
     </dxl:Query>
   </dxl:Thread>
-  <dxl:Plan Id="0" SpaceSize="110000">
+  <dxl:Plan Id="0" SpaceSize="111440">
     <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
       <dxl:Properties>
         <dxl:Cost StartupCost="0" TotalCost="67.421875" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
+++ b/data/dxl/minidump/Subq-JoinWithOuterRef.mdp
@@ -414,7 +414,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="80">
+    <dxl:Plan Id="0" SpaceSize="85">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="39.099609" Rows="1.000000" Width="4"/>

--- a/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -511,7 +511,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3386">
+    <dxl:Plan Id="0" SpaceSize="3486">
       <dxl:Limit>
 	<dxl:Properties>
 	  <dxl:Cost StartupCost="0" TotalCost="1724.005373" Rows="10.000000" Width="8"/>

--- a/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -428,7 +428,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="476628">
+    <dxl:Plan Id="0" SpaceSize="492802">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9.230469" Rows="1.000000" Width="8"/>

--- a/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
+++ b/data/dxl/minidump/SubqExists-Without-External-Corrs.mdp
@@ -428,7 +428,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="244760">
+    <dxl:Plan Id="0" SpaceSize="251803">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="18.187988" Rows="1.000000" Width="8"/>

--- a/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -3673,7 +3673,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="273980">
+    <dxl:Plan Id="0" SpaceSize="291817">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="865342008.829724" Rows="10325183.250315" Width="697"/>

--- a/data/dxl/minidump/TPCH-Q5.mdp
+++ b/data/dxl/minidump/TPCH-Q5.mdp
@@ -6497,7 +6497,7 @@
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2274342136">
+    <dxl:Plan Id="0" SpaceSize="2669610492">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3010953415.490394" Rows="25.000000" Width="34"/>

--- a/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -20527,7 +20527,7 @@ select  i_item_id
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3344110">
+    <dxl:Plan Id="0" SpaceSize="3522552">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="52385.226068" Rows="4.196915" Width="127"/>

--- a/data/dxl/minidump/Union-On-HJNs.mdp
+++ b/data/dxl/minidump/Union-On-HJNs.mdp
@@ -486,7 +486,7 @@
         </dxl:LogicalProject>
       </dxl:UnionAll>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3924607896000000">
+    <dxl:Plan Id="0" SpaceSize="4627492789679616">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="54.180489" Rows="2.000000" Width="32"/>

--- a/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/data/dxl/minidump/UnnestSQJoins.mdp
@@ -1265,7 +1265,7 @@ WHERE
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="41322">
+    <dxl:Plan Id="0" SpaceSize="42331">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="43434.041016" Rows="197964.000000" Width="148"/>

--- a/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -202,6 +202,14 @@ namespace gpopt
 				return GPOS_NEW(pmp) COrderSpec(pmp);
 			}
 
+			virtual
+			CRewindabilitySpec *PrsDerive
+				(
+				IMemoryPool *pmp,
+				CExpressionHandle &exprhdl
+				)
+				const;
+
 			//-------------------------------------------------------------------------------------
 			// Enforced Properties
 			//-------------------------------------------------------------------------------------

--- a/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -237,6 +237,28 @@ CPhysicalHashJoin::PrsRequired
 	return PrsPassThru(pmp, exprhdl, prsRequired, 0 /*ulChildIndex*/);
 }
 
+
+CRewindabilitySpec *
+CPhysicalHashJoin::PrsDerive
+	(
+	IMemoryPool * /* pmp */,
+	CExpressionHandle &exprhdl
+	)
+	const
+{
+	CRewindabilitySpec *prsOuter = exprhdl.Pdpplan(0 /*ulChildIndex*/)->Prs();
+	GPOS_ASSERT(NULL != prsOuter);
+
+	// Hash Join is rewindable as long as the outer side is, because the hash
+	// operator implicitly materializes the inner.
+	// Note that the most correct thing here would be to downgrade
+	// ErtMarkRestore to ErtNone, but we won't exercise that code until we
+	// support merge join.
+	prsOuter->AddRef();
+	return prsOuter;
+}
+
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CPhysicalHashJoin::PdsMatch

--- a/libgpopt/src/operators/CPhysicalHashJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalHashJoin.cpp
@@ -241,7 +241,7 @@ CPhysicalHashJoin::PrsRequired
 CRewindabilitySpec *
 CPhysicalHashJoin::PrsDerive
 	(
-	IMemoryPool * /* pmp */,
+	IMemoryPool *,
 	CExpressionHandle &exprhdl
 	)
 	const

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -127,6 +127,9 @@ CastedInClauseWithMCV FilterScalarCast;
 CProjectTest:
 ProjectWithConstant ProjectWithTextConstant ProjectSetFunction;
 
+CHashJoinPropertyTest:
+HashJoinIsRewindableWhenOuterChildIsRewindable;
+
 CPartTbl1Test:
 NoPartConstraint-WhenNoDefaultPartsAndIndices
 PartConstraint-WhenIndicesAndNoDefaultParts PartConstraint-WithOnlyDefaultPartInfo


### PR DESCRIPTION
Its inner child need not be rewindable for a hash join to be rewindable, unlike
a nested loop join. The logic to compute the derived and required properties
were out of sync.  Specifically the logic to derive the rewindablility for a
hash join erraneously reported unrewindable when the inner child was not
rewindable, even though the outer child was. This wasn't wrong logically, but
it led to extraneous physical spool nodes in the plan, which might cause other
issues for us. One such example is that the materialize might end up in between
a partition selector and a Dynamic table scan leading to wrong results.

This commit fixes that issue by simply returning the outer child's
rewindability while deriving the rewindability.

[#154605891]
Signed-off-by: Abhijit Subramanya <asubramanya@pivotal.io>