### PR TITLE
Add pipeline for running explain tests

### DIFF
--- a/concourse/test_explain_ds_suite_pipeline.yml
+++ b/concourse/test_explain_ds_suite_pipeline.yml
@@ -1,0 +1,361 @@
+groups: []
+resources:
+- name: gporca-commits-to-test
+  type: git
+  source:
+    branch: ds-explain-test
+    uri: https://github.com/greenplum-db/gporca-pipeline-misc
+- name: orca_main_src  # used for yml task files
+  type: git
+  source:
+    branch: master
+    paths: null
+    uri: https://github.com/greenplum-db/gporca
+- name: orca_baseline_src # used for baseline build
+  type: git
+  source:
+    branch: master
+    paths: null
+    uri: https://github.com/greenplum-db/gporca
+- name: xerces_patch
+  type: git
+  source:
+    branch: master
+    paths:
+    - patches/xerces-c-gpdb.patch
+    - concourse/xerces-c
+    - concourse/package_tarball.bash
+    uri: https://github.com/greenplum-db/gporca
+- name: bin_gpdb_centos6
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_gpdb_with_orca_centos6.tar.gz
+- name: bin_gpdb_baseline_centos6
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_gpdb_baseline_with_orca_centos6.tar.gz
+- name: gpdb_main_src  # used for yml task files
+  type: git
+  source:
+    branch: master
+    ignore_paths:
+    - README.md
+    - LICENSE
+    - COPYRIGHT
+    - .gitignore
+    uri: https://github.com/hardikar/gpdb
+- name: gpdb_baseline_src  # used for baseline build
+  type: git
+  source:
+    branch: 5X_STABLE
+    paths:
+    - config/orca.m4  #trigger only when 5X_STABLE has bumped ORCA versions
+    uri: https://github.com/greenplum-db/gpdb
+- name: gpdb_tarball
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: gpdb_src.tar.gz
+- name: bin_orca_centos5_release
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_orca_centos5_release.tar.gz
+- name: bin_orca_baseline_centos5_release
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_orca_baseline_centos5_release.tar.gz
+- name: bin_xerces_centos5
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: bin_xerces_centos5.tar.gz
+- name: orca_tarball
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: orca_src.tar.gz
+- name: explain_test_suite
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: ds_partitioned_suite_1tb.tar.gz
+- name: explain_output
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: explain_output.tar.gz
+- name: explain_output_baseline
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: explain_output_baseline.tar.gz
+- name: explain_test_results
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: explain_ds_test_results.tar.gz
+
+resource_types: []
+jobs:
+- name: xerces_centos5
+  max_in_flight: 2
+  plan:
+  - get: xerces_patch
+    trigger: true
+  - aggregate:
+    - task: build
+      file: xerces_patch/concourse/xerces-c/build_xerces_centos5.yml
+  - aggregate:
+    - task: package_tarball
+      file: xerces_patch/concourse/xerces-c/package_tarball_centos5.yml
+  - aggregate:
+    - put: bin_xerces_centos5
+      params:
+        from: package_tarball_centos5/bin_xerces_centos5.tar.gz
+- name: orca_centos5_release
+  max_in_flight: 2
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - clone_repos_to_test
+      version: every
+    - get: orca_main_src
+      passed:
+      - clone_repos_to_test
+    - get: bin_xerces_centos5
+      passed:
+      - xerces_centos5
+    - get: orca_tarball
+      passed:
+      - clone_repos_to_test
+      trigger: true
+  - task: untar_build_and_test_release
+    file: orca_main_src/concourse/untar_build_and_test_centos5_release.yml
+  - put: bin_orca_centos5_release
+    params:
+      from: package_tarball_release/bin_orca_centos5_release.tar.gz
+- name: clone_repos_to_test
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      trigger: true
+      version: every
+    - get: orca_main_src
+  - task: clone_repos_to_test
+    file: orca_main_src/concourse/clone_remote_repo.yml
+  - aggregate:
+    - put: orca_tarball
+      params:
+        from: package_tarball/orca_src.tar.gz
+    - put: gpdb_tarball
+      params:
+        from: package_tarball/gpdb_src.tar.gz
+- name: build_gpdb
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - orca_centos5_release
+    - get: bin_orca
+      passed:
+      - orca_centos5_release
+      resource: bin_orca_centos5_release
+      trigger: true
+      version: every
+    - get: bin_xerces
+      passed:
+      - xerces_centos5
+      resource: bin_xerces_centos5
+    - get: gpdb_tarball
+      passed:
+      - clone_repos_to_test
+    - get: gpdb_main_src
+  - task: build_with_orca
+    file: gpdb_main_src/concourse/tasks/untar_build_with_orca.yml
+  - put: bin_gpdb_centos6
+    params:
+      from: package_tarball/bin_gpdb.tar.gz
+
+- name: orca_baseline_centos5_release
+  max_in_flight: 2
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - clone_repos_to_test
+      version: every
+    - get: orca_main_src
+      passed:
+      - clone_repos_to_test
+    - get: orca_src
+      resource: orca_baseline_src
+      trigger: true
+    - get: bin_xerces_centos5
+      passed:
+      - xerces_centos5
+  - task: build_and_test_release
+    file: orca_main_src/concourse/build_and_test_centos5_release.yml
+  - task: package_tarball_release
+    file: orca_main_src/concourse/package_tarball_centos5_release.yml
+  - put: bin_orca_baseline_centos5_release
+    params:
+      from: package_tarball_release/bin_orca_centos5_release.tar.gz
+
+- name: build_gpdb_baseline
+  plan:
+  - aggregate:
+    - get: bin_orca
+      resource: bin_orca_baseline_centos5_release
+      passed:
+      - orca_baseline_centos5_release
+    - get: bin_xerces
+      resource: bin_xerces_centos5
+      passed:
+      - xerces_centos5
+    - get: gpdb_main_src
+    - get: gpdb_src
+      resource: gpdb_baseline_src
+      trigger: true
+  - task: build_with_orca
+    file: gpdb_main_src/concourse/tasks/build_with_orca.yml
+  - task: package_tarball
+    file: gpdb_main_src/concourse/tasks/package_tarball.yml
+  - put: bin_gpdb_baseline_centos6
+    params:
+      file: package_tarball/bin_gpdb.tar.gz
+
+- name: test_explain_suite
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - build_gpdb
+    - get: bin_orca
+      passed:
+      - build_gpdb
+      resource: bin_orca_centos5_release
+    - get: bin_xerces
+      passed:
+      - build_gpdb
+      resource: bin_xerces_centos5
+    - get: bin_gpdb
+      passed:
+      - build_gpdb
+      resource: bin_gpdb_centos6
+      trigger: true
+    - get: gpdb_main_src
+      passed:
+      - build_gpdb
+      params:
+        submodules: none
+    - get: gpdb_tarball
+      passed:
+      - build_gpdb
+    - get: explain_test_suite
+  - task: run_explain_suite
+    file: gpdb_main_src/concourse/tasks/untar_test_with_orca.yml
+    params:
+      ACTION: test_explain_suite
+    timeout: 90m
+  - put: explain_output
+    params:
+      file: icg_output/explain_ouput.tar.gz
+
+- name: test_explain_suite_baseline
+  plan:
+  - aggregate:
+    - get: bin_orca
+      resource: bin_orca_baseline_centos5_release
+      params:
+        globs:
+          - bin_orca_baseline_centos5_release.tar.gz
+      passed:
+      - build_gpdb_baseline
+    - get: bin_xerces
+      resource: bin_xerces_centos5
+      passed:
+      - build_gpdb_baseline
+    - get: bin_gpdb
+      resource: bin_gpdb_baseline_centos6
+      passed:
+      - build_gpdb_baseline
+      trigger: true
+    - get: gpdb_src
+      resource: gpdb_baseline_src
+      passed:
+      - build_gpdb_baseline
+      params:
+        submodules: none
+    - get: gpdb_main_src
+      passed:
+      - build_gpdb_baseline
+      params:
+        submodules: none
+    - get: explain_test_suite
+  - task: explain_suite_baseline
+    timeout: 64m
+    file: gpdb_main_src/concourse/tasks/test_explain_suite_with_orca.yml
+  - put: explain_output_baseline
+    params:
+      file: icg_output/explain_ouput.tar.gz
+- name: diff_explain_results_with_baseline
+  plan:
+  - aggregate:
+    - get: gpdb_main_src
+      passed:
+      - test_explain_suite
+      params:
+        submodules: none
+    - get: explain_output
+      passed:
+      - test_explain_suite
+      trigger: true
+    - get: explain_output_baseline
+      passed:
+      - test_explain_suite_baseline
+  - task: diff_explain_results_with_baseline
+    timeout: 64m
+    file: gpdb_main_src/concourse/tasks/diff_explain_results_with_baseline.yml
+  - put: explain_test_results
+    params:
+      file: diffs/explain_test_results.tar.gz

