### PR TITLE
Support Nested Loop Index plans using nest params

### DIFF
--- a/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3638,6 +3638,7 @@ CTranslatorExprToDXL::PdxlnNLJoin
 
 	EdxlJoinType edxljt = EdxljtSentinel;
 	BOOL fIndexNLJ = false;
+	DrgPcr *outer_refs = NULL;
 	switch (pop->Eopid())
 	{
 		case COperator::EopPhysicalInnerNLJoin:
@@ -3648,12 +3649,14 @@ CTranslatorExprToDXL::PdxlnNLJoin
 			edxljt = EdxljtInner;
 			fIndexNLJ = true;
 			StoreIndexNLJOuterRefs(pop);
+			outer_refs = CPhysicalInnerIndexNLJoin::PopConvert(pop)->PdrgPcrOuterRefs();
 			break;
 
 		case COperator::EopPhysicalLeftOuterIndexNLJoin:
 			edxljt = EdxljtLeft;
 			fIndexNLJ = true;
 			StoreIndexNLJOuterRefs(pop);
+			outer_refs = CPhysicalLeftOuterIndexNLJoin::PopConvert(pop)->PdrgPcrOuterRefs();
 			break;
 
 		case COperator::EopPhysicalLeftOuterNLJoin:
@@ -3689,6 +3692,21 @@ CTranslatorExprToDXL::PdxlnNLJoin
 
 	// construct a join node
 	CDXLPhysicalNLJoin *pdxlopNLJ = GPOS_NEW(m_pmp) CDXLPhysicalNLJoin(m_pmp, edxljt,fIndexNLJ);
+
+	if (fIndexNLJ && GPOS_FTRACE(EopttraceEnableNestLoopParams))
+	{
+		DrgPdxlcr *col_refs = GPOS_NEW(m_pmp) DrgPdxlcr(m_pmp);
+		for (ULONG ul = 0; ul < outer_refs->UlLength(); ul++)
+		{
+			CColRef *col_ref = (*outer_refs)[ul];
+			CMDName *md_name = GPOS_NEW(m_pmp) CMDName(m_pmp, col_ref->Name().Pstr());
+			IMDId *mdid = col_ref->Pmdtype()->Pmdid();
+			mdid->AddRef();
+			CDXLColRef *colref_dxl = GPOS_NEW(m_pmp) CDXLColRef(m_pmp, md_name, col_ref->UlId(), mdid, col_ref->ITypeModifier());
+			col_refs->Append(colref_dxl);
+		}
+		pdxlopNLJ->SetNestLoopParamsColRefs(col_refs);
+	}
 
 	// construct projection list
 	// compute required columns

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalNLJoin.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalNLJoin.h
@@ -16,6 +16,7 @@
 
 #include "gpos/base.h"
 #include "naucrates/dxl/operators/CDXLPhysicalJoin.h"
+#include "naucrates/dxl/operators/CDXLColRef.h"
 
 namespace gpdxl
 {
@@ -47,12 +48,18 @@ namespace gpdxl
 			// i.e., inner side is an index scan that uses values from outer side
 			BOOL m_fIndexNLJ;
 
+			DrgPdxlcr *m_nest_params_col_refs;
+
+			void SerializeNestLoopParamsToDXL(CXMLSerializer *pxmlser) const;
+
 			// private copy ctor
 			CDXLPhysicalNLJoin(const CDXLPhysicalNLJoin&);
 
 		public:
 			// ctor/dtor
 			CDXLPhysicalNLJoin(IMemoryPool *pmp, EdxlJoinType edxljt, BOOL fIndexNLJ);
+		
+			~CDXLPhysicalNLJoin();
 			
 			// accessors
 			Edxlopid Edxlop() const;
@@ -67,6 +74,13 @@ namespace gpdxl
 			// serialize operator in DXL format
 			virtual
 			void SerializeToDXL(CXMLSerializer *pxmlser, const CDXLNode *pdxln) const;
+
+			void SetNestLoopParamsColRefs(DrgPdxlcr *nest_params_col_refs);
+
+			DrgPdxlcr *GetNestLoopParamsColRefs()
+			{
+				return m_nest_params_col_refs;
+			}
 
 			// conversion function
 			static

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerFactory.h
@@ -1648,6 +1648,24 @@ namespace gpdxl
 				CParseHandlerBase *pphRoot
 				);
 
+			// construct a nested loop param list parse handler
+			static
+			CParseHandlerBase *CreateNLJIndexParamListParseHandler
+			(
+			 IMemoryPool *mp,
+			 CParseHandlerManager *parse_handler_manager,
+			 CParseHandlerBase *parse_handler_root
+			 );
+
+			// construct a nested loop param parse handler
+			static
+			CParseHandlerBase *CreateNLJIndexParamParseHandler
+			(
+			 IMemoryPool *pmp,
+			 CParseHandlerManager *parse_handler_manager,
+			 CParseHandlerBase *parse_handler_root
+			 );
+
 		public:
 			
 			// initialize mappings of tokens to parse handlers

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerNLJIndexParam.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerNLJIndexParam.h
@@ -1,0 +1,84 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal Software, Inc.
+//
+//	@filename:
+//		CParseHandlerNLJIndexParam.h
+//
+//	@doc:
+//		
+//		SAX parse handler class for parsing a single NLJ index param
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CParseHandlerNLJIndexParam_H
+#define GPDXL_CParseHandlerNLJIndexParam_H
+
+#include "gpos/base.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+
+namespace gpdxl
+{
+	using namespace gpos;
+
+	XERCES_CPP_NAMESPACE_USE
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CParseHandlerNLJIndexParam
+	//
+	//	@doc:
+	//		Parse handler for parsing a Param of NLJ
+	//
+	//---------------------------------------------------------------------------
+	class CParseHandlerNLJIndexParam : public CParseHandlerBase
+	{
+		private:
+	
+			// column reference
+			CDXLColRef *m_nest_param_colref_dxl;
+
+			// private copy ctor
+			CParseHandlerNLJIndexParam(const CParseHandlerNLJIndexParam &);
+	
+			// process the start of an element
+			void StartElement
+					(
+					const XMLCh* const element_uri, 		// URI of element's namespace
+					const XMLCh* const element_local_name,	// local part of element's name
+					const XMLCh* const element_qname,		// element's qname
+					const Attributes& attr				// element's attributes
+					);
+	
+			// process the end of an element
+			void EndElement
+					(
+					const XMLCh* const element_uri, 		// URI of element's namespace
+					const XMLCh* const element_local_name,	// local part of element's name
+					const XMLCh* const element_qname		// element's qname
+					);
+	
+		public:
+			// ctor/dtor
+			CParseHandlerNLJIndexParam
+					(
+					IMemoryPool *mp,
+					CParseHandlerManager *parse_handler_manager,
+					CParseHandlerBase *parse_handler_root
+					);
+
+			virtual
+			~CParseHandlerNLJIndexParam();
+
+			// return column reference
+			CDXLColRef *GetNestParamColRefDxl(void)
+			const
+			{
+				return m_nest_param_colref_dxl;
+			}
+
+	};
+
+}
+#endif // GPDXL_CParseHandlerNLJIndexParam_H
+
+//EOF

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerNLJIndexParamList.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerNLJIndexParamList.h
@@ -1,0 +1,86 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal Software, Inc.
+//
+//	@filename:
+//		CParseHandlerNLJIndexParamList.h
+//
+//	@doc:
+//		
+//		SAX parse handler class for parsing NLJ ParamList
+//---------------------------------------------------------------------------
+
+#ifndef GPDXL_CParseHandlerNLJIndexParamList_H
+#define GPDXL_CParseHandlerNLJIndexParamList_H
+
+#include "gpos/base.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+
+namespace gpdxl
+{
+	using namespace gpos;
+
+	XERCES_CPP_NAMESPACE_USE
+
+	//---------------------------------------------------------------------------
+	//	@class:
+	//		CParseHandlerNLJIndexParamList
+	//
+	//	@doc:
+	//		Parse handler for parsing a scalar NLJ ParamList
+	//
+	//---------------------------------------------------------------------------
+	class CParseHandlerNLJIndexParamList : public CParseHandlerBase
+	{
+		private:
+
+			BOOL m_is_param_list;
+
+			// array of outer column references
+			DrgPdxlcr *m_nest_params_colrefs_array;
+
+			// private copy ctor
+			CParseHandlerNLJIndexParamList(const CParseHandlerNLJIndexParamList &);
+	
+			// process the start of an element
+			void StartElement
+					(
+					const XMLCh* const element_uri, 		// URI of element's namespace
+					const XMLCh* const element_local_name,	// local part of element's name
+					const XMLCh* const element_qname,		// element's qname
+					const Attributes& attr				// element's attributes
+					);
+	
+			// process the end of an element
+			void EndElement
+					(
+					const XMLCh* const element_uri, 		// URI of element's namespace
+					const XMLCh* const element_local_name,	// local part of element's name
+					const XMLCh* const element_qname		// element's qname
+					);
+	
+		public:
+			// ctor
+			CParseHandlerNLJIndexParamList
+					(
+					IMemoryPool *mp,
+					CParseHandlerManager *parse_handler_mgr,
+					CParseHandlerBase *parse_handler_root
+					);
+
+			// dtor
+			virtual
+			~CParseHandlerNLJIndexParamList();
+
+			// return param column references
+			DrgPdxlcr *GetNLParamsColRefs()
+			const
+			{
+				return m_nest_params_colrefs_array;
+			}
+	};
+
+}
+#endif // GPDXL_CParseHandlerNLJIndexParamList_H
+
+//EOF

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerNLJoin.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerNLJoin.h
@@ -23,6 +23,19 @@ namespace gpdxl
 
 	XERCES_CPP_NAMESPACE_USE
 	
+	// indices of nested loop join elements in the children array
+	enum ENLJoinParseHandlerChildIndices
+	{
+		EdxlParseHandlerNLJIndexProp = 0,
+		EdxlParseHandlerNLJIndexProjList,
+		EdxlParseHandlerNLJIndexFilter,
+		EdxlParseHandlerNLJIndexJoinFilter,
+		EdxlParseHandlerNLJIndexLeftChild,
+		EdxlParseHandlerNLJIndexRightChild,
+		EdxlParseHandlerNLJIndexNestLoopParams,
+		EdxlParseHandlerNLJIndexSentinel
+	};
+	
 	//---------------------------------------------------------------------------
 	//	@class:
 	//		CParseHandlerNLJoin

--- a/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
+++ b/libnaucrates/include/naucrates/dxl/parser/parsehandlers.h
@@ -210,6 +210,8 @@
 
 #include "naucrates/dxl/parser/CParseHandlerScalarExpr.h"
 
+#include "naucrates/dxl/parser/CParseHandlerNLJIndexParamList.h"
+#include "naucrates/dxl/parser/CParseHandlerNLJIndexParam.h"
 #endif // !GPDXL_parsehandlers_H
 
 // EOF

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -423,6 +423,9 @@ namespace gpdxl
 		EdxltokenTrue,
 		EdxltokenFalse,
 		
+		EdxltokenNLJIndexParamList,
+		EdxltokenNLJIndexParam,
+		
 		// metadata-related constants
 		EdxltokenRelation,
 		EdxltokenRelationExternal,

--- a/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -196,6 +196,9 @@ namespace gpos
 
 		// do not use the built-in evaluators for integers in constraint derivation
 		EopttraceUseExternalConstantExpressionEvaluationForInts = 105001,
+		
+		// is nestloop params enabled, it is only enabled in GPDB 6.x onwards.
+		EopttraceEnableNestLoopParams = 10600,
 
 		// max
 		EopttraceSentinel = 199999

--- a/libnaucrates/src/parser/CParseHandlerFactory.cpp
+++ b/libnaucrates/src/parser/CParseHandlerFactory.cpp
@@ -276,7 +276,9 @@ CParseHandlerFactory::Init
 
 			{EdxltokenScalarExpr, &PphScalarExpr},
 			{EdxltokenScalarValuesList, &PphScalarValuesList},
-			{EdxltokenPhysicalValuesScan, &PphValuesScan}
+			{EdxltokenPhysicalValuesScan, &PphValuesScan},
+			{EdxltokenNLJIndexParamList, &CreateNLJIndexParamListParseHandler},
+			{EdxltokenNLJIndexParam, &CreateNLJIndexParamParseHandler}
 
 	};
 	
