### PR TITLE
Refactor statistics computation for joins

### DIFF
--- a/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
+++ b/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2018 Pivotal Software, Inc.
+//	Copyright (C) 2018 Pivotal, Inc.
 //
 //	Base Index Apply operator for Inner and Outer Join;
 //	a variant of inner/outer apply that captures the need to implement a

--- a/libgpopt/include/gpopt/operators/CLogicalJoin.h
+++ b/libgpopt/include/gpopt/operators/CLogicalJoin.h
@@ -165,13 +165,13 @@ namespace gpopt
 			// compute required stat columns of the n-th child
 			virtual
 			CColRefSet *PcrsStat
-				(
-				IMemoryPool *pmp,
-				CExpressionHandle &exprhdl,
-				CColRefSet *pcrsInput,
-				ULONG ulChildIndex
-				)
-				const
+					(
+					IMemoryPool *pmp,
+					CExpressionHandle &exprhdl,
+					CColRefSet *pcrsInput,
+					ULONG ulChildIndex
+					)
+					const
 			{
 				const ULONG ulArity = exprhdl.UlArity();
 

--- a/libgpopt/src/operators/CLogicalJoin.cpp
+++ b/libgpopt/src/operators/CLogicalJoin.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2011 EMC Corp.
+//	Copyright (C) 2018 Pivotal, Inc.
 //
 //	@filename:
 //		CLogicalJoin.cpp
@@ -18,7 +18,7 @@
 #include "gpopt/operators/CExpressionHandle.h"
 #include "gpopt/operators/CLogicalJoin.h"
 #include "gpopt/operators/CPredicateUtils.h"
-#include "naucrates/statistics/CStatisticsUtils.h"
+#include "naucrates/statistics/CJoinStatsProcessor.h"
 
 using namespace gpopt;
 
@@ -77,7 +77,7 @@ CLogicalJoin::PstatsDerive
 	)
 	const
 {
-	return CStatisticsUtils::PstatsJoin(pmp, exprhdl, pdrgpstatCtxt);
+	return CJoinStatsProcessor::PstatsJoin(pmp, exprhdl, pdrgpstatCtxt);
 }
 
 // EOF

--- a/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2012 EMC Corp.
+//	Copyright (C) 2018 Pivotal, Inc.
 //
 //	@filename:
 //		CHistogram.h
@@ -121,15 +121,15 @@ namespace gpnaucrates
 
 			static
 			void AddBuckets
-				(
-				IMemoryPool *pmp,
-				DrgPbucket *pdrgppbucketSrc,
-				DrgPbucket *pdrgppbucketDest,
-				CDouble dRows,
-				DrgPdouble *pdrgpdouble,
-				ULONG ulBegin,
-				ULONG ulEnd
-				);
+					(
+					IMemoryPool *pmp,
+					DrgPbucket *pdrgppbucketSrc,
+					DrgPbucket *pdrgppbucketDest,
+					CDouble dRows,
+					DrgPdouble *pdrgpdouble,
+					ULONG ulBegin,
+					ULONG ulEnd
+					);
 
 			// check if we can compute NDVRemain for JOIN histogram for the given input histograms
 			static
@@ -156,14 +156,14 @@ namespace gpnaucrates
 			CHistogram(DrgPbucket *pdrgppbucket, BOOL fWellDefined = true);
 
 			CHistogram
-				(
-				DrgPbucket *pdrgppbucket,
-				BOOL fWellDefined,
-				CDouble dNullFreq,
-				CDouble dDistinctRemain,
-				CDouble dFreqRemain,
-				BOOL fColStatsMissing = false
-				);
+					(
+					DrgPbucket *pdrgppbucket,
+					BOOL fWellDefined,
+					CDouble dNullFreq,
+					CDouble dDistinctRemain,
+					CDouble dFreqRemain,
+					BOOL fColStatsMissing = false
+					);
 
 			// set null frequency
 			void SetNullFrequency(CDouble dNullFreq);
@@ -440,9 +440,9 @@ namespace gpnaucrates
 			static
 			BOOL FSupportsFilter(CStatsPred::EStatsCmpType escmpt);
 
-			// is comparison type supported for joins
+			// is the join predicate's comparison type supported
 			static
-			BOOL FSupportsJoin(CStatsPred::EStatsCmpType escmpt);
+			BOOL FSupportsJoinPred(CStatsPred::EStatsCmpType escmpt);
 
 			// create the default histogram for a given column reference
 			static

--- a/libnaucrates/include/naucrates/statistics/CInnerJoinStatsProcessor.h
+++ b/libnaucrates/include/naucrates/statistics/CInnerJoinStatsProcessor.h
@@ -1,0 +1,37 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CInnerJoinStatsProcessor.h
+//
+//	@doc:
+//		Processor for computing statistics for Inner Join
+//---------------------------------------------------------------------------
+#ifndef GPNAUCRATES_CInnerJoinStatsProcessor_H
+#define GPNAUCRATES_CInnerJoinStatsProcessor_H
+
+#include "naucrates/statistics/CJoinStatsProcessor.h"
+
+
+namespace gpnaucrates
+{
+	class CInnerJoinStatsProcessor : public CJoinStatsProcessor
+	{
+		public:
+			// inner join with another stats structure
+			static
+			CStatistics *PstatsInnerJoinStatic
+					(
+					IMemoryPool *pmp,
+					const IStatistics *pistatsOuter,
+					const IStatistics *pistatsInner,
+					DrgPstatspredjoin *pdrgpstatspredjoin
+					);
+	};
+}
+
+#endif // !GPNAUCRATES_CInnerJoinStatsProcessor_H
+
+// EOF
+

--- a/libnaucrates/include/naucrates/statistics/CJoinStatsProcessor.h
+++ b/libnaucrates/include/naucrates/statistics/CJoinStatsProcessor.h
@@ -1,0 +1,115 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CJoinStatsProcessor.h
+//
+//	@doc:
+//		Compute statistics for all joins
+//---------------------------------------------------------------------------
+#ifndef GPNAUCRATES_CJoinStatsProcessor_H
+#define GPNAUCRATES_CJoinStatsProcessor_H
+
+namespace gpnaucrates
+{
+
+	// Parent class for computing statistics for all joins
+	class CJoinStatsProcessor
+	{
+		protected:
+
+			// return join cardinality based on scaling factor and join type
+			static
+			CDouble DJoinCardinality
+				(
+				 CStatisticsConfig *pstatsconf,
+				 CDouble dRowsLeft,
+				 CDouble dRowsRight,
+				 DrgPdouble *pdrgpd,
+				 IStatistics::EStatsJoinType eStatsJoinType
+				);
+
+
+			// check if the join statistics object is empty output based on the input
+			// histograms and the join histograms
+			static
+			BOOL FEmptyJoinStats
+				(
+				 BOOL fEmptyOuter,
+				 BOOL fEmptyOutput,
+				 const CHistogram *phistOuter,
+				 const CHistogram *phistInner,
+				 CHistogram *phistJoin,
+				 IStatistics::EStatsJoinType eStatsJoinType
+				 );
+
+			// helper for joining histograms
+			static
+			void JoinHistograms
+				(
+				 IMemoryPool *pmp,
+				 const CHistogram *phist1,
+				 const CHistogram *phist2,
+				 CStatsPredJoin *pstatsjoin,
+				 CDouble dRows1,
+				 CDouble dRows2,
+				 CHistogram **pphist1, // output: histogram 1 after join
+				 CHistogram **pphist2, // output: histogram 2 after join
+				 CDouble *pdScaleFactor, // output: scale factor based on the join
+				 BOOL fEmptyInput, // if true, one of the inputs is empty
+				 IStatistics::EStatsJoinType eStatsJoinType,
+				 BOOL fIgnoreLasjHistComputation
+				 );
+
+		public:
+
+			// main driver to generate join stats
+			static
+			CStatistics *PstatsJoinDriver
+				(
+				 IMemoryPool *pmp,
+				 CStatisticsConfig *pstatsconf,
+				 const IStatistics *pistatsOuter,
+				 const IStatistics *pistatsInner,
+				 DrgPstatspredjoin *pdrgpstatspredjoin,
+				 IStatistics::EStatsJoinType eStatsJoinType,
+				 BOOL fIgnoreLasjHistComputation
+				 );
+
+			static
+			IStatistics *PstatsJoinArray
+				(
+				 IMemoryPool *pmp,
+				 DrgPstat *pdrgpstat,
+				 CExpression *pexprScalar,
+				 IStatistics::EStatsJoinType eStatsJoinType
+				 );
+
+			// derive statistics for join operation given array of statistics object
+			static
+			IStatistics *PstatsJoin
+				(
+				 IMemoryPool *pmp,
+				 CExpressionHandle &exprhdl,
+				 DrgPstat *pdrgpstatCtxt
+				 );
+
+			// derive statistics when scalar expression has outer references
+			static
+			IStatistics *PstatsDeriveWithOuterRefs
+				(
+				 IMemoryPool *pmp,
+				 CExpressionHandle &exprhdl, // handle attached to the logical expression we want to derive stats for
+				 CExpression *pexprScalar, // scalar condition used for stats derivation
+				 IStatistics *pstats, // statistics object of attached expression
+				 DrgPstat *pdrgpstatOuter, // array of stats objects where outer references are defined
+				 IStatistics::EStatsJoinType eStatsJoinType
+				 );
+	};
+}
+
+#endif // !GPNAUCRATES_CJoinStatsProcessor_H
+
+// EOF
+

