### PR TITLE
Don't stop testing when a minidump test fails

### DIFF
--- a/server/include/unittest/gpopt/CTestUtils.h
+++ b/server/include/unittest/gpopt/CTestUtils.h
@@ -649,7 +649,6 @@ namespace gpopt
 				IMemoryPool *pmp,
 				const CHAR *szMDFilePath,
 				const CHAR *rgszFileNames[],
-				ULONG ulTests,
 				ULONG *pulTestCounter,
 				ULONG ulSessionId,
 				ULONG ulCmdId,


### PR DESCRIPTION
Previously, when a test is run as:
`$ ./server/gporca_test -U <>`
we stopped at the first failing minidump, be it a plan space change or
actual plan diff and did not continue with the subsequent minidumps.

This commit changes the behaviour such that we run through all the
minidump tests and do not stop at the first failure. The space size
change or plan change will be displayed in case of each failure. The
advantage is, we can get a quicker and consolidated feedback without
re-running the test after fixing each failing minidump.

Signed-off-by: Dhanashree Kashid <dkashid@pivotal.io>