@@ -2427,4 +2429,25 @@ CParseHandlerFactory::PphMDArrayCoerceCast
 	return GPOS_NEW(pmp) CParseHandlerMDArrayCoerceCast(pmp, pphm, pphRoot);
 }
 
+CParseHandlerBase *
+CParseHandlerFactory::CreateNLJIndexParamListParseHandler
+(
+ IMemoryPool *mp,
+ CParseHandlerManager *parse_handler_manager,
+ CParseHandlerBase *parse_handler_root
+ )
+{
+	return GPOS_NEW(mp) CParseHandlerNLJIndexParamList(mp, parse_handler_manager, parse_handler_root);
+}
+
+CParseHandlerBase *
+CParseHandlerFactory::CreateNLJIndexParamParseHandler
+(
+ IMemoryPool *mp,
+ CParseHandlerManager *parse_handler_manager,
+ CParseHandlerBase *parse_handler_root
+ )
+{
+	return GPOS_NEW(mp) CParseHandlerNLJIndexParam(mp, parse_handler_manager, parse_handler_root);
+}
 // EOF

--- a/libnaucrates/src/parser/CParseHandlerNLJIndexParam.cpp
+++ b/libnaucrates/src/parser/CParseHandlerNLJIndexParam.cpp
@@ -1,0 +1,111 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal Software, Inc.
+//
+//	@filename:
+//		CParseHandlerNLJIndexParam.cpp
+//
+//	@doc:
+//		
+//		Implementation of the SAX parse handler class for parsing a NLJ index Param
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/parser/CParseHandlerPhysicalOp.h"
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+#include "naucrates/dxl/parser/CParseHandlerFactory.h"
+#include "naucrates/dxl/CDXLUtils.h"
+#include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+
+#include "naucrates/dxl/parser/CParseHandlerNLJIndexParam.h"
+
+using namespace gpdxl;
+
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParam::CParseHandlerNLJIndexParam
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CParseHandlerNLJIndexParam::CParseHandlerNLJIndexParam
+	(
+	IMemoryPool *mp,
+	CParseHandlerManager *parse_handler_manager,
+	CParseHandlerBase *parse_handler_root
+	)
+	:
+	CParseHandlerBase(mp, parse_handler_manager, parse_handler_root),
+	m_nest_param_colref_dxl(NULL)
+{
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParam::~CParseHandlerNLJIndexParam
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CParseHandlerNLJIndexParam::~CParseHandlerNLJIndexParam()
+{
+	m_nest_param_colref_dxl->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParam::StartElement
+//
+//	@doc:
+//		Processes a Xerces start element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerNLJIndexParam::StartElement
+	(
+	const XMLCh* const, // element_uri,
+	const XMLCh* const element_local_name,
+	const XMLCh* const, // element_qname,
+	const Attributes &attrs
+	)
+{
+	if (0 != XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenNLJIndexParam), element_local_name))
+	{
+		CWStringDynamic *str = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, str->Wsz());
+	}
+
+	m_nest_param_colref_dxl = CDXLOperatorFactory::Pdxlcr(m_pphm->Pmm(), attrs, EdxltokenNLJIndexParam);
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParam::EndElement
+//
+//	@doc:
+//		Processes a Xerces end element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerNLJIndexParam::EndElement
+	(
+	const XMLCh* const, // element_uri,
+	const XMLCh* const element_local_name,
+	const XMLCh* const // element_qname
+	)
+{
+	if(0 != XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenNLJIndexParam), element_local_name))
+	{
+		CWStringDynamic *pstr = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag,	pstr->Wsz());
+	}
+
+	// deactivate handler
+	m_pphm->DeactivateHandler();
+}
+
+// EOF