--- a/libnaucrates/include/naucrates/statistics/CLeftAntiSemiJoinStatsProcessor.h
+++ b/libnaucrates/include/naucrates/statistics/CLeftAntiSemiJoinStatsProcessor.h
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CLeftAntiSemiJoinStatsProcessor.h
+//
+//	@doc:
+//		Processor for computing statistics for Left Anti-Semi Join
+//---------------------------------------------------------------------------
+#ifndef GPNAUCRATES_CLeftAntiSemiJoinStatsProcessor_H
+#define GPNAUCRATES_CLeftAntiSemiJoinStatsProcessor_H
+
+#include "naucrates/statistics/CJoinStatsProcessor.h"
+
+
+
+namespace gpnaucrates
+{
+	class CLeftAntiSemiJoinStatsProcessor : public CJoinStatsProcessor
+	{
+		public:
+			// helper for LAS-joining histograms
+			static
+			void JoinHistogramsLASJ
+					(
+					IMemoryPool *pmp,
+					const CHistogram *phist1,
+					const CHistogram *phist2,
+					CStatsPredJoin *pstatsjoin,
+					CDouble dRows1,
+					CDouble dRows2,
+					CHistogram **pphist1, // output: histogram 1 after join
+					CHistogram **pphist2, // output: histogram 2 after join
+					CDouble *pdScaleFactor, // output: scale factor based on the join
+					BOOL fEmptyInput, // if true, one of the inputs is empty
+					IStatistics::EStatsJoinType eStatsJoinType,
+					BOOL fIgnoreLasjHistComputation
+					);
+			// left anti semi join with another stats structure
+			static
+			CStatistics *PstatsLASJoinStatic
+					(
+					IMemoryPool *pmp,
+					const IStatistics *pistatsOuter,
+					const IStatistics *pistatsInner,
+					DrgPstatspredjoin *pdrgpstatspredjoin,
+					BOOL fIgnoreLasjHistComputation // except for the case of LOJ cardinality estimation this flag is always
+					// "true" since LASJ stats computation is very aggressive
+					);
+			// compute the null frequency for LASJ
+			static
+			CDouble DNullFreqLASJ(CStatsPred::EStatsCmpType escmpt, const CHistogram *phistOuter, const CHistogram *phistInner);
+	};
+}
+
+#endif // !GPNAUCRATES_CLeftAntiSemiJoinStatsProcessor_H
+
+// EOF
+

--- a/libnaucrates/include/naucrates/statistics/CLeftOuterJoinStatsProcessor.h
+++ b/libnaucrates/include/naucrates/statistics/CLeftOuterJoinStatsProcessor.h
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CLeftOuterJoinStatsProcessor.h
+//
+//	@doc:
+//		Processor for computing statistics for Left Outer Join
+//---------------------------------------------------------------------------
+#ifndef GPNAUCRATES_CLeftOuterJoinStatsProcessor_H
+#define GPNAUCRATES_CLeftOuterJoinStatsProcessor_H
+
+#include "naucrates/statistics/CJoinStatsProcessor.h"
+
+namespace gpnaucrates
+{
+	class CLeftOuterJoinStatsProcessor : public CJoinStatsProcessor
+	{
+	private:
+		// create a new hash map of histograms from the results of the inner join and the histograms of the outer child
+		static
+		HMUlHist *PhmulhistLOJ
+				(
+				IMemoryPool *pmp,
+				const CStatistics *pstatsOuter,
+				const CStatistics *pstatsInner,
+				CStatistics *pstatsInnerJoin,
+				DrgPstatspredjoin *pdrgpstatspredjoin,
+				CDouble dRowsInnerJoin,
+				CDouble *pdRowsLASJ
+				);
+		// helper method to add histograms of the inner side of a LOJ
+		static
+		void AddHistogramsLOJInner
+				(
+				IMemoryPool *pmp,
+				const CStatistics *pstatsInnerJoin,
+				DrgPul *pdrgpulInnerColId,
+				CDouble dRowsLASJ,
+				CDouble dRowsInnerJoin,
+				HMUlHist *phmulhistLOJ
+				);
+
+	public:
+		static
+		CStatistics *PstatsLOJStatic
+				(
+				IMemoryPool *pmp,
+				const IStatistics *pstatsOuter,
+				const IStatistics *pstatsInner,
+				DrgPstatspredjoin *pdrgpstatspredjoin
+				);
+	};
+}
+
+#endif // !GPNAUCRATES_CLeftOuterJoinStatsProcessor_H
+
+// EOF
+

--- a/libnaucrates/include/naucrates/statistics/CLeftSemiJoinStatsProcessor.h
+++ b/libnaucrates/include/naucrates/statistics/CLeftSemiJoinStatsProcessor.h
@@ -1,0 +1,35 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CLeftSemiJoinStatsProcessor.h
+//
+//	@doc:
+//		Processor for computing statistics for Left Semi Join
+//---------------------------------------------------------------------------
+#ifndef GPNAUCRATES_CLeftSemiJoinStatsProcessor_H
+#define GPNAUCRATES_CLeftSemiJoinStatsProcessor_H
+
+#include "naucrates/statistics/CJoinStatsProcessor.h"
+
+namespace gpnaucrates
+{
+	class CLeftSemiJoinStatsProcessor : public CJoinStatsProcessor
+	{
+		public:
+			static
+			CStatistics *PstatsLSJoinStatic
+					(
+					IMemoryPool *pmp,
+					const IStatistics *pstatsOuter,
+					const IStatistics *pstatsInner,
+					DrgPstatspredjoin *pdrgpstatspredjoin
+					);
+	};
+}
+
+#endif // !GPNAUCRATES_CLeftSemiJoinStatsProcessor_H
+
+// EOF
+

--- a/libnaucrates/include/naucrates/statistics/CStatisticsUtils.h
+++ b/libnaucrates/include/naucrates/statistics/CStatisticsUtils.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright 2012 EMC Corp.
+//	Copyright 2018 Pivotal, Inc.
 //
 //	@filename:
 //		CStatisticsUtils.h
@@ -149,18 +149,6 @@ namespace gpnaucrates
 					CDouble dDistinctTotal,
 					DrgPbucket *pdrgpbucket
 					);
-
-			// helper for deriving statistics for join operation based on given scalar expression
-			static
-			IStatistics *PstatsJoinWithOuterRefs
-				(
-				IMemoryPool *pmp,
-				CExpressionHandle &exprhdl,
-				DrgPstat *pdrgpstatChildren,
-				CExpression *pexprScalarLocal, // filter expression on local columns only
-				CExpression *pexprScalarOuterRefs, // filter expression involving outer references
-				DrgPstat *pdrgpstatOuter
-				);
 
 			// add the NDVs for all of the grouping columns
 			static
@@ -324,17 +312,7 @@ namespace gpnaucrates
 			void PrintHistogramMap(IOstream &os, HMUlHist *phmulhist);
 #endif // GPOS_DEBUG
 
-			// derive statistics when scalar expression has outer references
-			static
-			IStatistics *PstatsDeriveWithOuterRefs
-				(
-				IMemoryPool *pmp,
-				BOOL fOuterJoin, // use outer join semantics for statistics derivation
-				CExpressionHandle &exprhdl, // handle attached to the logical expression we want to derive stats for
-				CExpression *pexprScalar, // scalar condition used for stats derivation
-				IStatistics *pstats, // statistics object of attached expression
-				DrgPstat *pdrgpstatOuter // array of stats objects where outer references are defined
-				);
+
 
 			// derive statistics for filter operation based on given scalar expression
 			static
@@ -347,14 +325,6 @@ namespace gpnaucrates
 				CExpression *pexprScalarOuterRefs, // filter expression involving outer references
 				DrgPstat *pdrgpstatOuter
 				);
