### PR TITLE
Merge NDVs when computing statistics for ORs

### DIFF
--- a/data/dxl/minidump/ArrayCmpAny.mdp
+++ b/data/dxl/minidump/ArrayCmpAny.mdp
@@ -1,0 +1,653 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<!--
+TPC-DS 
+explain select * from date_dim where d_quarter_name in ('2000Q1','2000Q2','2000Q3')
+-->
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000" EnforceConstraintsOnDML="false"/>
+      <dxl:TraceFlags Value="101013,102074,102120,103001,103014,103015,103022,103027,104003,104004,104005,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16393.1.0" Name="date_dim" Rows="73049.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16393.1.0" Name="date_dim" IsTemporary="false" HasOids="false" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="0" Keys="31,29" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="d_date_sk" Attno="1" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_date_id" Attno="2" Mdid="0.1042.1.0" TypeModifier="20" Nullable="false" ColWidth="17">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_date" Attno="3" Mdid="0.1082.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_month_seq" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_week_seq" Attno="5" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_quarter_seq" Attno="6" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_year" Attno="7" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_dow" Attno="8" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_moy" Attno="9" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_dom" Attno="10" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_qoy" Attno="11" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_fy_year" Attno="12" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_fy_quarter_seq" Attno="13" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_fy_week_seq" Attno="14" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_day_name" Attno="15" Mdid="0.1042.1.0" TypeModifier="13" Nullable="true" ColWidth="10">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_quarter_name" Attno="16" Mdid="0.1042.1.0" TypeModifier="10" Nullable="true" ColWidth="7">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_holiday" Attno="17" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_weekend" Attno="18" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_following_holiday" Attno="19" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_first_dom" Attno="20" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_last_dom" Attno="21" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_same_day_ly" Attno="22" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_same_day_lq" Attno="23" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_current_day" Attno="24" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_current_week" Attno="25" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_current_month" Attno="26" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_current_quarter" Attno="27" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_current_year" Attno="28" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d_null" Attno="29" Mdid="0.1043.1.0" TypeModifier="14" Nullable="true" ColWidth="0">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1042.1.0" Name="bpchar" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="false" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.1054.1.0"/>
+        <dxl:InequalityOp Mdid="0.1057.1.0"/>
+        <dxl:LessThanOp Mdid="0.1058.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1059.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1060.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1061.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1078.1.0"/>
+        <dxl:ArrayType Mdid="0.1014.1.0"/>
+        <dxl:MinAgg Mdid="0.2245.1.0"/>
+        <dxl:MaxAgg Mdid="0.2244.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.1054.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.1042.1.0"/>
+        <dxl:RightType Mdid="0.1042.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1048.1.0"/>
+        <dxl:Commutator Mdid="0.1054.1.0"/>
+        <dxl:InverseOp Mdid="0.1057.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.426.1.0"/>
+          <dxl:OpClass Mdid="0.427.1.0"/>
+          <dxl:OpClass Mdid="0.3018.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.1058.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.1042.1.0"/>
+        <dxl:RightType Mdid="0.1042.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1049.1.0"/>
+        <dxl:Commutator Mdid="0.1060.1.0"/>
+        <dxl:InverseOp Mdid="0.1061.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.426.1.0"/>
+          <dxl:OpClass Mdid="0.3018.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.1060.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.1042.1.0"/>
+        <dxl:RightType Mdid="0.1042.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1051.1.0"/>
+        <dxl:Commutator Mdid="0.1058.1.0"/>
+        <dxl:InverseOp Mdid="0.1059.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.426.1.0"/>
+          <dxl:OpClass Mdid="0.3018.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16393.1.0.15" Name="d_quarter_name" Width="7.000000" NullFreq="0.000000" NdvRemain="797.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.1093.1.0"/>
+        <dxl:InequalityOp Mdid="0.1094.1.0"/>
+        <dxl:LessThanOp Mdid="0.1095.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1096.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1097.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1098.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1092.1.0"/>
+        <dxl:ArrayType Mdid="0.1182.1.0"/>
+        <dxl:MinAgg Mdid="0.2138.1.0"/>
+        <dxl:MaxAgg Mdid="0.2122.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16393.1.0.0" Name="d_date_sk" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2415052"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2419585"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2419585"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2424302"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2424302"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2429183"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2429183"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2434672"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2434672"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2439543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2439543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2444148"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2444148"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2449142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2449142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2453870"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2453870"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2458734"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2458734"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2463944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2463944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2468676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2468676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2473507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2473507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2478041"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2478041"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2482821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.066667" DistinctValues="4869.933333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2482821"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="2487990"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="d_date_id" TypeMdid="0.1042.1.0" TypeModifier="20"/>
+        <dxl:Ident ColId="3" ColName="d_date" TypeMdid="0.1082.1.0"/>
+        <dxl:Ident ColId="4" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="5" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="7" ColName="d_year" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="8" ColName="d_dow" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="d_moy" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="d_dom" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="12" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="15" ColName="d_day_name" TypeMdid="0.1042.1.0" TypeModifier="13"/>
+        <dxl:Ident ColId="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10"/>
+        <dxl:Ident ColId="17" ColName="d_holiday" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="18" ColName="d_weekend" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="20" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="21" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="24" ColName="d_current_day" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="25" ColName="d_current_week" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="26" ColName="d_current_month" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="28" ColName="d_current_year" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="29" ColName="d_null" TypeMdid="0.1043.1.0" TypeModifier="14"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:ArrayComp OperatorName="=" OperatorMdid="0.1054.1.0" OperatorType="Any">
+          <dxl:Ident ColId="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10" ArrayConstLength="3"/>
+          <dxl:Array ArrayType="0.1014.1.0" ElementType="0.1042.1.0" MultiDimensional="false">
+            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDBRMQ==" LintValue="382083900"/>
+            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDBRMg==" LintValue="382092092"/>
+            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDBRMw==" LintValue="382100284"/>
+          </dxl:Array>
+        </dxl:ArrayComp>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16393.1.0" TableName="date_dim">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" TypeModifier="20" ColWidth="17"/>
+              <dxl:Column ColId="3" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="7" ColName="d_year" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" TypeModifier="13" ColWidth="10"/>
+              <dxl:Column ColId="16" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10" ColWidth="7"/>
+              <dxl:Column ColId="17" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="18" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="19" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="20" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="21" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="22" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="23" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="24" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="25" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="26" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="27" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="28" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+              <dxl:Column ColId="29" Attno="29" ColName="d_null" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="0"/>
+              <dxl:Column ColId="30" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+  <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+    <dxl:Properties>
+      <dxl:Cost StartupCost="0" TotalCost="433.710434" Rows="275.964868" Width="118"/>
+    </dxl:Properties>
+    <dxl:ProjList>
+      <dxl:ProjElem ColId="0" Alias="d_date_sk">
+        <dxl:Ident ColId="0" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="1" Alias="d_date_id">
+        <dxl:Ident ColId="1" ColName="d_date_id" TypeMdid="0.1042.1.0" TypeModifier="20"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="2" Alias="d_date">
+        <dxl:Ident ColId="2" ColName="d_date" TypeMdid="0.1082.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="3" Alias="d_month_seq">
+        <dxl:Ident ColId="3" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="4" Alias="d_week_seq">
+        <dxl:Ident ColId="4" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="5" Alias="d_quarter_seq">
+        <dxl:Ident ColId="5" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="6" Alias="d_year">
+        <dxl:Ident ColId="6" ColName="d_year" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="7" Alias="d_dow">
+        <dxl:Ident ColId="7" ColName="d_dow" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="8" Alias="d_moy">
+        <dxl:Ident ColId="8" ColName="d_moy" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="9" Alias="d_dom">
+        <dxl:Ident ColId="9" ColName="d_dom" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="10" Alias="d_qoy">
+        <dxl:Ident ColId="10" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="11" Alias="d_fy_year">
+        <dxl:Ident ColId="11" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="12" Alias="d_fy_quarter_seq">
+        <dxl:Ident ColId="12" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="13" Alias="d_fy_week_seq">
+        <dxl:Ident ColId="13" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="14" Alias="d_day_name">
+        <dxl:Ident ColId="14" ColName="d_day_name" TypeMdid="0.1042.1.0" TypeModifier="13"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="15" Alias="d_quarter_name">
+        <dxl:Ident ColId="15" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="16" Alias="d_holiday">
+        <dxl:Ident ColId="16" ColName="d_holiday" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="17" Alias="d_weekend">
+        <dxl:Ident ColId="17" ColName="d_weekend" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="18" Alias="d_following_holiday">
+        <dxl:Ident ColId="18" ColName="d_following_holiday" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="19" Alias="d_first_dom">
+        <dxl:Ident ColId="19" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="20" Alias="d_last_dom">
+        <dxl:Ident ColId="20" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="21" Alias="d_same_day_ly">
+        <dxl:Ident ColId="21" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="22" Alias="d_same_day_lq">
+        <dxl:Ident ColId="22" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="23" Alias="d_current_day">
+        <dxl:Ident ColId="23" ColName="d_current_day" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="24" Alias="d_current_week">
+        <dxl:Ident ColId="24" ColName="d_current_week" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="25" Alias="d_current_month">
+        <dxl:Ident ColId="25" ColName="d_current_month" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="26" Alias="d_current_quarter">
+        <dxl:Ident ColId="26" ColName="d_current_quarter" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="27" Alias="d_current_year">
+        <dxl:Ident ColId="27" ColName="d_current_year" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:ProjElem>
+      <dxl:ProjElem ColId="28" Alias="d_null">
+        <dxl:Ident ColId="28" ColName="d_null" TypeMdid="0.1043.1.0" TypeModifier="14"/>
+      </dxl:ProjElem>
+    </dxl:ProjList>
+    <dxl:Filter/>
+    <dxl:SortingColumnList/>
+    <dxl:TableScan>
+      <dxl:Properties>
+        <dxl:Cost StartupCost="0" TotalCost="433.589079" Rows="275.964868" Width="118"/>
+      </dxl:Properties>
+      <dxl:ProjList>
+        <dxl:ProjElem ColId="0" Alias="d_date_sk">
+          <dxl:Ident ColId="0" ColName="d_date_sk" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="1" Alias="d_date_id">
+          <dxl:Ident ColId="1" ColName="d_date_id" TypeMdid="0.1042.1.0" TypeModifier="20"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="2" Alias="d_date">
+          <dxl:Ident ColId="2" ColName="d_date" TypeMdid="0.1082.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="3" Alias="d_month_seq">
+          <dxl:Ident ColId="3" ColName="d_month_seq" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="4" Alias="d_week_seq">
+          <dxl:Ident ColId="4" ColName="d_week_seq" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="5" Alias="d_quarter_seq">
+          <dxl:Ident ColId="5" ColName="d_quarter_seq" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="6" Alias="d_year">
+          <dxl:Ident ColId="6" ColName="d_year" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="7" Alias="d_dow">
+          <dxl:Ident ColId="7" ColName="d_dow" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="8" Alias="d_moy">
+          <dxl:Ident ColId="8" ColName="d_moy" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="9" Alias="d_dom">
+          <dxl:Ident ColId="9" ColName="d_dom" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="10" Alias="d_qoy">
+          <dxl:Ident ColId="10" ColName="d_qoy" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="11" Alias="d_fy_year">
+          <dxl:Ident ColId="11" ColName="d_fy_year" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="12" Alias="d_fy_quarter_seq">
+          <dxl:Ident ColId="12" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="13" Alias="d_fy_week_seq">
+          <dxl:Ident ColId="13" ColName="d_fy_week_seq" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="14" Alias="d_day_name">
+          <dxl:Ident ColId="14" ColName="d_day_name" TypeMdid="0.1042.1.0" TypeModifier="13"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="15" Alias="d_quarter_name">
+          <dxl:Ident ColId="15" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="16" Alias="d_holiday">
+          <dxl:Ident ColId="16" ColName="d_holiday" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="17" Alias="d_weekend">
+          <dxl:Ident ColId="17" ColName="d_weekend" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="18" Alias="d_following_holiday">
+          <dxl:Ident ColId="18" ColName="d_following_holiday" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="19" Alias="d_first_dom">
+          <dxl:Ident ColId="19" ColName="d_first_dom" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="20" Alias="d_last_dom">
+          <dxl:Ident ColId="20" ColName="d_last_dom" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="21" Alias="d_same_day_ly">
+          <dxl:Ident ColId="21" ColName="d_same_day_ly" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="22" Alias="d_same_day_lq">
+          <dxl:Ident ColId="22" ColName="d_same_day_lq" TypeMdid="0.23.1.0"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="23" Alias="d_current_day">
+          <dxl:Ident ColId="23" ColName="d_current_day" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="24" Alias="d_current_week">
+          <dxl:Ident ColId="24" ColName="d_current_week" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="25" Alias="d_current_month">
+          <dxl:Ident ColId="25" ColName="d_current_month" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="26" Alias="d_current_quarter">
+          <dxl:Ident ColId="26" ColName="d_current_quarter" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="27" Alias="d_current_year">
+          <dxl:Ident ColId="27" ColName="d_current_year" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:ProjElem>
+        <dxl:ProjElem ColId="28" Alias="d_null">
+          <dxl:Ident ColId="28" ColName="d_null" TypeMdid="0.1043.1.0" TypeModifier="14"/>
+        </dxl:ProjElem>
+      </dxl:ProjList>
+      <dxl:Filter>
+        <dxl:ArrayComp OperatorName="=" OperatorMdid="0.1054.1.0" OperatorType="Any">
+          <dxl:Ident ColId="15" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10"/>
+          <dxl:Array ArrayType="0.1014.1.0" ElementType="0.1042.1.0" MultiDimensional="false">
+            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDBRMQ==" LintValue="382083900"/>
+            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDBRMg==" LintValue="382092092"/>
+            <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" IsByValue="false" Value="AAAACjIwMDBRMw==" LintValue="382100284"/>
+          </dxl:Array>
+        </dxl:ArrayComp>
+      </dxl:Filter>
+      <dxl:TableDescriptor Mdid="0.16393.1.0" TableName="date_dim">
+        <dxl:Columns>
+          <dxl:Column ColId="0" Attno="1" ColName="d_date_sk" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="1" Attno="2" ColName="d_date_id" TypeMdid="0.1042.1.0" TypeModifier="20" ColWidth="17"/>
+          <dxl:Column ColId="2" Attno="3" ColName="d_date" TypeMdid="0.1082.1.0" ColWidth="4"/>
+          <dxl:Column ColId="3" Attno="4" ColName="d_month_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="4" Attno="5" ColName="d_week_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="5" Attno="6" ColName="d_quarter_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="6" Attno="7" ColName="d_year" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="7" Attno="8" ColName="d_dow" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="8" Attno="9" ColName="d_moy" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="9" Attno="10" ColName="d_dom" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="10" Attno="11" ColName="d_qoy" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="11" Attno="12" ColName="d_fy_year" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="12" Attno="13" ColName="d_fy_quarter_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="13" Attno="14" ColName="d_fy_week_seq" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="14" Attno="15" ColName="d_day_name" TypeMdid="0.1042.1.0" TypeModifier="13" ColWidth="10"/>
+          <dxl:Column ColId="15" Attno="16" ColName="d_quarter_name" TypeMdid="0.1042.1.0" TypeModifier="10" ColWidth="7"/>
+          <dxl:Column ColId="16" Attno="17" ColName="d_holiday" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="17" Attno="18" ColName="d_weekend" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="18" Attno="19" ColName="d_following_holiday" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="19" Attno="20" ColName="d_first_dom" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="20" Attno="21" ColName="d_last_dom" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="21" Attno="22" ColName="d_same_day_ly" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="22" Attno="23" ColName="d_same_day_lq" TypeMdid="0.23.1.0" ColWidth="4"/>
+          <dxl:Column ColId="23" Attno="24" ColName="d_current_day" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="24" Attno="25" ColName="d_current_week" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="25" Attno="26" ColName="d_current_month" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="26" Attno="27" ColName="d_current_quarter" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="27" Attno="28" ColName="d_current_year" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+          <dxl:Column ColId="28" Attno="29" ColName="d_null" TypeMdid="0.1043.1.0" TypeModifier="14" ColWidth="0"/>
+          <dxl:Column ColId="29" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+          <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+          <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+        </dxl:Columns>
+      </dxl:TableDescriptor>
+    </dxl:TableScan>
+  </dxl:GatherMotion>
+</dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/FilterScalarCast.mdp
+++ b/data/dxl/minidump/FilterScalarCast.mdp
@@ -514,7 +514,7 @@ EXPLAIN SELECT * FROM foo WHERE b IN ('xyz', 'asds');
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="432.861857" Rows="1405.718310" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="432.916810" Rows="2810.436620" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -528,7 +528,7 @@ EXPLAIN SELECT * FROM foo WHERE b IN ('xyz', 'asds');
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="432.814710" Rows="1405.718310" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="432.822548" Rows="2810.436620" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/data/dxl/minidump/MinCardinalityNaryJoin.mdp
+++ b/data/dxl/minidump/MinCardinalityNaryJoin.mdp
@@ -13358,10 +13358,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63735661952">
+    <dxl:Plan Id="0" SpaceSize="19925943560">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="16516.907108" Rows="122051.162098" Width="191"/>
+          <dxl:Cost StartupCost="0" TotalCost="89973519743081.046875" Rows="312803.779111" Width="191"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="ccd">
@@ -13417,7 +13417,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="16430.031904" Rows="122051.162098" Width="191"/>
+            <dxl:Cost StartupCost="0" TotalCost="89973519742858.390625" Rows="312803.779111" Width="191"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="3"/>
@@ -13492,7 +13492,7 @@
           <dxl:Filter/>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="16345.139666" Rows="122051.162098" Width="191"/>
