### PR TITLE
[WIP] Do not push down residual filters in index NLJ

### DIFF
--- a/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
@@ -367,7 +367,7 @@ select * from x, y where x.i > y.j and y.k = 10;
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.002729" Rows="1.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002805" Rows="1.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -397,9 +397,9 @@ select * from x, y where x.i > y.j and y.k = 10;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.002551" Rows="1.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002626" Rows="1.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -429,7 +429,10 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="13" ColName="k" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+            </dxl:Comparison>
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
@@ -489,7 +492,7 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:BroadcastMotion>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.001346" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001320" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="i">
@@ -505,12 +508,7 @@ select * from x, y where x.i > y.j and y.k = 10;
                 <dxl:Ident ColId="14" ColName="m" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="13" ColName="k" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-              </dxl:Comparison>
-            </dxl:Filter>
+            <dxl:Filter/>
             <dxl:RecheckCond>
               <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                 <dxl:Ident ColId="12" ColName="j" TypeMdid="0.23.1.0"/>

--- a/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -416,7 +416,7 @@ select * from x, y where x.i > y.j and y.k = 10;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.002737" Rows="1.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.002813" Rows="1.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -446,9 +446,9 @@ select * from x, y where x.i > y.j and y.k = 10;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.002559" Rows="1.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.002634" Rows="1.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -478,7 +478,10 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="13" ColName="k" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
+            </dxl:Comparison>
           </dxl:JoinFilter>
           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
@@ -538,7 +541,7 @@ select * from x, y where x.i > y.j and y.k = 10;
           </dxl:BroadcastMotion>
           <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.001354" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.001320" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="11" Alias="i">
@@ -577,7 +580,7 @@ select * from x, y where x.i > y.j and y.k = 10;
             </dxl:PartitionSelector>
             <dxl:DynamicBitmapTableScan PartIndexId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001354" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001320" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="11" Alias="i">
@@ -593,12 +596,7 @@ select * from x, y where x.i > y.j and y.k = 10;
                   <dxl:Ident ColId="14" ColName="m" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="13" ColName="k" TypeMdid="0.23.1.0"/>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="10"/>
-                </dxl:Comparison>
-              </dxl:Filter>
+              <dxl:Filter/>
               <dxl:RecheckCond>
                 <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
                   <dxl:Ident ColId="12" ColName="j" TypeMdid="0.23.1.0"/>

--- a/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1400,7 +1400,7 @@ ORDER BY 1 asc ;
     <dxl:Plan Id="0" SpaceSize="70">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="24.847656" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="23.437500" Rows="1.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1413,7 +1413,7 @@ ORDER BY 1 asc ;
         </dxl:SortingColumnList>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="23.843750" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="22.433594" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="23"/>
@@ -1426,7 +1426,7 @@ ORDER BY 1 asc ;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="22.820312" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="21.410156" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1441,7 +1441,7 @@ ORDER BY 1 asc ;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="21.820312" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="20.410156" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1457,7 +1457,7 @@ ORDER BY 1 asc ;
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="20.816406" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="19.406250" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="23" Alias="fivemin">
@@ -1475,9 +1475,9 @@ ORDER BY 1 asc ;
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true">
+                <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="19.808594" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="18.398438" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="event_ts">
@@ -1486,7 +1486,12 @@ ORDER BY 1 asc ;
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                      <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                        <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
+                      </dxl:Cast>
+                      <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
+                    </dxl:Comparison>
                   </dxl:JoinFilter>
                   <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
@@ -1534,7 +1539,7 @@ ORDER BY 1 asc ;
                   </dxl:BroadcastMotion>
                   <dxl:Sequence>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2.419922" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="0.002381" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="11" Alias="ets">
@@ -1570,7 +1575,7 @@ ORDER BY 1 asc ;
                     </dxl:PartitionSelector>
                     <dxl:DynamicBitmapTableScan PartIndexId="1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="2.419922" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.001953" Rows="0.002381" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="11" Alias="ets">
@@ -1583,14 +1588,7 @@ ORDER BY 1 asc ;
                           <dxl:Ident ColId="15" ColName="end_ts" TypeMdid="0.20.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                          <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
-                            <dxl:Ident ColId="12" ColName="sym" TypeMdid="0.1043.1.0"/>
-                          </dxl:Cast>
-                          <dxl:Ident ColId="0" ColName="symbol" TypeMdid="0.1042.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
+                      <dxl:Filter/>
                       <dxl:RecheckCond>
                         <dxl:And>
                           <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.414.1.0">

--- a/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -825,7 +825,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="36">
+    <dxl:Plan Id="0" SpaceSize="37">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="635.393021" Rows="22.230000" Width="24"/>

--- a/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
+++ b/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
@@ -22,35 +22,30 @@ create index idx_t3_a on t3(a);
 create index idx_t4_a on t4(a);
 set optimizer_enable_hashjoin=off;
 
-explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a and t2.b > 5) left join t3 on t3.a = t0.a left join t4 on (t4.a=t0.a and t4.b < 3);
-
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3452.00 rows=5 width=40)
-   ->  Nested Loop Left Join  (cost=0.00..3452.00 rows=2 width=40)
-         Join Filter: true
-         ->  Nested Loop Left Join  (cost=0.00..1728.00 rows=2 width=32)
+shardikar=# explain (costs off) select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a and t2.b > 5) left join t3 on t3.a = t0.a left join t4 on (t4.a=t0.a and t4.b < 3);
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Nested Loop Left Join
+         Join Filter: (b < 3)
+         ->  Nested Loop Left Join
                Join Filter: true
-               ->  Nested Loop Left Join  (cost=0.00..435.00 rows=1 width=24)
+               ->  Nested Loop Left Join
                      Join Filter: true
-                     ->  Nested Loop Left Join  (cost=0.00..433.00 rows=1 width=16)
+                     ->  Nested Loop Left Join
                            Join Filter: true
-                           ->  Table Scan on t0  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Index Scan using t1_pkey on t1  (cost=0.00..2.00 rows=1 width=8)
-                                 Index Cond: t1.a = t0.a
-                     ->  Index Scan using t2_pkey on t2  (cost=0.00..2.00 rows=1 width=8)
-                           Index Cond: t2.a = t0.a
-                           Filter: t2.b > 5
-               ->  Bitmap Table Scan on t3  (cost=0.00..1293.00 rows=1 width=8)
-                     Recheck Cond: t3.a = t0.a
-                     ->  Bitmap Index Scan on idx_t3_a  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: t3.a = t0.a
-         ->  Bitmap Table Scan on t4  (cost=0.00..1724.00 rows=1 width=8)
-               Recheck Cond: t4.a = t0.a
-               Filter: t4.b < 3
-               ->  Bitmap Index Scan on idx_t4_a  (cost=0.00..0.00 rows=0 width=0)
-                     Index Cond: t4.a = t0.a
- Settings:  optimizer=on
- Optimizer status: PQO version 2.53.3
-(26 rows)
+                           ->  Table Scan on t0
+                           ->  Index Scan using t1_pkey on t1
+                                 Index Cond: (a = t0.a)
+                     ->  Index Scan using t2_pkey on t2
+                           Index Cond: (a = t0.a)
+                           Filter: (b > 5)
+               ->  Bitmap Table Scan on t3
+                     Recheck Cond: (a = t0.a)
+                     ->  Bitmap Index Scan on idx_t3_a
+                           Index Cond: (a = t0.a)
+         ->  Bitmap Table Scan on t4
+               Recheck Cond: (a = t0.a)
+               ->  Bitmap Index Scan on idx_t4_a
+                     Index Cond: (a = t0.a)
 -->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
@@ -503,7 +498,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3466.003117" Rows="5.000000" Width="40"/>
+          <dxl:Cost StartupCost="0" TotalCost="3466.003439" Rows="5.000000" Width="40"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -539,9 +534,9 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true">
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3466.002372" Rows="5.000000" Width="40"/>
+            <dxl:Cost StartupCost="0" TotalCost="3466.002693" Rows="5.000000" Width="40"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -577,9 +572,12 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
+            </dxl:Comparison>
           </dxl:JoinFilter>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true">
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="1742.001590" Rows="4.000000" Width="32"/>
             </dxl:Properties>
@@ -613,7 +611,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
             <dxl:JoinFilter>
               <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
             </dxl:JoinFilter>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true">
+            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="449.000653" Rows="3.000000" Width="24"/>
               </dxl:Properties>
@@ -641,7 +639,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
               <dxl:JoinFilter>
                 <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
               </dxl:JoinFilter>
-              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true">
+              <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="437.000259" Rows="2.000000" Width="16"/>
                 </dxl:Properties>
@@ -806,7 +804,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
           </dxl:NestedLoopJoin>
           <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.000471" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000440" Rows="0.250000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="32" Alias="a">
@@ -816,12 +814,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
                 <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter>
-              <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                <dxl:Ident ColId="33" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="3"/>
-              </dxl:Comparison>
-            </dxl:Filter>
+            <dxl:Filter/>
             <dxl:RecheckCond>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
                 <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>

--- a/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -986,7 +986,8 @@ namespace gpopt
 				CTableDescriptor *ptabdesc,
 				CExpression *pexprScalar,
 				CColRefSet *outer_refs,
-				CColRefSet *pcrsReqd
+				CColRefSet *pcrsReqd,
+				CExpression **ppexprResidual
 				);
 
 			// transform a Select over a (dynamic) table get into a bitmap table scan

--- a/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -381,6 +381,7 @@ void CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives
 	}
 
 	CLogical *popGet = CLogical::PopConvert(pexprInner->Pop());
