### PR TITLE
Force Redistribute Motion on Insert on Randomly Distributed Tables

### DIFF
--- a/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
+++ b/data/dxl/minidump/InsertConstTupleRandomDistribution.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:TraceFlags Value="101001,101013,103001"/>
+      <dxl:TraceFlags Value="101001,101013,103001,106001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
@@ -201,52 +201,70 @@
             <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Result>
+        <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="2.014648" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="a">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="2" Alias="b">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="3" Alias="ColRef_0003">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              <dxl:Ident ColId="3" ColName="ColRef_0003" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
+          <dxl:SortingColumnList/>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1.002930" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="2.014648" Rows="1.000000" Width="12"/>
             </dxl:Properties>
-            <dxl:ProjList/>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="a">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="b">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Result>
+            <dxl:OneTimeFilter/>
+            <dxl:RandomMotion InputSegments="0" OutputSegments="0,1" DuplicateSensitive="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1.002930" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
-              <dxl:OneTimeFilter/>
+              <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="">
-                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
+                <dxl:ProjList/>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
+                <dxl:Result>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="1.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                </dxl:Result>
               </dxl:Result>
-            </dxl:Result>
-          </dxl:RandomMotion>
-        </dxl:Result>
+            </dxl:RandomMotion>
+          </dxl:Result>
+        </dxl:RandomMotion>
       </dxl:DMLInsert>
     </dxl:Plan>
   </dxl:Thread>

--- a/data/dxl/minidump/InsertRandomDistr.mdp
+++ b/data/dxl/minidump/InsertRandomDistr.mdp
@@ -6,7 +6,7 @@
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/> 
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
-      <dxl:TraceFlags Value="101000,101001,101013,103001"/>
+      <dxl:TraceFlags Value="101000,101001,101013,103001,106001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -341,7 +341,7 @@
             <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:Result>
+        <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="21.531250" Rows="1000.000000" Width="12"/>
           </dxl:Properties>
@@ -353,14 +353,14 @@
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:SortingColumnList/>
+          <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="8.812500" Rows="1000.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="21.531250" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -369,12 +369,15 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:TableScan>
+            <dxl:OneTimeFilter/>
+            <dxl:RandomMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3.906250" Rows="1000.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="8.812500" Rows="1000.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -385,22 +388,37 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="0.17004.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:RandomMotion>
-        </dxl:Result>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="3.906250" Rows="1000.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.17004.1.1" TableName="r">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:RandomMotion>
+          </dxl:Result>
+        </dxl:RandomMotion>
       </dxl:DMLInsert>
     </dxl:Plan>
   </dxl:Thread>

--- a/data/dxl/minidump/ProjectSetFunction.mdp
+++ b/data/dxl/minidump/ProjectSetFunction.mdp
@@ -38,7 +38,7 @@ explain insert into table1 values (1,10,generate_series(1,1000000));
           <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:TraceFlags Value="102024,102025,102115,102116,102117,102119,102121,103014,103015"/>
+      <dxl:TraceFlags Value="102024,102025,102115,102116,102117,102119,102121,103014,103015,106001"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -576,7 +576,7 @@ explain insert into table1 values (1,10,generate_series(1,1000000));
             <dxl:Column ColId="46" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
+        <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
           <dxl:Properties>
             <dxl:Cost StartupCost="0" TotalCost="0.000461" Rows="1.000000" Width="128"/>
           </dxl:Properties>
@@ -644,90 +644,159 @@ explain insert into table1 values (1,10,generate_series(1,1000000));
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
-          <dxl:Result>
+          <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000129" Rows="1.000000" Width="128"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000461" Rows="1.000000" Width="128"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="a">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="2" Alias="b">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="3" Alias="c">
-                <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1000000"/>
-                </dxl:FuncExpr>
+                <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="5" Alias="text_col">
-                <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                <dxl:Ident ColId="5" ColName="text_col" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="6" Alias="toast_col">
-                <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                <dxl:Ident ColId="6" ColName="toast_col" TypeMdid="0.25.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="7" Alias="non_toast_col">
-                <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="7" ColName="non_toast_col" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="8" Alias="bigint_col">
-                <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:Ident ColId="8" ColName="bigint_col" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="9" Alias="char_vary_col">
-                <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                <dxl:Ident ColId="9" ColName="char_vary_col" TypeMdid="0.1043.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="numeric_col">
-                <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="10" ColName="numeric_col" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="11" Alias="int_col">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:Ident ColId="11" ColName="int_col" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="12" Alias="float_col">
-                <dxl:ConstValue TypeMdid="0.700.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="12" ColName="float_col" TypeMdid="0.700.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="13" Alias="int_array_col">
-                <dxl:ConstValue TypeMdid="0.1007.1.0" IsNull="true" IsByValue="false"/>
+                <dxl:Ident ColId="13" ColName="int_array_col" TypeMdid="0.1007.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="14" Alias="before_rename_col">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                <dxl:Ident ColId="14" ColName="before_rename_col" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="15" Alias="change_datatype_col">
-                <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="15" ColName="change_datatype_col" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="16" Alias="a_ts_without">
-                <dxl:ConstValue TypeMdid="0.1114.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="16" ColName="a_ts_without" TypeMdid="0.1114.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="17" Alias="b_ts_with">
-                <dxl:ConstValue TypeMdid="0.1184.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="17" ColName="b_ts_with" TypeMdid="0.1184.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="18" Alias="date_column">
-                <dxl:ConstValue TypeMdid="0.1082.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="18" ColName="date_column" TypeMdid="0.1082.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="19" Alias="col_set_default">
-                <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                <dxl:Ident ColId="19" ColName="col_set_default" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="4" Alias="col_with_default_text">
-                <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACXRlc3Qx" LintValue="794436454"/>
+                <dxl:Ident ColId="4" ColName="col_with_default_text" TypeMdid="0.1043.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:OneTimeFilter/>
+            <dxl:SortingColumnList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000129" Rows="1.000000" Width="128"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="">
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                <dxl:ProjElem ColId="1" Alias="a">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="b">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="3" Alias="c">
+                  <dxl:FuncExpr FuncId="0.1067.1.0" FuncRetSet="true" TypeMdid="0.23.1.0">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1000000"/>
+                  </dxl:FuncExpr>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="5" Alias="text_col">
+                  <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="6" Alias="toast_col">
+                  <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="non_toast_col">
+                  <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="bigint_col">
+                  <dxl:ConstValue TypeMdid="0.20.1.0" IsNull="true" IsByValue="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="char_vary_col">
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="true" IsByValue="false" LintValue="0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="numeric_col">
+                  <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="int_col">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="float_col">
+                  <dxl:ConstValue TypeMdid="0.700.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="13" Alias="int_array_col">
+                  <dxl:ConstValue TypeMdid="0.1007.1.0" IsNull="true" IsByValue="false"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="before_rename_col">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true" IsByValue="true"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="change_datatype_col">
+                  <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="a_ts_without">
+                  <dxl:ConstValue TypeMdid="0.1114.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="b_ts_with">
+                  <dxl:ConstValue TypeMdid="0.1184.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="date_column">
+                  <dxl:ConstValue TypeMdid="0.1082.1.0" IsNull="true" IsByValue="true" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="col_set_default">
+                  <dxl:ConstValue TypeMdid="0.1700.1.0" IsNull="true" IsByValue="false" DoubleValue="0.000000"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="4" Alias="col_with_default_text">
+                  <dxl:ConstValue TypeMdid="0.1043.1.0" IsNull="false" IsByValue="false" Value="AAAACXRlc3Qx" LintValue="794436454"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
             </dxl:Result>
