### PR TITLE
Fix for cardinality estimation of left outer joins

### DIFF
--- a/data/dxl/minidump/LOJ-IsNullPred.mdp
+++ b/data/dxl/minidump/LOJ-IsNullPred.mdp
@@ -12162,7 +12162,7 @@
     <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1980639.835413" Rows="2818278.671879" Width="251"/>
+          <dxl:Cost StartupCost="0" TotalCost="944427.390625" Rows="1.000000" Width="251"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -12299,7 +12299,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1635234.564592" Rows="2818278.671879" Width="251"/>
+            <dxl:Cost StartupCost="0" TotalCost="944426.268066" Rows="1.000000" Width="251"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">
@@ -12440,7 +12440,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="944425.022949" Rows="6352219.549592" Width="251"/>
+              <dxl:Cost StartupCost="0" TotalCost="944425.022949" Rows="3537227.014741" Width="251"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="ss_sold_date_sk">

--- a/data/dxl/minidump/LeftJoin-With-Coalesce.mdp
+++ b/data/dxl/minidump/LeftJoin-With-Coalesce.mdp
@@ -704,7 +704,7 @@ where coalesce(t2.fname, t3.fname) is not null;
     <dxl:Plan Id="0" SpaceSize="108">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1678.580161" Rows="2.250000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1657.955433" Rows="2.250000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="26" Alias="fname">
@@ -715,7 +715,7 @@ where coalesce(t2.fname, t3.fname) is not null;
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1678.580080" Rows="2.250000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1657.955353" Rows="2.250000" Width="8"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="26"/>
@@ -728,7 +728,7 @@ where coalesce(t2.fname, t3.fname) is not null;
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1678.580066" Rows="2.250000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1657.955339" Rows="2.250000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="26" Alias="fname">
@@ -743,7 +743,7 @@ where coalesce(t2.fname, t3.fname) is not null;
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1678.580057" Rows="2.250000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1657.955330" Rows="2.250000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="26" Alias="fname">
@@ -759,7 +759,7 @@ where coalesce(t2.fname, t3.fname) is not null;
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1678.580029" Rows="2.250000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1657.955302" Rows="2.250000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="26"/>
@@ -772,7 +772,7 @@ where coalesce(t2.fname, t3.fname) is not null;
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1647.097475" Rows="511329.406256" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1632.719299" Rows="409874.951066" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="26" Alias="fname">
@@ -786,7 +786,7 @@ where coalesce(t2.fname, t3.fname) is not null;
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1645.052157" Rows="511329.406256" Width="9"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1631.079799" Rows="409874.951066" Width="9"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="fname">
@@ -809,7 +809,7 @@ where coalesce(t2.fname, t3.fname) is not null;
                     <dxl:OneTimeFilter/>
                     <dxl:HashJoin JoinType="Left">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1602.995314" Rows="1278323.515639" Width="9"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1597.367584" Rows="1024687.377665" Width="9"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="9" Alias="fname">
@@ -829,7 +829,7 @@ where coalesce(t2.fname, t3.fname) is not null;
                       </dxl:HashCondList>
                       <dxl:HashJoin JoinType="Left">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1017.464148" Rows="1024599.006865" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1017.242914" Rows="1008796.570473" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="id">

--- a/data/dxl/minidump/NaryWithLojAndNonLojChilds.mdp
+++ b/data/dxl/minidump/NaryWithLojAndNonLojChilds.mdp
@@ -1732,7 +1732,7 @@
     <dxl:Plan Id="0" SpaceSize="349">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.819059" Rows="18.888891" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.816289" Rows="10.000001" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1758,7 +1758,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.817370" Rows="18.888891" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.815395" Rows="10.000001" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -1790,7 +1790,7 @@
           </dxl:HashCondList>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.808365" Rows="18.888891" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.807190" Rows="10.000001" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -1823,7 +1823,7 @@
             </dxl:HashCondList>
             <dxl:HashJoin JoinType="Left">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.805324" Rows="18.888889" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.805159" Rows="10.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">

--- a/data/dxl/minidump/ReplicatedLOJReplicated.mdp
+++ b/data/dxl/minidump/ReplicatedLOJReplicated.mdp
@@ -1046,7 +1046,7 @@
     <dxl:Plan Id="0" SpaceSize="4">
       <dxl:GatherMotion InputSegments="0" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.385564" Rows="198.989800" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.362313" Rows="100.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -1066,7 +1066,7 @@
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Left">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.349969" Rows="596.969400" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.344425" Rows="300.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">

--- a/libnaucrates/src/statistics/CBucket.cpp
+++ b/libnaucrates/src/statistics/CBucket.cpp
@@ -604,7 +604,7 @@ CBucket::CompareUpperBounds
 	CPoint *point2 = bucket2->GetUpperBound();
 
 	BOOL is_closed_point1 = bucket1->IsUpperClosed();