-
-			// derive statistics for the given join predicate
-			static
-			IStatistics *PstatsJoinArray(IMemoryPool *pmp, BOOL fOuterJoin, DrgPstat *pdrgpstat, CExpression *pexprScalar);
-
-			// derive statistics for join operation given array of statistics object
-			static
-			IStatistics *PstatsJoin(IMemoryPool *pmp, CExpressionHandle &exprhdl, DrgPstat *pdrgpstatCtxt);
 
 			// derive statistics of dynamic scan based on part-selector stats in the given map
 			static
@@ -436,9 +406,7 @@ namespace gpnaucrates
 							CColRefSet *pcrsGrpColComputed // output set of grouping columns that are computed attributes
 							);
 
-		 	// compute the null frequency for LASJ
-			static
-			CDouble DNullFreqLASJ(CStatsPred::EStatsCmpType escmpt, const CHistogram *phistOuter, const CHistogram *phistInner);
+
 
 			// return the total number of distinct values in the given array of buckets
 			static
@@ -455,6 +423,23 @@ namespace gpnaucrates
 			// return the default column width
 			static
 			CDouble DDefaultColumnWidth(const IMDType *pmdtype);
+
+			// helper method to add width information
+			static
+			void AddWidthInfo(IMemoryPool *pmp, HMUlDouble *phmuldoubleSrc, HMUlDouble *phmuldoubleDest);
+
+
+			// for the output stats object, compute its upper bound cardinality mapping based on the bounding method
+			// estimated output cardinality and information maintained in the current stats object
+			static
+			void ComputeCardUpperBounds
+				(
+				IMemoryPool *pmp, // memory pool
+				const CStatistics *pstatsInput,
+				CStatistics *pstatsOutput, // output statistics object that is to be updated
+				CDouble dRowsOutput, // estimated output cardinality of the operator
+				CStatistics::ECardBoundingMethod ecbm // technique used to estimate max source cardinality in the output stats object
+				);
 
 	}; // class CStatisticsUtils
 

--- a/libnaucrates/include/naucrates/statistics/IStatistics.h
+++ b/libnaucrates/include/naucrates/statistics/IStatistics.h
@@ -1,6 +1,6 @@
-	//---------------------------------------------------------------------------
+//---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2012 EMC Corp.
+//	Copyright (C) 2018 Pivotal, Inc.
 //
 //	@filename:
 //		IStatistics.h
@@ -144,6 +144,12 @@ namespace gpnaucrates
 			// create new statistics structure after applying the filter
 			virtual
 			IStatistics *PstatsFilter(IMemoryPool *, CStatsPred *pstatspred, BOOL fCapNdvs) const = 0;
+
+			virtual
+			HMUlDouble *PHMUlDoubleWidth() const = 0;
+
+			virtual
+			ULONG UlNumberOfPredicates() const = 0;
 
 			// inner join with another stats structure
 			virtual

--- a/libnaucrates/src/statistics/CHistogram.cpp
+++ b/libnaucrates/src/statistics/CHistogram.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------
 //	Greenplum Database
-//	Copyright (C) 2011 EMC Corp.
+//	Copyright (C) 2018 Pivotal, Inc.
 //
 //	@filename:
 //		CHistogram.cpp
@@ -20,6 +20,7 @@
 
 #include "naucrates/statistics/CStatistics.h"
 #include "naucrates/statistics/CStatisticsUtils.h"
+#include "naucrates/statistics/CLeftAntiSemiJoinStatsProcessor.h"
 #include "naucrates/statistics/CScaleFactorUtils.h"
 #include "naucrates/statistics/CHistogramUtils.h"
 
@@ -871,7 +872,7 @@ CHistogram::PhistJoin
 	)
 	const
 {
-	GPOS_ASSERT(FSupportsJoin(escmpt));
+	GPOS_ASSERT(FSupportsJoinPred(escmpt));
 
 	if (CStatsPred::EstatscmptEq == escmpt)
 	{
@@ -973,7 +974,7 @@ CHistogram::PhistLASJ
 		GPOS_DELETE(pbucketCandidate);
 	}
 
-	CDouble dNullFreq = CStatisticsUtils::DNullFreqLASJ(escmpt, this, phist);
+	CDouble dNullFreq = CLeftAntiSemiJoinStatsProcessor::DNullFreqLASJ(escmpt, this, phist);
 
 	return GPOS_NEW(pmp) CHistogram(pdrgppbucketNew, true /*fWellDefined*/, dNullFreq, m_dDistinctRemain, m_dFreqRemain);
 }
@@ -1059,7 +1060,7 @@ CHistogram::FSupportsFilter
 
 // is comparison type supported for join?
 BOOL
-CHistogram::FSupportsJoin
+CHistogram::FSupportsJoinPred
 	(
 	CStatsPred::EStatsCmpType escmpt
 	)

--- a/libnaucrates/src/statistics/CInnerJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CInnerJoinStatsProcessor.cpp
@@ -1,0 +1,44 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CInnerJoinStatsProcessor.cpp
+//
+//	@doc:
+//		Statistics helper routines for processing Inner Joins
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/ops.h"
+#include "naucrates/statistics/CInnerJoinStatsProcessor.h"
+
+using namespace gpmd;
+
+// return statistics object after performing inner join
+CStatistics *
+CInnerJoinStatsProcessor::PstatsInnerJoinStatic
+			(
+			IMemoryPool *pmp,
+			const IStatistics *pistatsOuter,
+			const IStatistics *pistatsInner,
+			DrgPstatspredjoin *pdrgpstatspredjoin
+			)
+{
+	GPOS_ASSERT(NULL != pistatsOuter);
+	GPOS_ASSERT(NULL != pistatsInner);
+	GPOS_ASSERT(NULL != pdrgpstatspredjoin);
+	const CStatistics *pstatsOuter = dynamic_cast<const CStatistics *> (pistatsOuter);
+
+	return CJoinStatsProcessor::PstatsJoinDriver
+			(
+			pmp,
+			pstatsOuter->PStatsConf(),
+			pistatsOuter,
+			pistatsInner,
+			pdrgpstatspredjoin,
+			IStatistics::EsjtInnerJoin,
+			true /* fIgnoreLasjHistComputation */
+			);
+}
+
+// EOF