+              <dxl:Cost StartupCost="0" TotalCost="89973519742640.828125" Rows="312803.779111" Width="191"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -13592,7 +13592,7 @@
             </dxl:HashExprList>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="16320.817717" Rows="122051.162098" Width="191"/>
+                <dxl:Cost StartupCost="0" TotalCost="89973519742578.500000" Rows="312803.779111" Width="191"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -13648,7 +13648,7 @@
               <dxl:OneTimeFilter/>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="16320.817717" Rows="122051.162098" Width="191"/>
+                  <dxl:Cost StartupCost="0" TotalCost="89973519742578.500000" Rows="312803.779111" Width="191"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="3"/>
@@ -13723,7 +13723,7 @@
                 <dxl:Filter/>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="12442.676658" Rows="5719390.578080" Width="189"/>
+                    <dxl:Cost StartupCost="0" TotalCost="22087986938243.031250" Rows="100172276179760064.000000" Width="189"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -13785,7 +13785,7 @@
                   </dxl:HashCondList>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="10362.359857" Rows="965277.538797" Width="167"/>
+                      <dxl:Cost StartupCost="0" TotalCost="38893.711714" Rows="10689690.415439" Width="167"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -13847,7 +13847,7 @@
                     </dxl:HashCondList>
                     <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="9655.428774" Rows="965277.538797" Width="163"/>
