### PR TITLE
Add Pipeline to test specified orca and gpdb branch

### DIFF
--- a/concourse/clone_remote_repo.py
+++ b/concourse/clone_remote_repo.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import optparse
+import subprocess
+import sys
+
+def read_commit_info(filename):
+  with open(filename, 'r') as fp:
+    data = fp.readline().strip('\n')
+
+  return data.split(',')[0], data.split(',')[1]
+
+def create_tarball(directory):
+  tar_cmd = 'mkdir -p package_tarball && tar -cvzf package_tarball/{0}.tar.gz {0}'.format(directory)
+  exec_command(tar_cmd)
+
+def exec_command(cmd):
+  print "Executing command: {0}".format(cmd)
+  p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+  output = p.communicate()[0]
+  if p.returncode != 0:
+    sys.exit(p.returncode)
+
+def remote_checkout(branch_or_commit, remote_url, dirname):
+  cmd = "git clone {0} {1}".format(remote_url, dirname)
+  exec_command(cmd)
+  cmd = "pushd {0} && git checkout {1} && popd".format(dirname, branch_or_commit)
+  exec_command(cmd)
+
+
+if __name__ == "__main__":
+  parser = optparse.OptionParser()
+  parser.add_option("--orcaRemoteInfo", dest="orcaRemoteInfo", default="gporca-commits-to-test/orca_remote_info.txt")
+  parser.add_option("--gpdbRemoteInfo", dest="gpdbRemoteInfo", default="gporca-commits-to-test/gpdb_remote_info.txt")
+
+  (options, args) = parser.parse_args()
+
+  # read commit / branch info and repo url
+  orca_branch, orca_remote = read_commit_info(options.orcaRemoteInfo)
+  gpdb_branch, gpdb_remote = read_commit_info(options.gpdbRemoteInfo)
+
+  print "orca commit: {0}, orca remote: {1}".format(orca_branch, orca_remote)
+  print "gpdb commit: {0}, gpdb remote: {1}".format(gpdb_branch, gpdb_remote)
+
+  # checkout the branch from the given repo
+  remote_checkout(orca_branch, orca_remote, 'orca_src')
+  remote_checkout(gpdb_branch, gpdb_remote, 'gpdb_src')
+
+  # create tarballs for orca and gpdb
+  create_tarball('orca_src')
+  create_tarball('gpdb_src')

--- a/concourse/clone_remote_repo.yml
+++ b/concourse/clone_remote_repo.yml
@@ -1,0 +1,13 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: yolo/orcadev
+    tag: centos6
+inputs:
+  - name: orca_main_src
+  - name: gporca-commits-to-test
+outputs:
+  - name: package_tarball
+run:
+  path: orca_main_src/concourse/clone_remote_repo.py