--- a/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -1,0 +1,611 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CJoinStatsProcessor.cpp
+//
+//	@doc:
+//		Statistics helper routines for processing all join types
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/ops.h"
+#include "gpopt/optimizer/COptimizerConfig.h"
+
+#include "naucrates/statistics/CStatisticsUtils.h"
+#include "naucrates/statistics/CJoinStatsProcessor.h"
+#include "naucrates/statistics/CLeftAntiSemiJoinStatsProcessor.h"
+#include "naucrates/statistics/CScaleFactorUtils.h"
+
+using namespace gpopt;
+
+// helper for joining histograms
+void
+CJoinStatsProcessor::JoinHistograms
+			(
+			IMemoryPool *pmp,
+			const CHistogram *phist1,
+			const CHistogram *phist2,
+			CStatsPredJoin *pstatsjoin,
+			CDouble dRows1,
+			CDouble dRows2,
+			CHistogram **pphist1, // output: histogram 1 after join
+			CHistogram **pphist2, // output: histogram 2 after join
+			CDouble *pdScaleFactor, // output: scale factor based on the join
+			BOOL fEmptyInput,
+			IStatistics::EStatsJoinType eStatsJoinType,
+			BOOL fIgnoreLasjHistComputation
+			)
+{
+	GPOS_ASSERT(NULL != phist1);
+	GPOS_ASSERT(NULL != phist2);
+	GPOS_ASSERT(NULL != pstatsjoin);
+	GPOS_ASSERT(NULL != pphist1);
+	GPOS_ASSERT(NULL != pphist2);
+	GPOS_ASSERT(NULL != pdScaleFactor);
+
+	if (IStatistics::EsjtLeftAntiSemiJoin == eStatsJoinType)
+	{
+		CLeftAntiSemiJoinStatsProcessor::JoinHistogramsLASJ
+				(
+				pmp,
+				phist1,
+				phist2,
+				pstatsjoin,
+				dRows1,
+				dRows2,
+				pphist1,
+				pphist2,
+				pdScaleFactor,
+				fEmptyInput,
+				eStatsJoinType,
+				fIgnoreLasjHistComputation
+				);
+
+		return;
+	}
+
+	if (fEmptyInput)
+	{
+		// use Cartesian product as scale factor
+		*pdScaleFactor = dRows1 * dRows2;
+		*pphist1 =  GPOS_NEW(pmp) CHistogram(GPOS_NEW(pmp) DrgPbucket(pmp));
+		*pphist2 =  GPOS_NEW(pmp) CHistogram(GPOS_NEW(pmp) DrgPbucket(pmp));
+
+		return;
+	}
+
+	*pdScaleFactor = CScaleFactorUtils::DDefaultScaleFactorJoin;
+
+	CStatsPred::EStatsCmpType escmpt = pstatsjoin->Escmpt();
+	BOOL fEmptyHistograms = phist1->FEmpty() || phist2->FEmpty();
+
+	if (fEmptyHistograms)
+	{
+		// if one more input has no histograms (due to lack of statistics
+		// for table columns or computed columns), we estimate
+		// the join cardinality to be the max of the two rows.
+		// In other words, the scale factor is equivalent to the
+		// min of the two rows.
+		*pdScaleFactor = std::min(dRows1, dRows2);
+	}
+	else if (CHistogram::FSupportsJoinPred(escmpt))
+	{
+		CHistogram *phistJoin = phist1->PhistJoinNormalized
+				(
+				pmp,
+				escmpt,
+				dRows1,
+				phist2,
+				dRows2,
+				pdScaleFactor
+				);
+
+		if (CStatsPred::EstatscmptEq == escmpt || CStatsPred::EstatscmptINDF == escmpt)
+		{
+			if (phist1->FScaledNDV())
+			{
+				phistJoin->SetNDVScaled();
+			}
+			*pphist1 = phistJoin;
+			*pphist2 = (*pphist1)->PhistCopy(pmp);
+			if (phist2->FScaledNDV())
+			{
+				(*pphist2)->SetNDVScaled();
+			}
+			return;
+		}
+
+		// note that for IDF and Not Equality predicate, we do not generate histograms but
+		// just the scale factors.
+
+		GPOS_ASSERT(phistJoin->FEmpty());
+		GPOS_DELETE(phistJoin);
+
+		// TODO:  Feb 21 2014, for all join condition except for "=" join predicate
+		// we currently do not compute new histograms for the join columns
+	}
+
+	// for an unsupported join predicate operator or in the case of
+	// missing histograms, copy input histograms and use default scale factor
+	*pphist1 = phist1->PhistCopy(pmp);
+	*pphist2 = phist2->PhistCopy(pmp);
+}
+
+//	derive statistics for the given join's predicate(s)
+IStatistics *
+CJoinStatsProcessor::PstatsJoinArray
+		(
+		IMemoryPool *pmp,
+		DrgPstat *pdrgpstat,
+		CExpression *pexprScalar,
+		IStatistics::EStatsJoinType eStatsJoinType
+		)
+{
+	GPOS_ASSERT(NULL != pexprScalar);
+	GPOS_ASSERT(NULL != pdrgpstat);
+	GPOS_ASSERT(0 < pdrgpstat->UlLength());
+	BOOL fLeftOuterJoin = IStatistics::EsjtLeftOuterJoin == eStatsJoinType;
+	GPOS_ASSERT_IMP(fLeftOuterJoin, 2 == pdrgpstat->UlLength());
+
+
+	// create an empty set of outer references for statistics derivation
+	CColRefSet *pcrsOuterRefs = GPOS_NEW(pmp) CColRefSet(pmp);
+
+	// join statistics objects one by one using relevant predicates in given scalar expression
+	const ULONG ulStats = pdrgpstat->UlLength();
+	IStatistics *pstats = (*pdrgpstat)[0]->PstatsCopy(pmp);
+	CDouble dRowsOuter = pstats->DRows();
+
+	for (ULONG ul = 1; ul < ulStats; ul++)
+	{
+		IStatistics *pstatsCurrent = (*pdrgpstat)[ul];
+
+		DrgPcrs *pdrgpcrsOutput= GPOS_NEW(pmp) DrgPcrs(pmp);
+		pdrgpcrsOutput->Append(pstats->Pcrs(pmp));
+		pdrgpcrsOutput->Append(pstatsCurrent->Pcrs(pmp));
+
+		CStatsPred *pstatspredUnsupported = NULL;
+		DrgPstatspredjoin *pdrgpstatspredjoin = CStatsPredUtils::PdrgpstatspredjoinExtract
+				(
+						pmp,
+						pexprScalar,
+						pdrgpcrsOutput,
+						pcrsOuterRefs,
+						&pstatspredUnsupported
+				);
+		IStatistics *pstatsNew = NULL;
+		if (fLeftOuterJoin)
+		{
+			pstatsNew = pstats->PstatsLOJ(pmp, pstatsCurrent, pdrgpstatspredjoin);
+		}
+		else
+		{
+			pstatsNew = pstats->PstatsInnerJoin(pmp, pstatsCurrent, pdrgpstatspredjoin);
+		}
+		pstats->Release();
+		pstats = pstatsNew;
+
+		if (NULL != pstatspredUnsupported)
+		{
+			// apply the unsupported join filters as a filter on top of the join results.
+			// TODO,  June 13 2014 we currently only cap NDVs for filters
+			// immediately on top of tables.
+			IStatistics *pstatsAfterJoinFilter = pstats->PstatsFilter
+					(
+							pmp,
+							pstatspredUnsupported,
+							false /* fCapNdvs */
+					);
+
+			// If it is outer join and the cardinality after applying the unsupported join
+			// filters is less than the cardinality of outer child, we don't use this stats.
+			// Because we need to make sure that Card(LOJ) >= Card(Outer child of LOJ).
+			if (fLeftOuterJoin && pstatsAfterJoinFilter->DRows() < dRowsOuter)
+			{
+				pstatsAfterJoinFilter->Release();
+			}
+			else
+			{
+				pstats->Release();
+				pstats = pstatsAfterJoinFilter;
+			}
+
+			pstatspredUnsupported->Release();
+		}
+
+		pdrgpstatspredjoin->Release();
+		pdrgpcrsOutput->Release();
+	}
+
+	// clean up
+	pcrsOuterRefs->Release();
+
+	return pstats;
+}
+
+
+// main driver to generate join stats
+CStatistics *
+CJoinStatsProcessor::PstatsJoinDriver
+		(
+		IMemoryPool *pmp,
+		CStatisticsConfig *pstatsconf,
+		const IStatistics *pistatsOuter,
+		const IStatistics *pistatsInner,
+		DrgPstatspredjoin *pdrgppredInfo,
+		IStatistics::EStatsJoinType eStatsJoinType,
+		BOOL fIgnoreLasjHistComputation
+		)
+{
+	GPOS_ASSERT(NULL != pmp);
+	GPOS_ASSERT(NULL != pistatsInner);
+	GPOS_ASSERT(NULL != pistatsOuter);
+
+	GPOS_ASSERT(NULL != pdrgppredInfo);
+
+	BOOL fLASJ = (IStatistics::EsjtLeftAntiSemiJoin == eStatsJoinType);
+	BOOL fSemiJoin = IStatistics::FSemiJoin(eStatsJoinType);
+
+	// Extract stat objects for inner and outer child.
+	// Historically, IStatistics was meant to have multiple derived classes
+	// However, currently only CStatistics implements IStatistics
+	// Until this changes, the interfaces have been designed to take IStatistics as parameters
+	// In the future, IStatistics should be removed, as it is not being utilized as designed
+	const CStatistics *pstatsOuter = dynamic_cast<const CStatistics *> (pistatsOuter);
+	const CStatistics *pstatsInner = dynamic_cast<const CStatistics *> (pistatsInner);
+
+	// create hash map from colid -> histogram for resultant structure
+	HMUlHist *phmulhistJoin = GPOS_NEW(pmp) HMUlHist(pmp);
+
+	// build a bitset with all join columns
+	CBitSet *pbsJoinColIds = GPOS_NEW(pmp) CBitSet(pmp);
+	for (ULONG ul = 0; ul < pdrgppredInfo->UlLength(); ul++)
+	{
+		CStatsPredJoin *pstatsjoin = (*pdrgppredInfo)[ul];
+
+		(void) pbsJoinColIds->FExchangeSet(pstatsjoin->UlColId1());
+		if (!fSemiJoin)
+		{
+			(void) pbsJoinColIds->FExchangeSet(pstatsjoin->UlColId2());
+		}
+	}
+
+	// histograms on columns that do not appear in join condition will
+	// be copied over to the result structure
+	pstatsOuter->AddNotExcludedHistograms(pmp, pbsJoinColIds, phmulhistJoin);
+	if (!fSemiJoin)
+	{
+		pstatsInner->AddNotExcludedHistograms(pmp, pbsJoinColIds, phmulhistJoin);
+	}
+
+	DrgPdouble *pdrgpd = GPOS_NEW(pmp) DrgPdouble(pmp);
+	const ULONG ulJoinConds = pdrgppredInfo->UlLength();
+
+	BOOL fEmptyOutput = false;
+	CDouble dRowsJoin = 0;
+	// iterate over join's predicate(s)
+	for (ULONG ul = 0; ul < ulJoinConds; ul++)
+	{
+		CStatsPredJoin *ppredInfo = (*pdrgppredInfo)[ul];
+		ULONG ulColId1 = ppredInfo->UlColId1();
+		ULONG ulColId2 = ppredInfo->UlColId2();
+		GPOS_ASSERT(ulColId1 != ulColId2);
+		// find the histograms corresponding to the two columns
+		const CHistogram *phistOuter = pstatsOuter->Phist(ulColId1);
+		// are column id1 and 2 always in the order of outer inner?
+		const CHistogram *phistInner = pstatsInner->Phist(ulColId2);
+		GPOS_ASSERT(NULL != phistOuter);
+		GPOS_ASSERT(NULL != phistInner);
+		BOOL fEmptyInput = CStatistics::FEmptyJoinInput(pstatsOuter, pstatsInner, fLASJ);
+
+		CDouble dScaleFactorLocal(1.0);
+		CHistogram *phistOuterAfter = NULL;
+		CHistogram *phistInnerAfter = NULL;
+		JoinHistograms
+				(
+						pmp,
+						phistOuter,
+						phistInner,
+						ppredInfo,
+						pstatsOuter->DRows(),
+						pstatsInner->DRows(),
+						&phistOuterAfter,
+						&phistInnerAfter,
+						&dScaleFactorLocal,
+						fEmptyInput,
+						eStatsJoinType,
+						fIgnoreLasjHistComputation
+				);
+
+		fEmptyOutput = FEmptyJoinStats(pstatsOuter->FEmpty(), fEmptyOutput, phistOuter, phistInner, phistOuterAfter, eStatsJoinType);
+
+		CStatisticsUtils::AddHistogram(pmp, ulColId1, phistOuterAfter, phmulhistJoin);
+		if (!fSemiJoin)
+		{
+			CStatisticsUtils::AddHistogram(pmp, ulColId2, phistInnerAfter, phmulhistJoin);
+		}
+		GPOS_DELETE(phistOuterAfter);
+		GPOS_DELETE(phistInnerAfter);
+
+		pdrgpd->Append(GPOS_NEW(pmp) CDouble(dScaleFactorLocal));
+	}
+
+
+	dRowsJoin = CStatistics::DMinRows;
+	if (!fEmptyOutput)
+	{
+		dRowsJoin = DJoinCardinality(pstatsconf, pstatsOuter->DRows(), pstatsInner->DRows(), pdrgpd, eStatsJoinType);
+	}
+
+	// clean up
+	pdrgpd->Release();
+	pbsJoinColIds->Release();
+
+	HMUlDouble *phmuldoubleWidthResult = GPOS_NEW(pmp) HMUlDouble(pmp);
+	CStatisticsUtils::AddWidthInfo(pmp, pstatsOuter->PHMUlDoubleWidth(), phmuldoubleWidthResult);
+	if (!fSemiJoin)
+	{
+		CStatisticsUtils::AddWidthInfo(pmp, pstatsInner->PHMUlDoubleWidth(), phmuldoubleWidthResult);
+	}
+
+	// create an output stats object
+	CStatistics *pstatsJoin = GPOS_NEW(pmp) CStatistics
+			(
+					pmp,
+					phmulhistJoin,
+					phmuldoubleWidthResult,
+					dRowsJoin,
+					fEmptyOutput,
+					pstatsOuter->UlNumberOfPredicates()
+			);
+
+	// In the output statistics object, the upper bound source cardinality of the join column
+	// cannot be greater than the upper bound source cardinality information maintained in the input
+	// statistics object. Therefore we choose CStatistics::EcbmMin the bounding method which takes
+	// the minimum of the cardinality upper bound of the source column (in the input hash map)
+	// and estimated join cardinality.
+
+	CStatisticsUtils::ComputeCardUpperBounds(pmp, pstatsOuter, pstatsJoin, dRowsJoin, CStatistics::EcbmMin /* ecbm */);
+	if (!fSemiJoin)
+	{
+		CStatisticsUtils::ComputeCardUpperBounds(pmp, pstatsInner, pstatsJoin, dRowsJoin, CStatistics::EcbmMin /* ecbm */);
+	}
+
+		return pstatsJoin;
+}
+
+
+// return join cardinality based on scaling factor and join type
+CDouble
+CJoinStatsProcessor::DJoinCardinality
+		(
+		CStatisticsConfig *pstatsconf,
+		CDouble dRowsLeft,
+		CDouble dRowsRight,
+		DrgPdouble *pdrgpd,
+		IStatistics::EStatsJoinType eStatsJoinType
+		)
+{
+	GPOS_ASSERT(NULL != pstatsconf);
+	GPOS_ASSERT(NULL != pdrgpd);
+
+	CDouble dScaleFactor = CScaleFactorUtils::DCumulativeJoinScaleFactor(pstatsconf, pdrgpd);
+	CDouble dCartesianProduct = dRowsLeft * dRowsRight;
+
+	if (IStatistics::EsjtLeftAntiSemiJoin == eStatsJoinType || IStatistics::EsjtLeftSemiJoin == eStatsJoinType)
+	{
+		CDouble dRows = dRowsLeft;
+
+		if (IStatistics::EsjtLeftAntiSemiJoin == eStatsJoinType)
+		{
+			dRows = dRowsLeft / dScaleFactor;
+		}
+		else
+		{
+			// semi join results cannot exceed size of outer side
+			dRows = std::min(dRowsLeft.DVal(), (dCartesianProduct / dScaleFactor).DVal());
+		}
+
+		return std::max(DOUBLE(1.0), dRows.DVal());
+	}
+
+	GPOS_ASSERT(CStatistics::DMinRows <= dScaleFactor);
+
+	return std::max(CStatistics::DMinRows.DVal(), (dCartesianProduct / dScaleFactor).DVal());
+}
+
+
+
+// check if the join statistics object is empty output based on the input
+// histograms and the join histograms
+BOOL
+CJoinStatsProcessor::FEmptyJoinStats
+		(
+		BOOL fEmptyOuter,
+		BOOL fEmptyOutput,
+		const CHistogram *phistOuter,
+		const CHistogram *phistInner,
+		CHistogram *phistJoin,
+		IStatistics::EStatsJoinType eStatsJoinType
+		)
+{
+	GPOS_ASSERT(NULL != phistOuter);
+	GPOS_ASSERT(NULL != phistInner);
+	GPOS_ASSERT(NULL != phistJoin);
+	BOOL fLASJ = IStatistics::EsjtLeftAntiSemiJoin == eStatsJoinType;
+	return fEmptyOutput ||
+		   (!fLASJ && fEmptyOuter) ||
+		   (!phistOuter->FEmpty() && !phistInner->FEmpty() && phistJoin->FEmpty());
+}
+
+// Derive statistics for join operation given array of statistics object
+IStatistics *
+CJoinStatsProcessor::PstatsJoin
+		(
+		IMemoryPool *pmp,
+		CExpressionHandle &exprhdl,
+		DrgPstat *pdrgpstatCtxt
+		)
+{
+	GPOS_ASSERT(CLogical::EspNone < CLogical::PopConvert(exprhdl.Pop())->Esp(exprhdl));
+
+	DrgPstat *pdrgpstat = GPOS_NEW(pmp) DrgPstat(pmp);
+	const ULONG ulArity = exprhdl.UlArity();
+	for (ULONG ul = 0; ul < ulArity - 1; ul++)
+	{
+		IStatistics *pstatsChild = exprhdl.Pstats(ul);
+		pstatsChild->AddRef();
+		pdrgpstat->Append(pstatsChild);
+	}
+
+	CExpression *pexprJoinPred = NULL;
+	if (exprhdl.Pdpscalar(ulArity - 1)->FHasSubquery())
+	{
+		// in case of subquery in join predicate, assume join condition is True
+		pexprJoinPred = CUtils::PexprScalarConstBool(pmp, true /*fVal*/);
+	}
+	else
+	{
+		// remove implied predicates from join condition to avoid cardinality under-estimation
+		pexprJoinPred = CPredicateUtils::PexprRemoveImpliedConjuncts(pmp, exprhdl.PexprScalarChild(ulArity - 1), exprhdl);
+	}
+
+	// split join predicate into local predicate and predicate involving outer references
+	CExpression *pexprLocal = NULL;
+	CExpression *pexprOuterRefs = NULL;
+
+	// get outer references from expression handle
+	CColRefSet *pcrsOuter = exprhdl.Pdprel()->PcrsOuter();
+
+	CPredicateUtils::SeparateOuterRefs(pmp, pexprJoinPred, pcrsOuter, &pexprLocal, &pexprOuterRefs);
+	pexprJoinPred->Release();
+
+	COperator::EOperatorId eopid = exprhdl.Pop()->Eopid();
+	GPOS_ASSERT(COperator::EopLogicalLeftOuterJoin == eopid ||
+				COperator::EopLogicalInnerJoin == eopid ||
+				COperator::EopLogicalNAryJoin == eopid);
+
+	// we use Inner Join semantics here except in the case of Left Outer Join
+	IStatistics::EStatsJoinType eStatsJoinType = IStatistics::EsjtInnerJoin;
+	if (COperator::EopLogicalLeftOuterJoin == eopid)
+	{
+		eStatsJoinType = IStatistics::EsjtLeftOuterJoin;
+	}
+
+	// derive stats based on local join condition
+	IStatistics *pstatsJoin = CJoinStatsProcessor::PstatsJoinArray(pmp, pdrgpstat, pexprLocal, eStatsJoinType);
+
+	if (exprhdl.FHasOuterRefs() && 0 < pdrgpstatCtxt->UlLength())
+	{
+		// derive stats based on outer references
+		IStatistics *pstats = PstatsDeriveWithOuterRefs(pmp, exprhdl, pexprOuterRefs, pstatsJoin, pdrgpstatCtxt, eStatsJoinType);
+		pstatsJoin->Release();
+		pstatsJoin = pstats;
+	}
+
+	pexprLocal->Release();
+	pexprOuterRefs->Release();
+
+	pdrgpstat->Release();
+
+	return pstatsJoin;
+}
+
+
+// Derives statistics when the scalar expression contains one or more outer references.
+// This stats derivation mechanism passes around a context array onto which
+// operators append their stats objects as they get derived. The context array is
+// filled as we derive stats on the children of a given operator. This gives each
+// operator access to the stats objects of its previous siblings as well as to the outer
+// operators in higher levels.
+// For example, in this expression:
+//
+// JOIN
+//   |--Get(R)
+//   +--Select(R.r=S.s)
+//       +-- Get(S)
+//
+// We start by deriving stats on JOIN's left child (Get(R)) and append its
+// stats to the context. Then, we call stats derivation on JOIN's right child
+// (SELECT), passing it the current context.  This gives SELECT access to the
+// histogram on column R.r--which is an outer reference in this example. After
+// JOIN's children's stats are computed, JOIN combines them into a parent stats
+// object, which is passed upwards to JOIN's parent. This mechanism gives any
+// operator access to the histograms of outer references defined anywhere in
+// the logical tree. For example, we also support the case where outer
+// reference R.r is defined two levels upwards:
+//
+//    JOIN
+//      |---Get(R)
+//      +--JOIN
+//         |--Get(T)
+//         +--Select(R.r=S.s)
+//               +--Get(S)
+//
+//
+//
+// The next step is to combine the statistics objects of the outer references
+// with those of the local columns. You can think of this as a correlated
+// expression, where for each outer tuple, we need to extract the outer ref
+// value and re-execute the inner expression using the current outer ref value.
+// This has the same semantics as a Join from a statistics perspective.
+//
+// We pull statistics for outer references from the passed statistics context,
+// using Join statistics derivation in this case.
+//
+// For example:
+//
+// 			Join
+// 			 |--Get(R)
+// 			 +--Join
+// 				|--Get(S)
+// 				+--Select(T.t=R.r)
+// 					+--Get(T)
+//
+// when deriving statistics on 'Select(T.t=R.r)', we join T with the cross
+// product (R x S) based on the condition (T.t=R.r)
+IStatistics *
+CJoinStatsProcessor::PstatsDeriveWithOuterRefs
+		(
+		IMemoryPool *pmp,
+		CExpressionHandle &
+#ifdef GPOS_DEBUG
+		exprhdl // handle attached to the logical expression we want to derive stats for
+#endif // GPOS_DEBUG
+,
+		CExpression *pexprScalar, // scalar condition to be used for stats derivation
+		IStatistics *pstats, // statistics object of the attached expression
+		DrgPstat *pdrgpstatOuter, // array of stats objects where outer references are defined
+		IStatistics::EStatsJoinType eStatsJoinType
+		)
+{
+	GPOS_ASSERT(exprhdl.FHasOuterRefs() && "attached expression does not have outer references");
+	GPOS_ASSERT(NULL != pexprScalar);
+	GPOS_ASSERT(NULL != pstats);
+	GPOS_ASSERT(NULL != pdrgpstatOuter);
+	GPOS_ASSERT(0 < pdrgpstatOuter->UlLength());
+	GPOS_ASSERT(IStatistics::EstiSentinel != eStatsJoinType);
+
+	// join outer stats object based on given scalar expression,
+	// we use inner join semantics here to consider all relevant combinations of outer tuples
+	IStatistics *pstatsOuter = CJoinStatsProcessor::PstatsJoinArray(pmp, pdrgpstatOuter, pexprScalar, IStatistics::EsjtInnerJoin);
+	CDouble dRowsOuter = pstatsOuter->DRows();
+
+	// join passed stats object and outer stats based on the passed join type
+	DrgPstat *pdrgpstat = GPOS_NEW(pmp) DrgPstat(pmp);
+	pdrgpstat->Append(pstatsOuter);
+	pstats->AddRef();
+	pdrgpstat->Append(pstats);
+	IStatistics *pstatsJoined = CJoinStatsProcessor::PstatsJoinArray(pmp, pdrgpstat, pexprScalar, eStatsJoinType);
+	pdrgpstat->Release();
+
+	// scale result using cardinality of outer stats and set number of rebinds of returned stats
+	IStatistics *pstatsResult = pstatsJoined->PstatsScale(pmp, CDouble(1.0/dRowsOuter));
+	pstatsResult->SetRebinds(dRowsOuter);
+	pstatsJoined->Release();
+
+	return pstatsResult;
+}
+
+// EOF