+                        <dxl:Cost StartupCost="0" TotalCost="35407.002106" Rows="10689690.415439" Width="163"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -13913,7 +13913,7 @@
                       </dxl:HashCondList>
                       <dxl:HashJoin JoinType="Inner">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="8924.641576" Rows="965277.504323" Width="165"/>
+                          <dxl:Cost StartupCost="0" TotalCost="31656.185079" Rows="10689690.033665" Width="165"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -13978,7 +13978,7 @@
                         </dxl:HashCondList>
                         <dxl:HashJoin JoinType="Inner">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="8221.646581" Rows="965277.504323" Width="153"/>
+                            <dxl:Cost StartupCost="0" TotalCost="28215.842511" Rows="10689690.033665" Width="153"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14043,7 +14043,7 @@
                           </dxl:HashCondList>
                           <dxl:HashJoin JoinType="Inner">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="7489.311577" Rows="965277.504323" Width="150"/>
+                              <dxl:Cost StartupCost="0" TotalCost="24888.223876" Rows="10689690.033665" Width="150"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14108,7 +14108,7 @@
                             </dxl:HashCondList>
                             <dxl:HashJoin JoinType="Inner">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="6521.559385" Rows="965277.504323" Width="150"/>
+                                <dxl:Cost StartupCost="0" TotalCost="21359.223497" Rows="10689690.033665" Width="150"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14175,7 +14175,7 @@
                               </dxl:HashCondList>
                               <dxl:HashJoin JoinType="Inner">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="5837.590409" Rows="965277.504323" Width="133"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="18147.565283" Rows="10689690.033665" Width="133"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14240,7 +14240,7 @@
                                 </dxl:HashCondList>
                                 <dxl:HashJoin JoinType="Inner">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="5169.036157" Rows="965277.504323" Width="102"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="15205.385035" Rows="10689690.033665" Width="102"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14302,7 +14302,7 @@
                                   </dxl:HashCondList>
                                   <dxl:HashJoin JoinType="Inner">
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="4549.387236" Rows="965277.713032" Width="91"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="12685.524157" Rows="10689692.344949" Width="91"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14364,7 +14364,7 @@
                                     </dxl:HashCondList>
                                     <dxl:Sequence>
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="3942.541746" Rows="965278.119465" Width="99"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="10307.210916" Rows="10689696.845872" Width="99"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
                                         <dxl:ProjElem ColId="1" Alias="fl_yr">
