### PR TITLE
Override PlanId in minidump with an argument to gporca_test

### DIFF
--- a/libgpos/include/gpos/test/CUnittest.h
+++ b/libgpos/include/gpos/test/CUnittest.h
@@ -189,6 +189,10 @@ namespace gpos
 			static
 			void SetTraceFlag(const CHAR *szTrace);
 
+			// Parse plan id
+			static
+			ULLONG UllParsePlanId(const CHAR *szPlanId);
+
 			// get number of unittests
 			static
 			ULONG UlTests()

--- a/libgpos/src/test/CUnittest.cpp
+++ b/libgpos/src/test/CUnittest.cpp
@@ -457,6 +457,17 @@ CUnittest::SetTraceFlag
 	GPOS_SET_TRACE((ULONG) lTrace);
 }
 
+// Parse plan id
+ULLONG
+CUnittest::UllParsePlanId
+	(
+	const CHAR *szPlanId
+	)
+{
+	CHAR *pcEnd = NULL;
+	LINT ullPlanId = clib::LStrToL(szPlanId, &pcEnd, 0/*iBase*/);
+	return ullPlanId;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/server/src/startup/main.cpp
+++ b/server/src/startup/main.cpp
@@ -318,6 +318,7 @@ PvExec
 	CHAR *szFileName = NULL;
 	BOOL fMinidump = false;
 	BOOL fUnittest = false;
+	ULLONG ullPlanId = 0;
 	
 	while (pma->FGetopt(&ch))
 	{
@@ -341,7 +342,12 @@ PvExec
 			case 'T':
 				CUnittest::SetTraceFlag(optarg);
 				break;
-				
+
+			case 'i':
+				ullPlanId = CUnittest::UllParsePlanId(optarg);
+				GPOS_SET_TRACE(EopttraceEnumeratePlans);
+				break;
+
 			case 'd':
 				fMinidump = true;
 				szFileName = optarg;
@@ -382,6 +388,11 @@ PvExec
 		else
 		{
 			poconf -> AddRef();
+		}
+
+		if (ullPlanId != 0)
+		{
+			poconf->Pec()->SetPlanId(ullPlanId);
 		}
 
 		ULONG ulSegments = CTestUtils::UlSegments(poconf);
@@ -443,7 +454,7 @@ INT main
 	}
 
 	// setup args for unittest params
-	CMainArgs ma(iArgs, rgszArgs, "uU:d:xT:");
+	CMainArgs ma(iArgs, rgszArgs, "uU:d:xT:i:");
 	
 	// initialize unittest framework
 	CUnittest::Init(rgut, GPOS_ARRAY_SIZE(rgut), ConfigureTests, Cleanup);


### PR DESCRIPTION
Introduces a new command line argument to gporca_test. When it is set to
something non-zero, it will override the PlanId mentioned in the
minidump file (usually 0). This is useful for enumerating all plans
generated by ORCA easily.

e.g:
  for i in $(seq 0 15); do
    ./server/gporca_test -d $mdp -T 101001 -i $i
  done