--- a/libnaucrates/src/statistics/CLeftAntiSemiJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CLeftAntiSemiJoinStatsProcessor.cpp
@@ -1,0 +1,146 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CLeftAntiSemiJoinStatsProcessor.cpp
+//
+//	@doc:
+//		Statistics helper routines for processing Left Anti-Semi Join
+//---------------------------------------------------------------------------
+
+#include "naucrates/statistics/CStatisticsUtils.h"
+#include "naucrates/statistics/CLeftAntiSemiJoinStatsProcessor.h"
+#include "naucrates/statistics/CScaleFactorUtils.h"
+
+using namespace gpmd;
+
+// helper for LAS-joining histograms
+void
+CLeftAntiSemiJoinStatsProcessor::JoinHistogramsLASJ
+			(
+			IMemoryPool *pmp,
+			const CHistogram *phist1,
+			const CHistogram *phist2,
+			CStatsPredJoin *pstatsjoin,
+			CDouble dRows1,
+			CDouble ,//dRows2,
+			CHistogram **pphist1, // output: histogram 1 after join
+			CHistogram **pphist2, // output: histogram 2 after join
+			CDouble *pdScaleFactor, // output: scale factor based on the join
+			BOOL fEmptyInput,
+			IStatistics::EStatsJoinType,
+			BOOL fIgnoreLasjHistComputation
+			)
+{
+	GPOS_ASSERT(NULL != phist1);
+	GPOS_ASSERT(NULL != phist2);
+	GPOS_ASSERT(NULL != pstatsjoin);
+	GPOS_ASSERT(NULL != pphist1);
+	GPOS_ASSERT(NULL != pphist2);
+	GPOS_ASSERT(NULL != pdScaleFactor);
+
+	// anti-semi join should give the full outer side.
+	// use 1.0 as scale factor if anti semi join
+	*pdScaleFactor = 1.0;
+
+	CStatsPred::EStatsCmpType escmpt = pstatsjoin->Escmpt();
+
+	if (fEmptyInput)
+	{
+		*pphist1 = phist1->PhistCopy(pmp);
+		*pphist2 = NULL;
+
+		return;
+	}
+
+	BOOL fEmptyHistograms = phist1->FEmpty() || phist2->FEmpty();
+	if (!fEmptyHistograms && CHistogram::FSupportsJoinPred(escmpt))
+	{
+		*pphist1 = phist1->PhistLASJoinNormalized
+				(
+				pmp,
+				escmpt,
+				dRows1,
+				phist2,
+				pdScaleFactor,
+				fIgnoreLasjHistComputation
+				);
+		*pphist2 = NULL;
+
+		if ((*pphist1)->FEmpty())
+		{
+			// if the LASJ histograms is empty then all tuples of the outer join column
+			// joined with those on the inner side. That is, LASJ will produce no rows
+			*pdScaleFactor = dRows1;
+		}
+
+		return;
+	}
+
+	// for an unsupported join predicate operator or in the case of missing stats,
+	// copy input histograms and use default scale factor
+	*pdScaleFactor = CDouble(CScaleFactorUtils::DDefaultScaleFactorJoin);
+	*pphist1 = phist1->PhistCopy(pmp);
+	*pphist2 = NULL;
+}
+
+//	Return statistics object after performing LASJ
+CStatistics *
+CLeftAntiSemiJoinStatsProcessor::PstatsLASJoinStatic
+		(
+		IMemoryPool *pmp,
+		const IStatistics *pistatsOuter,
+		const IStatistics *pistatsInner,
+		DrgPstatspredjoin *pdrgpstatspredjoin,
+		BOOL fIgnoreLasjHistComputation
+		)
+{
+	GPOS_ASSERT(NULL != pistatsInner);
+	GPOS_ASSERT(NULL != pistatsOuter);
+	GPOS_ASSERT(NULL != pdrgpstatspredjoin);
+	const CStatistics *pstatsOuter = dynamic_cast<const CStatistics *> (pistatsOuter);
+
+	return CJoinStatsProcessor::PstatsJoinDriver
+			(
+			pmp,
+			pstatsOuter->PStatsConf(),
+			pistatsOuter,
+			pistatsInner,
+			pdrgpstatspredjoin,
+			IStatistics::EsjtLeftAntiSemiJoin /* esjt */,
+			fIgnoreLasjHistComputation
+			);
+}
+
+// Compute the null frequency for LASJ
+CDouble
+CLeftAntiSemiJoinStatsProcessor::DNullFreqLASJ
+		(
+		CStatsPred::EStatsCmpType escmpt,
+		const CHistogram *phistOuter,
+		const CHistogram *phistInner
+		)
+{
+	GPOS_ASSERT(NULL != phistOuter);
+	GPOS_ASSERT(NULL != phistInner);
+
+	if (CStatsPred::EstatscmptINDF != escmpt)
+	{
+		// for equality predicate NULLs on the outer side of the join
+		// will not join with those in the inner side
+		return phistOuter->DNullFreq();
+	}
+
+	if (CStatistics::DEpsilon < phistInner->DNullFreq())
+	{
+		// for INDF predicate NULLs on the outer side of the join
+		// will join with those in the inner side if they are present
+		return CDouble(0.0);
+	}
+
+	return phistOuter->DNullFreq();
+}
+
+
+// EOF