--- a/concourse/test_explain_ds_suite_pipeline.yml
+++ b/concourse/test_explain_ds_suite_pipeline.yml
@@ -51,7 +51,7 @@ resources:
     - LICENSE
     - COPYRIGHT
     - .gitignore
-    uri: https://github.com/hardikar/gpdb
+    uri: https://github.com/greenplum-db/gpdb
 - name: gpdb_baseline_src  # used for baseline build
   type: git
   source:
@@ -67,6 +67,14 @@ resources:
     region_name: us-west-2
     secret_access_key: {{s3_secret_access_key}}
     versioned_file: gpdb_src.tar.gz
+- name: gpdb_baseline_tarball
+  type: s3
+  source:
+    access_key_id: {{s3_access_key_id}}
+    bucket: {{gporca-concourse-bucket-dev}}
+    region_name: us-west-2
+    secret_access_key: {{s3_secret_access_key}}
+    versioned_file: gpdb_baseline_src.tar.gz
 - name: bin_orca_centos5_release
   type: s3
   source:
@@ -259,10 +267,30 @@ jobs:
     file: gpdb_main_src/concourse/tasks/build_with_orca.yml
   - task: package_tarball
     file: gpdb_main_src/concourse/tasks/package_tarball.yml
+  - task: package_gpdb_baseline_src
+    config:
+      platform: linux
+      image_resource:
+          type: docker-image
+          source:
+            repository: yolo/orcadev
+            tag: centos6
+      inputs:
+        - name: gpdb_src
+      outputs:
+        - name: package_gpdb_baseline_src
+      run:
+        path: bash
+        args:
+          - -ec
+          - |
+            tar czf "package_gpdb_baseline_src/gpdb_src.tar.gz" -C gpdb_src .
   - put: bin_gpdb_baseline_centos6
     params:
       file: package_tarball/bin_gpdb.tar.gz