@@ -14529,7 +14529,7 @@
                                       </dxl:PartitionSelector>
                                       <dxl:DynamicTableScan PartIndexId="1">
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="3942.541746" Rows="965278.119465" Width="99"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="10307.210916" Rows="10689696.845872" Width="99"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="1" Alias="fl_yr">

--- a/data/dxl/minidump/MinCardinalityNaryJoin.mdp
+++ b/data/dxl/minidump/MinCardinalityNaryJoin.mdp
@@ -13358,7 +13358,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="19925943560">
+    <dxl:Plan Id="0" SpaceSize="35594593568">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="89973519743081.046875" Rows="312803.779111" Width="191"/>

--- a/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -305,7 +305,8 @@ namespace gpnaucrates
 						CDouble rows,
 						const CHistogram *other_histogram,
 						CDouble rows_other,
-						CDouble *num_output_rows
+						CDouble *num_output_rows,
+						BOOL mergeNullsNDV
 						)
 						const;
 

--- a/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -306,7 +306,7 @@ namespace gpnaucrates
 						const CHistogram *other_histogram,
 						CDouble rows_other,
 						CDouble *num_output_rows,
-						BOOL mergeNullsNDV
+						BOOL merge_nulls_ndv
 						)
 						const;
 

--- a/libnaucrates/src/statistics/CFilterStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CFilterStatsProcessor.cpp
@@ -387,7 +387,7 @@ CFilterStatsProcessor::MakeHistHashMapDisjFilter
 
 	CDouble cumulative_rows(CStatistics::MinRows.Get());
 