+	CExpression *pexprResidual = NULL;
 	CExpression *pexprLogicalIndexGet = CXformUtils::PexprBitmapTableGet
 										(
 										mp,
@@ -389,7 +390,8 @@ void CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives
 										ptabdescInner,
 										pexprScalar,
 										outer_refs,
-										pcrsReqd
+										pcrsReqd,
+										&pexprResidual
 										);
 	if (NULL != pexprLogicalIndexGet)
 	{
@@ -397,6 +399,12 @@ void CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives
 		// and add it to xform results
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
 		pexprOuter->AddRef();
+
+		if (NULL == pexprResidual)
+		{
+			pexprResidual = CUtils::PexprScalarConstBool(mp, true);
+		}
+
 		CExpression *pexprIndexApply =
 			GPOS_NEW(mp) CExpression
 				(
@@ -404,7 +412,7 @@ void CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives
 				PopLogicalApply(mp, colref_array),
 				pexprOuter,
 				pexprLogicalIndexGet,
-				CPredicateUtils::PexprConjunction(mp, NULL /*pdrgpexpr*/)
+				pexprResidual
 				);
 		pxfres->Add(pexprIndexApply);
 	}

--- a/libgpopt/src/xforms/CXformUtils.cpp
+++ b/libgpopt/src/xforms/CXformUtils.cpp
@@ -3881,6 +3881,7 @@ CXformUtils::PexprSelect2BitmapBoolOp
 	pcrsReqd->Include(pcrsOutput);
 	pcrsReqd->Include(pcrsScalarExpr);
 
+	CExpression *pexprResidual = NULL;
 	CExpression *pexprResult = PexprBitmapTableGet
 								(
 								mp,
@@ -3889,8 +3890,21 @@ CXformUtils::PexprSelect2BitmapBoolOp
 								ptabdesc,
 								pexprScalar,
 								NULL,  // outer_refs
-								pcrsReqd
+								pcrsReqd,
+								&pexprResidual
 								);
+
+	if (NULL != pexprResidual)
+	{
+		// add a selection on top with the residual condition
+		pexprResult = GPOS_NEW(mp) CExpression
+						(
+						mp,
+						GPOS_NEW(mp) CLogicalSelect(mp),
+						pexprResult,
+						pexprResidual
+						);
+	}
 	pcrsReqd->Release();
 
 	return pexprResult;
@@ -3914,7 +3928,8 @@ CXformUtils::PexprBitmapTableGet
 	CTableDescriptor *ptabdesc,
 	CExpression *pexprScalar,
 	CColRefSet *outer_refs,
-	CColRefSet *pcrsReqd
+	CColRefSet *pcrsReqd,
+	CExpression **ppexprResidual
 	)
 {
 	GPOS_ASSERT(COperator::EopLogicalGet == popGet->Eopid() || 
@@ -3941,7 +3956,6 @@ CXformUtils::PexprBitmapTableGet
 	GPOS_ASSERT(NULL != pdrgpcrOutput);
 	
 	CExpression *pexprRecheck = NULL;
-	CExpression *pexprResidual = NULL;
 	CExpression *pexprBitmap = PexprScalarBitmapBoolOp
 				(
 				mp,
@@ -3955,7 +3969,7 @@ CXformUtils::PexprBitmapTableGet
 				pcrsReqd,
 				fConjunction,
 				&pexprRecheck,
-				&pexprResidual
+				ppexprResidual
 				);
 	CExpression *pexprResult = NULL;
 
@@ -4003,18 +4017,6 @@ CXformUtils::PexprBitmapTableGet
 						pexprRecheck,
 						pexprBitmap
 						);
-		
-		if (NULL != pexprResidual)
-		{
-			// add a selection on top with the residual condition
-			pexprResult = GPOS_NEW(mp) CExpression
-							(
-							mp,
-							GPOS_NEW(mp) CLogicalSelect(mp),
-							pexprResult,
-							pexprResidual
-							);				
-		}
 	}
 	
 	// cleanup


### PR DESCRIPTION
When the join condition of an Index NLJ contains index columns along
with non-index columns (residual filters), ORCA produces a plan with a
filter on the Index Scan. That is, it "pushes" the join filter down to
the Index Scan.

For example:
explain (costs off)
select * from foo, bar where foo.c = bar.c and foo.a = bar.a;

 Gather Motion 3:1  (slice2; segments: 3)
   ->  Nested Loop
         Join Filter: true
         ->  Broadcast Motion 3:3  (slice1; segments: 3)
               ->  Table Scan on bar
         ->  Index Scan using foo_c_bt_idx on foo
               Index Cond: (c = bar.c)
               Filter: (a = bar.a)

Although, this is not incorrect, it means that ORCA misses out on some
optimizations because the join now appears like a cross join. For
example, for the above plan, ORCA could have avoided the Broadcast
motion altogether if both foo and bar were distributed by (a).
Besides, since the pushed filter is not even used in the Index Scan, it
provides negligible performance advantages.

This PR disables this push down of the residual filters.