--- a/libnaucrates/src/statistics/CLeftOuterJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CLeftOuterJoinStatsProcessor.cpp
@@ -1,0 +1,221 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CLeftOuterJoinStatsProcessor.cpp
+//
+//	@doc:
+//		Statistics helper routines for processing Left Outer Joins
+//---------------------------------------------------------------------------
+
+#include "naucrates/statistics/CStatisticsUtils.h"
+#include "naucrates/statistics/CLeftOuterJoinStatsProcessor.h"
+
+using namespace gpmd;
+
+// return statistics object after performing LOJ operation with another statistics structure
+CStatistics *
+CLeftOuterJoinStatsProcessor::PstatsLOJStatic
+		(
+		IMemoryPool *pmp,
+		const IStatistics *pstatsOuter,
+		const IStatistics *pstatsInner,
+		DrgPstatspredjoin *pdrgpstatspredjoin
+		)
+{
+	GPOS_ASSERT(NULL != pstatsOuter);
+	GPOS_ASSERT(NULL != pstatsInner);
+	GPOS_ASSERT(NULL != pdrgpstatspredjoin);
+
+	const CStatistics *pstatsOuterSide = dynamic_cast<const CStatistics *> (pstatsOuter);
+	const CStatistics *pstatsInnerSide = dynamic_cast<const CStatistics *> (pstatsInner);
+
+	CStatistics *pstatsInnerJoin = pstatsOuterSide->PstatsInnerJoin(pmp, pstatsInner, pdrgpstatspredjoin);
+	CDouble dRowsInnerJoin = pstatsInnerJoin->DRows();
+	CDouble dRowsLASJ(1.0);
+
+	// create a new hash map of histograms, for each column from the outer child
+	// add the buckets that do not contribute to the inner join
+	HMUlHist *phmulhistLOJ = CLeftOuterJoinStatsProcessor::PhmulhistLOJ
+			(
+			pmp,
+			pstatsOuterSide,
+			pstatsInnerSide,
+			pstatsInnerJoin,
+			pdrgpstatspredjoin,
+			dRowsInnerJoin,
+			&dRowsLASJ
+			);
+
+	HMUlDouble *phmuldoubleWidth = GPOS_NEW(pmp) HMUlDouble(pmp);
+	CStatisticsUtils::AddWidthInfo(pmp, pstatsInnerJoin->PHMUlDoubleWidth(), phmuldoubleWidth);
+
+	pstatsInnerJoin->Release();
+
+	// cardinality of LOJ is at least the cardinality of the outer child
+	CDouble dRowsLOJ = std::max(pstatsOuter->DRows(), dRowsInnerJoin + dRowsLASJ);
+
+	// create an output stats object
+	CStatistics *pstatsLOJ = GPOS_NEW(pmp) CStatistics
+			(
+			pmp,
+			phmulhistLOJ,
+			phmuldoubleWidth,
+			dRowsLOJ,
+			pstatsOuter->FEmpty(),
+			pstatsOuter->UlNumberOfPredicates()
+			);
+
+	// In the output statistics object, the upper bound source cardinality of the join column
+	// cannot be greater than the upper bound source cardinality information maintained in the input
+	// statistics object. Therefore we choose CStatistics::EcbmMin the bounding method which takes
+	// the minimum of the cardinality upper bound of the source column (in the input hash map)
+	// and estimated join cardinality.
+
+	// modify source id to upper bound card information
+	CStatisticsUtils::ComputeCardUpperBounds(pmp, pstatsOuterSide, pstatsLOJ, dRowsLOJ, CStatistics::EcbmMin /* ecbm */);
+	CStatisticsUtils::ComputeCardUpperBounds(pmp, pstatsInnerSide, pstatsLOJ, dRowsLOJ, CStatistics::EcbmMin /* ecbm */);
+
+	return pstatsLOJ;
+}
+
+// create a new hash map of histograms for LOJ from the histograms
+// of the outer child and the histograms of the inner join
+HMUlHist *
+CLeftOuterJoinStatsProcessor::PhmulhistLOJ
+		(
+		IMemoryPool *pmp,
+		const CStatistics *pstatsOuter,
+		const CStatistics *pstatsInner,
+		CStatistics *pstatsInnerJoin,
+		DrgPstatspredjoin *pdrgpstatspredjoin,
+		CDouble dRowsInnerJoin,
+		CDouble *pdRowsLASJ
+		)
+{
+	GPOS_ASSERT(NULL != pstatsOuter);
+	GPOS_ASSERT(NULL != pstatsInner);
+	GPOS_ASSERT(NULL != pdrgpstatspredjoin);
+	GPOS_ASSERT(NULL != pstatsInnerJoin);
+
+	// build a bitset with all outer child columns contributing to the join
+	CBitSet *pbsOuterJoinCol = GPOS_NEW(pmp) CBitSet(pmp);
+	for (ULONG ul1 = 0; ul1 < pdrgpstatspredjoin->UlLength(); ul1++)
+	{
+		CStatsPredJoin *pstatsjoin = (*pdrgpstatspredjoin)[ul1];
+		(void) pbsOuterJoinCol->FExchangeSet(pstatsjoin->UlColId1());
+	}
+
+	// for the columns in the outer child, compute the buckets that do not contribute to the inner join
+	CStatistics *pstatsLASJ = pstatsOuter->PstatsLASJoin
+			(
+			pmp,
+			pstatsInner,
+			pdrgpstatspredjoin,
+			false /* fIgnoreLasjHistComputation */
+			);
+	CDouble dRowsLASJ(0.0);
+	if (!pstatsLASJ->FEmpty())
+	{
+		dRowsLASJ = pstatsLASJ->DRows();
+	}
+
+	HMUlHist *phmulhistLOJ = GPOS_NEW(pmp) HMUlHist(pmp);
+
+	DrgPul *pdrgpulOuterColId = pstatsOuter->PdrgulColIds(pmp);
+	const ULONG ulOuterCols = pdrgpulOuterColId->UlLength();
+
+	for (ULONG ul2 = 0; ul2 < ulOuterCols; ul2++)
+	{
+		ULONG ulColId = *(*pdrgpulOuterColId)[ul2];
+		const CHistogram *phistInnerJoin = pstatsInnerJoin->Phist(ulColId);
+		GPOS_ASSERT(NULL != phistInnerJoin);
+
+		if (pbsOuterJoinCol->FBit(ulColId))
+		{
+			// add buckets from the outer histogram that do not contribute to the inner join
+			const CHistogram *phistLASJ = pstatsLASJ->Phist(ulColId);
+			GPOS_ASSERT(NULL != phistLASJ);
+
+			if (phistLASJ->FWellDefined() && !phistLASJ->FEmpty())
+			{
+				// union the buckets from the inner join and LASJ to get the LOJ buckets
+				CHistogram *phistLOJ = phistLASJ->PhistUnionAllNormalized(pmp, dRowsLASJ, phistInnerJoin, dRowsInnerJoin);
+				CStatisticsUtils::AddHistogram(pmp, ulColId, phistLOJ, phmulhistLOJ);
+				GPOS_DELETE(phistLOJ);
+			}
+			else
+			{
+				CStatisticsUtils::AddHistogram(pmp, ulColId, phistInnerJoin, phmulhistLOJ);
+			}
+		}
+		else
+		{
+			// if column from the outer side that is not a join then just add it
+			CStatisticsUtils::AddHistogram(pmp, ulColId, phistInnerJoin, phmulhistLOJ);
+		}
+	}
+
+	pstatsLASJ->Release();
+
+	// extract all columns from the inner child of the join
+	DrgPul *pdrgpulInnerColId = pstatsInner->PdrgulColIds(pmp);
+
+	// add its corresponding statistics
+	AddHistogramsLOJInner(pmp, pstatsInnerJoin, pdrgpulInnerColId, dRowsLASJ, dRowsInnerJoin, phmulhistLOJ);
+
+	*pdRowsLASJ = dRowsLASJ;
+
+	// clean up
+	pdrgpulInnerColId->Release();
+	pdrgpulOuterColId->Release();
+	pbsOuterJoinCol->Release();
+
+	return phmulhistLOJ;
+}
+
+
+// helper function to add histograms of the inner side of a LOJ
+void
+CLeftOuterJoinStatsProcessor::AddHistogramsLOJInner
+		(
+		IMemoryPool *pmp,
+		const CStatistics *pstatsInnerJoin,
+		DrgPul *pdrgpulInnerColId,
+		CDouble dRowsLASJ,
+		CDouble dRowsInnerJoin,
+		HMUlHist *phmulhistLOJ
+		)
+{
+	GPOS_ASSERT(NULL != pstatsInnerJoin);
+	GPOS_ASSERT(NULL != pdrgpulInnerColId);
+	GPOS_ASSERT(NULL != phmulhistLOJ);
+
+	const ULONG ulInnerCols = pdrgpulInnerColId->UlLength();
+
+	for (ULONG ul = 0; ul < ulInnerCols; ul++)
+	{
+		ULONG ulColId = *(*pdrgpulInnerColId)[ul];
+
+		const CHistogram *phistInnerJoin = pstatsInnerJoin->Phist(ulColId);
+		GPOS_ASSERT(NULL != phistInnerJoin);
+
+		// the number of nulls added to the inner side should be the number of rows of the LASJ on the outer side.
+		CHistogram *phistNull = GPOS_NEW(pmp) CHistogram
+				(
+				GPOS_NEW(pmp) DrgPbucket(pmp),
+				true /*fWellDefined*/,
+				1.0 /*dNullFreq*/,
+				CHistogram::DDefaultNDVRemain,
+				CHistogram::DDefaultNDVFreqRemain
+				);
+		CHistogram *phistLOJ = phistInnerJoin->PhistUnionAllNormalized(pmp, dRowsInnerJoin, phistNull, dRowsLASJ);
+		CStatisticsUtils::AddHistogram(pmp, ulColId, phistLOJ, phmulhistLOJ);
+
+		GPOS_DELETE(phistNull);
+		GPOS_DELETE(phistLOJ);
+	}
+}
+
+// EOF