-
+  - put: gpdb_baseline_tarball
+    params:
+      file: package_gpdb_baseline_src/gpdb_src.tar.gz
 - name: test_explain_suite
   max_in_flight: 1
   plan:
@@ -300,10 +328,12 @@ jobs:
   - put: explain_output
     params:
       file: icg_output/explain_ouput.tar.gz
-
 - name: test_explain_suite_baseline
   plan:
   - aggregate:
+    - get: gporca-commits-to-test
+      passed:
+      - build_gpdb
     - get: bin_orca
       resource: bin_orca_baseline_centos5_release
       params:
@@ -320,21 +350,22 @@ jobs:
       passed:
       - build_gpdb_baseline
       trigger: true
-    - get: gpdb_src
-      resource: gpdb_baseline_src
-      passed:
-      - build_gpdb_baseline
-      params:
-        submodules: none
     - get: gpdb_main_src
       passed:
       - build_gpdb_baseline
       params:
         submodules: none
+    - get: gpdb_tarball
+      resource: gpdb_baseline_tarball
+      passed:
+      - build_gpdb_baseline
     - get: explain_test_suite
-  - task: explain_suite_baseline
+  - task: run_explain_suite_baseline
     timeout: 64m
-    file: gpdb_main_src/concourse/tasks/test_explain_suite_with_orca.yml
+    file: gpdb_main_src/concourse/tasks/untar_test_with_orca.yml
+    params:
+      ACTION: test_explain_suite
+    timeout: 90m
   - put: explain_output_baseline
     params:
       file: icg_output/explain_ouput.tar.gz


### PR DESCRIPTION
This commit add the pipeline yml file for testing a custom GPDB and
GPORCA commit against gpdb/5X_STABLE and gporca/master using 1TB test
suite data to compare plans.

Corresponding GPDB PR: https://github.com/greenplum-db/gpdb/pull/7261