-	BOOL eqPredicate = true;
+	BOOL is_eq_predicate = true;
 	// iterate over filters and update corresponding histograms
 	const ULONG filters = disjunctive_pred_stats->GetNumPreds();
 	for (ULONG ul = 0; ul < filters; ul++)
@@ -482,9 +482,10 @@ CFilterStatsProcessor::MakeHistHashMapDisjFilter
 			else
 			{
 
-				if (!eqPredicate || CStatsPred::EsptPoint != child_pred_stats->GetPredStatsType())
+				if (!is_eq_predicate || CStatsPred::EsptPoint != child_pred_stats->GetPredStatsType())
 				{
-					eqPredicate = false;
+					// the predicate is not point predicate or is not an equality predicate
+					is_eq_predicate = false;
 				}
 				else
 				{
@@ -492,7 +493,7 @@ CFilterStatsProcessor::MakeHistHashMapDisjFilter
 					// then we can merge the NDVs, else it does not make sense as we may land up double counting.
 					// For instance, we will not merge NDVs for the predicate [(a = 10) OR (a < 15)]
 					// It is important to note that duplicate predicates will be pruned in the preprocessing step.
-					eqPredicate = (CStatsPred::EstatscmptEq == CStatsPredPoint::ConvertPredStats(child_pred_stats)->GetCmpType());
+					is_eq_predicate = (CStatsPred::EstatscmptEq == CStatsPredPoint::ConvertPredStats(child_pred_stats)->GetCmpType());
 				}
 
 				// statistics operation already conducted on this column
@@ -504,7 +505,7 @@ CFilterStatsProcessor::MakeHistHashMapDisjFilter
 																	disjunctive_child_col_histogram,
 																	num_rows_disj_child,
 																	&output_rows,
-																	eqPredicate
+																	is_eq_predicate
 																	);
 				cumulative_rows = output_rows;
 