--- a/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
+++ b/libnaucrates/src/parser/CParseHandlerNLJIndexParamList.cpp
@@ -1,0 +1,142 @@
+//---------------------------------------------------------------------------
+//	Greenplum Database
+//	Copyright (C) 2018 Pivotal Software, Inc.
+//
+//	@filename:
+//		CParseHandlerNLJIndexParamList.cpp
+//
+//	@doc:
+//		
+//		Implementation of the SAX parse handler class for parsing the ParamList
+//---------------------------------------------------------------------------
+
+#include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
+#include "naucrates/dxl/parser/CParseHandlerFactory.h"
+#include "naucrates/dxl/CDXLUtils.h"
+#include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+
+#include "naucrates/dxl/parser/CParseHandlerNLJIndexParamList.h"
+#include "naucrates/dxl/parser/CParseHandlerNLJIndexParam.h"
+
+using namespace gpdxl;
+
+
+XERCES_CPP_NAMESPACE_USE
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParamList::CParseHandlerNLJIndexParamList
+//
+//	@doc:
+//		Ctor
+//
+//---------------------------------------------------------------------------
+CParseHandlerNLJIndexParamList::CParseHandlerNLJIndexParamList
+	(
+	IMemoryPool *mp,
+	CParseHandlerManager *parse_handler_mgr,
+	CParseHandlerBase *parse_handler_root
+	)
+	:
+	CParseHandlerBase(mp, parse_handler_mgr, parse_handler_root)
+{
+	m_nest_params_colrefs_array = GPOS_NEW(mp) DrgPdxlcr(mp);
+	m_is_param_list = false;
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParamList::~CParseHandlerNLJIndexParamList
+//
+//	@doc:
+//		Dtor
+//
+//---------------------------------------------------------------------------
+CParseHandlerNLJIndexParamList::~CParseHandlerNLJIndexParamList()
+{
+	m_nest_params_colrefs_array->Release();
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParamList::StartElement
+//
+//	@doc:
+//		Processes a Xerces start element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerNLJIndexParamList::StartElement
+	(
+	const XMLCh* const element_uri,
+	const XMLCh* const element_local_name,
+	const XMLCh* const element_qname,
+	const Attributes &attrs
+	)
+{
+	if(0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenNLJIndexParamList), element_local_name))
+	{
+		// we can't have seen a paramlist already
+		GPOS_ASSERT(!m_is_param_list);
+		// start the paramlist
+		m_is_param_list = true;
+	}
+	else if(0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenNLJIndexParam), element_local_name))
+	{
+		// we must have seen a paramlist already
+		GPOS_ASSERT(m_is_param_list);
+
+		// start new param
+		CParseHandlerBase *nest_param_parse_handler = CParseHandlerFactory::Pph(m_pmp, CDXLTokens::XmlstrToken(EdxltokenNLJIndexParam), m_pphm, this);
+		m_pphm->ActivateParseHandler(nest_param_parse_handler);
+
+		// store parse handler
+		this->Append(nest_param_parse_handler);
+
+		nest_param_parse_handler->startElement(element_uri, element_local_name, element_qname, attrs);
+	}
+	else
+	{
+		CWStringDynamic *str = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, str->Wsz());
+	}
+}
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CParseHandlerNLJIndexParamList::EndElement
+//
+//	@doc:
+//		Processes a Xerces end element event
+//
+//---------------------------------------------------------------------------
+void
+CParseHandlerNLJIndexParamList::EndElement
+	(
+	const XMLCh* const, // element_uri,
+	const XMLCh* const element_local_name,
+	const XMLCh* const // element_qname
+	)
+{
+	if(0 != XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenNLJIndexParamList), element_local_name))
+	{
+		CWStringDynamic *str = CDXLUtils::PstrFromXMLCh(m_pphm->Pmm(), element_local_name);
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag, str->Wsz());
+	}
+
+	const ULONG size = this->UlLength();
+	// add constructed children from child parse handlers
+	for (ULONG idx = 0; idx < size; idx++)
+	{
+		CParseHandlerNLJIndexParam *nest_param_parse_handler = dynamic_cast<CParseHandlerNLJIndexParam *>((*this)[idx]);
+
+		CDXLColRef *nest_param_colref_dxl = nest_param_parse_handler->GetNestParamColRefDxl();
+		nest_param_colref_dxl->AddRef();
+		m_nest_params_colrefs_array->Append(nest_param_colref_dxl);
+	}
+
+	// deactivate handler
+	m_pphm->DeactivateHandler();
+}
+
+// EOF