--- a/concourse/test_orca_pipeline.yml
+++ b/concourse/test_orca_pipeline.yml
@@ -1,0 +1,285 @@
+groups: []
+resources:
+- name: gporca-commits-to-test
+  type: git
+  source:
+    branch: master
+    uri: https://github.com/greenplum-db/gporca-pipeline-misc
+- name: regression_diffs
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: regression.diffs
+- name: orca_main_src
+  type: git
+  source:
+    branch: master
+    paths: null
+    uri: https://github.com/greenplum-db/gporca
+- name: xerces_patch
+  type: git
+  source:
+    branch: master
+    paths:
+    - patches/xerces-c-gpdb.patch
+    - concourse/xerces-c
+    - concourse/package_tarball.bash
+    uri: https://github.com/greenplum-db/gporca
+- name: regression_out
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: regression.out
+- name: bin_gpdb_centos6_assert
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_gpdb_assert_with_orca_centos6.tar.gz
+- name: gpdb_main_src
+  type: git
+  source:
+    branch: master
+    ignore_paths:
+    - README.md
+    - LICENSE
+    - COPYRIGHT
+    - .gitignore
+    uri: https://github.com/greenplum-db/gpdb
+- name: gpdb_tarball
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: gpdb_src.tar.gz
+- name: bin_orca_centos5_debug
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_orca_centos5_debug.tar.gz
+- name: bin_orca_centos5_release
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_orca_centos5_release.tar.gz
+- name: bin_xerces_centos5
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_xerces_centos5.tar.gz
+- name: orca_tarball
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: orca_src.tar.gz
+resource_types: []
+jobs:
+- name: xerces_centos5
+  max_in_flight: 2
+  plan:
+  - get: xerces_patch
+    trigger: true
+  - aggregate:
+    - task: build
+      file: xerces_patch/concourse/xerces-c/build_xerces_centos5.yml
+  - aggregate:
+    - task: package_tarball
+      file: xerces_patch/concourse/xerces-c/package_tarball_centos5.yml
+  - aggregate:
+    - put: bin_xerces_centos5
+      params:
+        from: package_tarball_centos5/bin_xerces_centos5.tar.gz
+- name: orca_centos5_release
+  max_in_flight: 2
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - clone_repos_to_test
+      trigger: true
+      version: every
+    - get: orca_main_src
+      passed:
+      - clone_repos_to_test
+    - get: bin_xerces_centos5
+      passed:
+      - xerces_centos5
+    - get: orca_tarball
+      passed:
+      - clone_repos_to_test
+  - task: untar_build_and_test_release
+    file: orca_main_src/concourse/untar_build_and_test_centos5_release.yml
+  - put: bin_orca_centos5_release
+    params:
+      from: package_tarball_release/bin_orca_centos5_release.tar.gz
+- name: orca_centos5_debug
+  max_in_flight: 2
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - clone_repos_to_test
+      trigger: true
+      version: every
+    - get: orca_main_src
+      passed:
+      - clone_repos_to_test
+    - get: bin_xerces_centos5
+      passed:
+      - xerces_centos5
+    - get: orca_tarball
+      passed:
+      - clone_repos_to_test
+  - task: untar_build_and_test_debug
+    file: orca_main_src/concourse/untar_build_and_test_centos5_debug.yml
+  - aggregate:
+    - put: bin_orca_centos5_debug
+      params:
+        from: package_tarball_debug/bin_orca_centos5_debug.tar.gz
+- name: clone_repos_to_test
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      trigger: true
+      version: every
+    - get: orca_main_src
+  - task: clone_repos_to_test
+    file: orca_main_src/concourse/clone_remote_repo.yml
+  - aggregate:
+    - put: orca_tarball
+      params:
+        from: package_tarball/orca_src.tar.gz
+    - put: gpdb_tarball
+      params:
+        from: package_tarball/gpdb_src.tar.gz
+- name: build_gpdb_assert
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - orca_centos5_release
+      - orca_centos5_debug
+      trigger: true
+      version: every
+    - get: bin_orca
+      passed:
+      - orca_centos5_release
+      resource: bin_orca_centos5_release
+      version: every
+    - get: bin_orca_centos5_debug
+      passed:
+      - orca_centos5_debug
+    - get: bin_xerces
+      passed:
+      - xerces_centos5
+      resource: bin_xerces_centos5
+    - get: gpdb_tarball
+      passed:
+      - clone_repos_to_test
+    - get: gpdb_main_src
+  - task: build_with_orca
+    file: gpdb_main_src/concourse/tasks/untar_build_with_orca_assert.yml
+  - put: bin_gpdb_centos6_assert
+    params:
+      from: package_tarball/bin_gpdb.tar.gz
+- name: gpdb_icg_with_orca_assert
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - build_gpdb_assert
+      trigger: true
+    - get: bin_orca
+      passed:
+      - build_gpdb_assert
+      resource: bin_orca_centos5_release
+    - get: bin_xerces
+      passed:
+      - build_gpdb_assert
+      resource: bin_xerces_centos5
+    - get: bin_gpdb
+      passed:
+      - build_gpdb_assert
+      resource: bin_gpdb_centos6_assert
+    - get: gpdb_main_src
+      passed:
+      - build_gpdb_assert
+      params:
+        submodules: none
+    - get: gpdb_tarball
+      passed:
+      - build_gpdb_assert
+  - task: icg_with_orca
+    file: gpdb_main_src/concourse/tasks/untar_test_with_orca_assert.yml
+    on_failure:
+      aggregate:
+      - put: regression_diffs
+        params:
+          file: icg_output/regression.diffs
+      - put: regression_out
+        params:
+          file: icg_output/regression.out
+    timeout: 90m
+- name: gpdb_icg_with_planner_assert
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - build_gpdb_assert
+      trigger: true
+    - get: bin_orca
+      passed:
+      - build_gpdb_assert
+      resource: bin_orca_centos5_release
+    - get: bin_xerces
+      passed:
+      - build_gpdb_assert
+      resource: bin_xerces_centos5
+    - get: bin_gpdb
+      passed:
+      - build_gpdb_assert
+      resource: bin_gpdb_centos6_assert
+    - get: gpdb_main_src
+      passed:
+      - build_gpdb_assert
+      params:
+        submodules: none
+    - get: gpdb_tarball
+      passed:
+      - build_gpdb_assert
+  - task: icg_with_planner
+    file: gpdb_main_src/concourse/tasks/untar_test_with_planner_assert.yml
+    on_failure:
+      aggregate:
+      - put: regression_diffs
+        params:
+          file: icg_output/regression.diffs
+      - put: regression_out
+        params:
+          file: icg_output/regression.out
+    timeout: 90m