--- a/libnaucrates/src/statistics/CLeftSemiJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CLeftSemiJoinStatsProcessor.cpp
@@ -1,0 +1,72 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright 2018 Pivotal, Inc.
+//
+//	@filename:
+//		CLeftSemiJoinStatsProcessor.cpp
+//
+//	@doc:
+//		Statistics helper routines for processing Left Semi Joins
+//---------------------------------------------------------------------------
+
+#include "gpopt/operators/ops.h"
+#include "naucrates/statistics/CLeftSemiJoinStatsProcessor.h"
+
+using namespace gpopt;
+
+// return statistics object after performing LSJ operation
+CStatistics *
+CLeftSemiJoinStatsProcessor::PstatsLSJoinStatic
+		(
+		IMemoryPool *pmp,
+		const IStatistics *pistatsOuter,
+		const IStatistics *pistatsInner,
+		DrgPstatspredjoin *pdrgpstatspredjoin
+		)
+{
+	GPOS_ASSERT(NULL != pistatsOuter);
+	GPOS_ASSERT(NULL != pistatsInner);
+	GPOS_ASSERT(NULL != pdrgpstatspredjoin);
+
+	const ULONG ulLen = pdrgpstatspredjoin->UlLength();
+
+	// iterate over all inner columns and perform a group by to remove duplicates
+	DrgPul *pdrgpulInnerColumnIds = GPOS_NEW(pmp) DrgPul(pmp);
+	for (ULONG ul = 0; ul < ulLen; ul++)
+	{
+		ULONG ulInnerColId = ((*pdrgpstatspredjoin)[ul])->UlColId2();
+		pdrgpulInnerColumnIds->Append(GPOS_NEW(pmp) ULONG(ulInnerColId));
+	}
+
+	// dummy agg columns required for group by derivation
+	DrgPul *pdrgpulAgg = GPOS_NEW(pmp) DrgPul(pmp);
+	IStatistics *pstatsInnerNoDups = pistatsInner->PstatsGroupBy
+			(
+			pmp,
+			pdrgpulInnerColumnIds,
+			pdrgpulAgg,
+			NULL // pbsKeys: no keys, use all grouping cols
+			);
+
+	const CStatistics *pstatsOuter = dynamic_cast<const CStatistics *> (pistatsOuter);
+	CStatistics *pstatsSemiJoin = CJoinStatsProcessor::PstatsJoinDriver
+			(
+			pmp,
+			pstatsOuter->PStatsConf(),
+			pstatsOuter,
+			pstatsInnerNoDups,
+			pdrgpstatspredjoin,
+			IStatistics::EsjtLeftSemiJoin /* esjt */,
+			true /* fIgnoreLasjHistComputation */
+			);
+
+	// clean up
+	pdrgpulInnerColumnIds->Release();
+	pdrgpulAgg->Release();
+	pstatsInnerNoDups->Release();
+
+	return pstatsSemiJoin;
+
+}
+
+// EOF