--- a/libnaucrates/src/parser/CParseHandlerNLJoin.cpp
+++ b/libnaucrates/src/parser/CParseHandlerNLJoin.cpp
@@ -16,8 +16,10 @@
 #include "naucrates/dxl/parser/CParseHandlerProperties.h"
 #include "naucrates/dxl/parser/CParseHandlerScalarOp.h"
 #include "naucrates/dxl/parser/CParseHandlerUtils.h"
+#include "naucrates/dxl/parser/CParseHandlerNLJIndexParamList.h"
 
 #include "naucrates/dxl/operators/CDXLOperatorFactory.h"
+#include "naucrates/traceflags/traceflags.h"
 
 using namespace gpdxl;
 
@@ -73,6 +75,14 @@ CParseHandlerNLJoin::StartElement
 	// create and activate the parse handler for the children nodes in reverse
 	// order of their expected appearance
 	
+	//parse handler for the nest loop params list
+	CParseHandlerBase *nest_params_parse_handler = NULL;
+	if (GPOS_FTRACE(EopttraceEnableNestLoopParams))
+	{
+		nest_params_parse_handler = CParseHandlerFactory::Pph(m_pmp, CDXLTokens::XmlstrToken(EdxltokenNLJIndexParamList), m_pphm, this);
+		m_pphm->ActivateParseHandler(nest_params_parse_handler);
+	}
+	
 	// parse handler for right child
 	CParseHandlerBase *pphRight = CParseHandlerFactory::Pph(m_pmp, CDXLTokens::XmlstrToken(EdxltokenPhysical), m_pphm, this);
 	m_pphm->ActivateParseHandler(pphRight);