--- a/libnaucrates/src/statistics/CHistogram.cpp
+++ b/libnaucrates/src/statistics/CHistogram.cpp
@@ -1617,7 +1617,7 @@ CHistogram::MakeUnionHistogramNormalize
 	const CHistogram *other_histogram,
 	CDouble rows_other,
 	CDouble *num_output_rows,
-	BOOL mergeNullsNDV
+	BOOL merge_nulls_ndv
 	)
 	const
 {
@@ -1717,7 +1717,7 @@ CHistogram::MakeUnionHistogramNormalize
 	// compute the total number of rows having distinct values not captured by the buckets in both the histograms
 	CDouble NDV_remain_num_rows = std::max( (this->GetFreqRemain() * rows), (other_histogram->GetFreqRemain() * rows_other));
 
-	if (mergeNullsNDV)
+	if (merge_nulls_ndv)
 	{
 		num_null_rows = this->GetNullFreq() * rows + other_histogram->GetNullFreq() * rows_other;
 		num_NDV_remain = m_distinct_remaining + other_histogram->GetDistinctRemain();

--- a/libnaucrates/src/statistics/CHistogram.cpp
+++ b/libnaucrates/src/statistics/CHistogram.cpp
@@ -1616,7 +1616,8 @@ CHistogram::MakeUnionHistogramNormalize
 	CDouble rows,
 	const CHistogram *other_histogram,
 	CDouble rows_other,
-	CDouble *num_output_rows
+	CDouble *num_output_rows,
+	BOOL mergeNullsNDV
 	)
 	const
 {
@@ -1715,6 +1716,13 @@ CHistogram::MakeUnionHistogramNormalize
 
 	// compute the total number of rows having distinct values not captured by the buckets in both the histograms
 	CDouble NDV_remain_num_rows = std::max( (this->GetFreqRemain() * rows), (other_histogram->GetFreqRemain() * rows_other));
+
+	if (mergeNullsNDV)
+	{
+		num_null_rows = this->GetNullFreq() * rows + other_histogram->GetNullFreq() * rows_other;
+		num_NDV_remain = m_distinct_remaining + other_histogram->GetDistinctRemain();
+		NDV_remain_num_rows = (this->GetFreqRemain() * rows + other_histogram->GetFreqRemain() * rows_other);
+	}
 
 	CHistogram *result_histogram = MakeHistogramUpdateFreq
 									(

--- a/libnaucrates/src/statistics/CStatisticsUtils.cpp
+++ b/libnaucrates/src/statistics/CStatisticsUtils.cpp
@@ -725,7 +725,8 @@ CStatisticsUtils::UpdateDisjStatistics
 												input_disjunct_rows,
 												result_histogram,
 												local_rows,
-												&output_rows
+												&output_rows,
+												false /* mergeNullsNDV - false to indicate not to double count */
 												);
 
 			GPOS_DELETE(previous_histogram);
@@ -984,7 +985,8 @@ CStatisticsUtils::CreateHistHashMapAfterMergingDisjPreds
 													cumulative_rows,
 													disj_child_histogram,
 													num_rows_disj_child,
-													&output_rows
+													&output_rows,
+													false /* mergeNullsNDV - false to indicate not to double count */
 													);
 
 				AddHistogram

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -130,7 +130,7 @@ SelectCheckConstraint ExpandJoinOrder SelectOnBpchar EqualityJoin EffectsOfJoinF
 UDA-AnyElement-1 UDA-AnyElement-2 MinCardinalityNaryJoin Project-With-NonScalar-Func;
 
 CArrayCmpTest:
-ArrayConcat ArrayRef FoldedArrayCmp IN-ArrayCmp NOT-IN-ArrayCmp ArrayCmpAll UDA-AnyArray InClauseWithMCV
+ArrayCmpAny ArrayConcat ArrayRef FoldedArrayCmp IN-ArrayCmp NOT-IN-ArrayCmp ArrayCmpAll UDA-AnyArray InClauseWithMCV
 CastedInClauseWithMCV FilterScalarCast;
 
 CProjectTest:


### PR DESCRIPTION
Consider the OR predicate (a = 10) OR (a = 15) and the input histogram has
only NDVs. The statistics function computes result histogram for (a = 10)
as well as (a = 15) independently and then merges the two resultant
histogram in one.

The merge operation was too strict and took the maximum of the number of
distinct values (NDV)  of the two histograms to be the value for the
merged histogram. The underlying reason is correct for predicates such
as (a = 10) OR (a < 15) since this logic avoids double counting.

However, for equality operation adding up the two NDVs is fine.

It is important to note that duplicate predicates are removed during the
preprocessing step. The test added is an array comparison which is
converted into an OR before cardinality estimation