### PR DESCRIPTION
This PR is a refactor of join stats processing logic out of CStatistics and into separate classes. There are very few logic changes in this PR, so to make it clear where those are for the reviewer, we have called them out here.

Main Re-factor Points:
- Create a new base class, `CJoinStatsProcessor`, into which we move methods from `CStatistics` and `CStatisticsUtils` which process statistics exclusively for joins.
- Create a child class for each join type (corresponding to the logical operator) and move processing methods specific to that type of join into its respective class - e.g. `CInnerJoinStatsProcessor` inherits from `CJoinStatsProcessor` and contains methods which manipulate statistics specific to Inner Joins.
- Because the methods were moved into the `C[join type]StatsProcessor` classes as static member functions, the interfaces had to be changed. In order to avoid interface changes throughout the codebase at the call sites, thin wrappers have been left in the `CStatistics` class which simply call the `C[join type]StatsProcessor` functions.
- Additionally, any helper functions used by the methods which were moved into the new classes which are not shared by any non-join statistics computations were also moved into those classes.
- Helper functions which are common to join and non-join computations
were kept in `CStatisticsUtils`.
- Going forward, helper functions which apply only to join computation should be added to the relevant `C[join type]StatsProcessor` class
Future Work:
- As an intermediate step, join type has been added as a parameter to many of the functions performing statistics computation for joins. In the future, calling the correct method based on join type should be implemented.
- Additionally it is a goal to leverage object-oriented principles to make instances of these processors based on the logical operator on which `PStatsDerive` is called.
- Remove `IStatistics`
- Functions placed in `CStatisticsUtils` which are exclusively used in `CStatistics` should ideally be moved into `CStatistics`.
- Move the methods in `CStatistics` responsible for processing statistics for other operator types into their own StatsProcessor classes -- e.g. Union All and Group By

Some changes to note:
- Add a detailed comment in `CJoinStatsProcessor::PstatsDeriveWithOuterRefs` and a few other places.
- Remove unnecessary initialization of ScaleFactor to 1.0 in `CJoinStatsProcessor::JoinHistograms`.
- miscellaneous cleanup for indentation, copyright.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>