@@ -104,6 +114,10 @@ CParseHandlerNLJoin::StartElement
 	this->Append(pphJoinFilter);
 	this->Append(pphLeft);
 	this->Append(pphRight);
+	if (NULL != nest_params_parse_handler)
+	{
+		this->Append(nest_params_parse_handler);
+	}
 }
 
 //---------------------------------------------------------------------------
@@ -134,23 +148,32 @@ CParseHandlerNLJoin::EndElement
 	}
 	
 	// construct node from the created child nodes
-	CParseHandlerProperties *pphProp = dynamic_cast<CParseHandlerProperties *>((*this)[0]);
-	CParseHandlerProjList *pphPrL = dynamic_cast<CParseHandlerProjList*>((*this)[1]);
-	CParseHandlerFilter *pphFilter = dynamic_cast<CParseHandlerFilter *>((*this)[2]);
-	CParseHandlerFilter *pphJoinFilter = dynamic_cast<CParseHandlerFilter *>((*this)[3]);
-	CParseHandlerPhysicalOp *pphLeft = dynamic_cast<CParseHandlerPhysicalOp *>((*this)[4]);
-	CParseHandlerPhysicalOp *pphRight = dynamic_cast<CParseHandlerPhysicalOp *>((*this)[5]);
+	CParseHandlerProperties *prop_parse_handler = dynamic_cast<CParseHandlerProperties *>((*this)[EdxlParseHandlerNLJIndexProp]);
+	CParseHandlerProjList *proj_list_parse_handler = dynamic_cast<CParseHandlerProjList*>((*this)[EdxlParseHandlerNLJIndexProjList]);
+	CParseHandlerFilter *filter_parse_handler = dynamic_cast<CParseHandlerFilter *>((*this)[EdxlParseHandlerNLJIndexFilter]);
+	CParseHandlerFilter *join_filter_parse_handler = dynamic_cast<CParseHandlerFilter *>((*this)[EdxlParseHandlerNLJIndexJoinFilter]);
+	CParseHandlerPhysicalOp *left_child_parse_handler = dynamic_cast<CParseHandlerPhysicalOp *>((*this)[EdxlParseHandlerNLJIndexLeftChild]);
+	CParseHandlerPhysicalOp *right_child_parse_handler = dynamic_cast<CParseHandlerPhysicalOp *>((*this)[EdxlParseHandlerNLJIndexRightChild]);
+
+	if (GPOS_FTRACE(EopttraceEnableNestLoopParams))
+	{
+		CParseHandlerNLJIndexParamList *nest_params_parse_handler = dynamic_cast<CParseHandlerNLJIndexParamList*>((*this)[EdxlParseHandlerNLJIndexNestLoopParams]);
+		GPOS_ASSERT(nest_params_parse_handler);
+		DrgPdxlcr *nest_params_colrefs = nest_params_parse_handler->GetNLParamsColRefs();
+		nest_params_colrefs->AddRef();
+		m_pdxlop->SetNestLoopParamsColRefs(nest_params_colrefs);
+	}
 
 	m_pdxln = GPOS_NEW(m_pmp) CDXLNode(m_pmp, m_pdxlop);
 	// set statictics and physical properties