-          </dxl:Result>
+          </dxl:RandomMotion>
         </dxl:RandomMotion>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -200,6 +200,10 @@ namespace gpos
 		// is nestloop params enabled, it is only enabled in GPDB 6.x onwards.
 		EopttraceIndexedNLJOuterRefAsParams = 106000,
 
+		// force redistribute motion on insert statement on randomly distributed tables
+		// for proper data distribution
+		EopttraceForceRedistributeOnInsertOnRandomDistrTables = 106001,
+
 		// max
 		EopttraceSentinel = 199999
 	};


### PR DESCRIPTION
If the trace flag EopttraceForceRedistributeOnInsertOnRandomDistrTables
is set, force a redistribute motion before executing insert on randomly
distributed table. This will ensure random data distribution across all
the segments, otherwise the data may be inserted into only 1 segment or a
few depending on the data distribution fed to Insert node.

Plan and data distribution after the commit.
```
create table foo (a int, b int) distributed randomly;
create table bar (a int, b int) distributed by (b);
insert into bar select i, i from generate_series(1,20)i;
create table baz (a int, b int) distributed randomly;
insert into baz select i, i from generate_series(1,20)i;
bchaudhary=# explain insert into foo values(1,1), (1,2), (1,3), (2,3), (23,234), (2342,2342432);
                                       QUERY PLAN
-----------------------------------------------------------------------------------------
 Insert  (cost=0.00..0.09 rows=2 width=8)
   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..0.00 rows=2 width=12)
         ->  Result  (cost=0.00..0.00 rows=2 width=12)
               ->  Result  (cost=0.00..0.00 rows=2 width=8)
                     ->  Values Scan on "Values"  (cost=0.00..0.00 rows=2 width=8)
 Optimizer: PQO version 2.67.0
(7 rows)

bchaudhary=# insert into foo values(1,1), (1,2), (1,3), (2,3), (23,234), (2342,2342432);
INSERT 0 6
Time: 100.191 ms
bchaudhary=# select count(*), gp_segment_id from foo group by 2;
 count | gp_segment_id
-------+---------------
     2 |             0
     2 |             1
     2 |             2

Time: 102.034 ms
truncate foo;
bchaudhary=# explain insert into foo select * from bar;
                                              QUERY PLAN
------------------------------------------------------------------------------------------------------
 Insert  (cost=0.00..431.02 rows=1 width=8)
   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12) ==> additional redistribute motion even though the data is redistributed already.
         ->  Result  (cost=0.00..431.00 rows=1 width=12)
               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                     ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
 Optimizer: PQO version 2.67.0
(6 rows)
bchaudhary=# insert into foo select * from bar;
INSERT 0 20
bchaudhary=# select count(*), gp_segment_id from foo group by 2;
 count | gp_segment_id
-------+---------------
     9 |             0
     8 |             1
     3 |             2

Time: 94.081 ms
bchaudhary=# explain insert into foo select * from baz;
                                        QUERY PLAN
-------------------------------------------------------------------------------------------
 Insert  (cost=0.00..431.02 rows=1 width=8)
   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
         ->  Result  (cost=0.00..431.00 rows=1 width=12)
               ->  Table Scan on baz  (cost=0.00..431.00 rows=1 width=8)
 Optimizer: PQO version 2.67.0
bchaudhary=# insert into foo select * from baz;
INSERT 0 20
Time: 117.243 ms
bchaudhary=# select count(*), gp_segment_id from foo group by 2;
 count | gp_segment_id
-------+---------------
     6 |             0
    10 |             1
     4 |             2
```

Corresponding GPDB PR: https://github.com/greenplum-db/gpdb/pull/5369