-	BOOL is_closed_point2 = bucket1->IsUpperClosed();
+	BOOL is_closed_point2 = bucket2->IsUpperClosed();
 
 	if (point1->Equals(point2))
 	{

--- a/libnaucrates/src/statistics/CBucket.cpp
+++ b/libnaucrates/src/statistics/CBucket.cpp
@@ -516,7 +516,7 @@ CBucket::CompareLowerBounds
 	CPoint *point2 = bucket2->GetLowerBound();
 
 	BOOL is_closed_point1 = bucket1->IsLowerClosed();
-	BOOL is_closed_point2 = bucket1->IsLowerClosed();
+	BOOL is_closed_point2 = bucket2->IsLowerClosed();
 
 	if (point1->Equals(point2))
 	{
@@ -909,13 +909,13 @@ CBucket::Difference
 	}
 
 	// if other bucket's LB is after this bucket's LB, then we get a valid first split
-	if (this->GetLowerBound()->IsLessThan(bucket_other->GetLowerBound()))
+	if (0 > CBucket::CompareLowerBounds(this, bucket_other))
 	{
 		*result_bucket_lower = this->MakeBucketScaleUpper(mp, bucket_other->GetLowerBound(), !bucket_other->IsLowerClosed());
 	}
 
-	// if other bucket's UB is lesser than this bucket's LB, then we get a valid split
-	if (bucket_other->GetUpperBound()->IsLessThan(this->GetUpperBound()))
+	// if other bucket's UB is lesser than this bucket's UB, then we get a valid split
+	if (0 > CBucket::CompareUpperBounds(bucket_other, this))
 	{
 		*result_bucket_upper = this->MakeBucketScaleLower(mp, bucket_other->GetUpperBound(), !bucket_other->IsUpperClosed());
 	}

--- a/libnaucrates/src/statistics/CHistogram.cpp
+++ b/libnaucrates/src/statistics/CHistogram.cpp
@@ -929,7 +929,7 @@ CHistogram::MakeLASJHistogram
 	const ULONG buckets1 = Buckets();
 	const ULONG buckets2 = histogram->Buckets();
 
-	while (idx1 < buckets1 && idx2 < buckets2)
+	while ((idx1 < buckets1 || NULL != upper_split_bucket) && idx2 < buckets2)
 	{
 		// bucket from other histogram
 		CBucket *bucket2 = (*histogram->m_histogram_buckets) [idx2];
@@ -957,11 +957,13 @@ CHistogram::MakeLASJHistogram
 			new_buckets->Append(lower_split_bucket);
 		}
 
+		// advance bucket2, if UB(candidate_bucket) >= UB(bucket2)
+		if (NULL != upper_split_bucket || 0 <= CBucket::CompareUpperBounds(candidate_bucket, bucket2))
+			idx2++;
+
 		// need to find a new candidate
 		GPOS_DELETE(candidate_bucket);
 		candidate_bucket = NULL;
-
-		idx2++;
 	}
 
 	candidate_bucket = upper_split_bucket;

--- a/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -229,7 +229,7 @@ CJoinStatsProcessor::SetResultingJoinStats
 		CStatisticsConfig *stats_config,
 		const IStatistics *outer_stats_input,
 		const IStatistics *inner_stats_input,
-										   CStatsPredJoinArray *join_pred_stats_info,
+		CStatsPredJoinArray *join_pred_stats_info,
 		IStatistics::EStatsJoinType join_type,
 		BOOL DoIgnoreLASJHistComputation
 		)

--- a/libnaucrates/src/statistics/CLeftOuterJoinStatsProcessor.cpp
+++ b/libnaucrates/src/statistics/CLeftOuterJoinStatsProcessor.cpp
@@ -86,7 +86,7 @@ CLeftOuterJoinStatsProcessor::MakeLOJHistogram
 		const CStatistics *outer_side_stats,
 		const CStatistics *inner_side_stats,
 		CStatistics *inner_join_stats,
-											   CStatsPredJoinArray *join_preds_stats,
+		CStatsPredJoinArray *join_preds_stats,
 		CDouble num_rows_inner_join,
 		CDouble *result_rows_LASJ
 		)


### PR DESCRIPTION
The cardinality of a left outer join is estimated as the cardinality of
an inner join plus the cardinality of a left anti-semijoin (LASJ).

The cardinality of the LASJ is computed by subtracting the inner child
histogram from the outer child, leaving only buckets of the outer table
that have no counterparts in the inner table. This is computed by method
CHistogram::MakeLASJHistogram().

There was a bug in this method where we stopped too early in some
cases, leading to an over-estimation of the rows in the LASJ.

We also fixed a couple of small issues in CBucket::CompareLowerBounds(),
a typo and two cases where we compared the boundary values but not
the included/excluded flags.

Several mdp files needed changes, all of these now return lower
cardinality estimates for left outer joins.

Note that we may still overestimate some outer join cardinalities,
since we use an NDV-based estimate for the inner join and this
estimate sometimes exceeds the number of rows indicated by the
intersection of inner and outer histogram. When that is the case,
then adding the difference of outer - inner histograms causes
us to double-count the rows in the LASJ. We can consider changing
that in a future fix, if it becomes an issue with plan quality.

Co-authored-by: Bhuvnesh Chaudhary <bchaudhary@pivotal.io>
Co-authored-by: Hans Zeller <hzeller@pivotal.io>