--- a/concourse/untar_build_and_test.py
+++ b/concourse/untar_build_and_test.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import subprocess
+import os
+import sys
+
+outputDirectory = os.environ['outputDirectory']
+build_type = os.environ['build_type']
+if build_type == 'DEBUG':
+    path_identifier = 'debug'
+else:
+    path_identifier = 'release'
+
+def exec_command(cmd):
+  print "Executing command: {0}".format(cmd)
+  retcode = subprocess.call(cmd, shell=True)
+  if retcode != 0:
+    sys.exit(retcode)
+
+untar_orca_cmd = "mkdir -p orca_src && tar -xf orca_tarball/orca_src.tar.gz -C orca_src --strip 1"
+exec_command(untar_orca_cmd)
+build_and_test_orca_cmd = "orca_main_src/concourse/build_and_test.py --build_type={0} --output_dir={1}/install bin_xerces_centos5".format(build_type, outputDirectory)
+exec_command(build_and_test_orca_cmd)
+package_tarball_cmd = "env dst_tarball=package_tarball_{0}/bin_orca_centos5_{0}.tar.gz src_root={1}/install orca_main_src/concourse/package_tarball.bash".format(path_identifier, outputDirectory)
+exec_command(package_tarball_cmd)

--- a/concourse/untar_build_and_test_centos5_debug.yml
+++ b/concourse/untar_build_and_test_centos5_debug.yml
@@ -1,0 +1,22 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: yolo/orcadev
+    tag: centos5
+inputs:
+  - name: orca_main_src
+  - name: orca_tarball
+  - name: bin_xerces_centos5
+
+caches:
+  - path: .ccache
+
+outputs:
+  - name: build_and_test_debug
+  - name: package_tarball_debug
+run:
+  path: orca_main_src/concourse/untar_build_and_test.py
+params:
+  build_type: DEBUG
+  outputDirectory: build_and_test_debug

--- a/concourse/untar_build_and_test_centos5_release.yml
+++ b/concourse/untar_build_and_test_centos5_release.yml
@@ -1,0 +1,22 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: yolo/orcadev
+    tag: centos5
+inputs:
+  - name: orca_main_src
+  - name: orca_tarball
+  - name: bin_xerces_centos5
+
+caches:
+  - path: .ccache
+
+outputs:
+  - name: build_and_test_release
+  - name: package_tarball_release
+run:
+  path: orca_main_src/concourse/untar_build_and_test.py
+params:
+  build_type: RelWithDebInfo
+  outputDirectory: build_and_test_release


### PR DESCRIPTION
This commits adds the pipeline and the related scripts to trigger
the orca ci pipeline, but this pipeline does not produce any github releases for the orca branch tested.

What is remaining:
- Integration with Slack (Will work with toolsmiths for it)

Note: Will change the URL pointing to my repos before merging. But since, there is no dependency on the remaining work, i raised the PR.
<img width="1901" alt="screen shot 2018-04-04 at 5 10 42 pm" src="https://user-images.githubusercontent.com/10293569/38340996-3b8c6486-382b-11e8-8297-c2baff388b4e.png">