-	CParseHandlerUtils::SetProperties(m_pdxln, pphProp);
+	CParseHandlerUtils::SetProperties(m_pdxln, prop_parse_handler);
 	
 	// add constructed children
-	AddChildFromParseHandler(pphPrL);
-	AddChildFromParseHandler(pphFilter);
-	AddChildFromParseHandler(pphJoinFilter);
-	AddChildFromParseHandler(pphLeft);
-	AddChildFromParseHandler(pphRight);
+	AddChildFromParseHandler(proj_list_parse_handler);
+	AddChildFromParseHandler(filter_parse_handler);
+	AddChildFromParseHandler(join_filter_parse_handler);
+	AddChildFromParseHandler(left_child_parse_handler);
+	AddChildFromParseHandler(right_child_parse_handler);
 	
 #ifdef GPOS_DEBUG
 	m_pdxlop->AssertValid(m_pdxln, false /* fValidateChildren */);

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -721,6 +721,8 @@ CDXLTokens::Init
 
 			{EdxltokenCtasOptionType, GPOS_WSZ_LIT("CtasOptionType")},
 			{EdxltokenVarTypeModList, GPOS_WSZ_LIT("VarTypeModList")},
+			{EdxltokenNLJIndexParamList, GPOS_WSZ_LIT("NLJIndexParamList")},
+			{EdxltokenNLJIndexParam, GPOS_WSZ_LIT("NLJIndexParam")},
 	};
 	
 	m_pstrmap = GPOS_NEW_ARRAY(m_pmp, SStrMapElem, EdxltokenSentinel);


### PR DESCRIPTION
This patch passes the outer references of index child of nested loop in the DXL
node to support the nest params mechanism.

This feature can be enabled by setting the trace flag EopttraceEnableNestLoopParams.

Co-authored-by: Abhijit Subramanya <asubramanya@pivotal.io>
Co-authored-by: Ekta Khanna <ekhanna@pivotal.io>