### PR TITLE
Remove Broadcast from Index NLJ

### DIFF
--- a/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/data/dxl/minidump/BitmapIndexScan.mdp
@@ -14,7 +14,7 @@ see sql/BitmapIndexScan.sql
           <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:TraceFlags Value="103027,102146,102024,102029,102120,103001,103014,103015,103022,104004,104005,105000"/>
+      <dxl:TraceFlags Value="102024,102029,102120,102146,103001,103014,103015,103022,103027,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:ColumnStatistics Mdid="1.24783.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
@@ -428,7 +428,7 @@ see sql/BitmapIndexScan.sql
     <dxl:Plan Id="0" SpaceSize="50">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5184.782412" Rows="1.000000" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="5184.781955" Rows="1.000000" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="23" Alias="fid">
@@ -437,9 +437,9 @@ see sql/BitmapIndexScan.sql
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5184.782391" Rows="1.000000" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="5184.781934" Rows="1.000000" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="23" Alias="fid">
@@ -448,153 +448,153 @@ see sql/BitmapIndexScan.sql
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-              <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
-              <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-            </dxl:Comparison>
+            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:TableScan>
+          <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001988" Rows="1.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="6" Alias="flex_value_id">
+                <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="23" Alias="fid">
                 <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.24783.1.1" TableName="foo">
-              <dxl:Columns>
-                <dxl:Column ColId="23" Attno="1" ColName="fid" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-          <dxl:Materialize Eager="false">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr TypeMdid="0.1700.1.0">
+                <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr TypeMdid="0.1700.1.0">
+                <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001931" Rows="1.000000" Width="18"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="6" Alias="flex_value_id">
+                  <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="23" Alias="fid">
+                  <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.001263" Rows="64.000000" Width="9"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="23" Alias="fid">
+                    <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="9"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="23" Alias="fid">
+                      <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.24783.1.1" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="23" Attno="1" ColName="fid" TypeMdid="0.1700.1.0"/>
+                      <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000578" Rows="1.000000" Width="9"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="6" Alias="flex_value_id">
+                    <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                      <dxl:Ident ColId="7" ColName="language" TypeMdid="0.1043.1.0"/>
+                    </dxl:Cast>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAAB1pIUw==" LintValue="686711588"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.24702.1.1" TableName="outer_table">
+                  <dxl:Columns>
+                    <dxl:Column ColId="6" Attno="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="7" Attno="2" ColName="language" TypeMdid="0.1043.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:NestedLoopJoin>
+          </dxl:RedistributeMotion>
+          <dxl:BitmapTableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="434.195309" Rows="1.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="3.193484" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
                 <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="flex_value_id">
+                <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="434.195300" Rows="1.000000" Width="9"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                  <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1700.1.0">
-                  <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="434.195292" Rows="1.000000" Width="9"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                    <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001803" Rows="64.000000" Width="9"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="6" Alias="flex_value_id">
-                      <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000578" Rows="1.000000" Width="9"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="6" Alias="flex_value_id">
-                        <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                          <dxl:Ident ColId="7" ColName="language" TypeMdid="0.1043.1.0"/>
-                        </dxl:Cast>
-                        <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAAB1pIUw==" LintValue="686711588"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="0.24702.1.1" TableName="outer_table">
-                      <dxl:Columns>
-                        <dxl:Column ColId="6" Attno="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="7" Attno="2" ColName="language" TypeMdid="0.1043.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="21" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="22" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:BroadcastMotion>
-                <dxl:BitmapTableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3.193483" Rows="1.000000" Width="9"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                      <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="flex_value_id">
-                      <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:RecheckCond>
-                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                      <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:Comparison>
-                  </dxl:RecheckCond>
-                  <dxl:BitmapIndexProbe>
-                    <dxl:IndexCondList>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                        <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                        <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:IndexCondList>
-                    <dxl:IndexDescriptor Mdid="0.24762.1.0" IndexName="inner_table_idx"/>
-                  </dxl:BitmapIndexProbe>
-                  <dxl:TableDescriptor Mdid="0.24732.1.1" TableName="inner_table">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="4" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="5" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:BitmapTableScan>
-              </dxl:NestedLoopJoin>
-            </dxl:RedistributeMotion>
-          </dxl:Materialize>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
+                <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:RecheckCond>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:Comparison>
+            </dxl:RecheckCond>
+            <dxl:BitmapIndexProbe>
+              <dxl:IndexCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                  <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                </dxl:Comparison>
+              </dxl:IndexCondList>
+              <dxl:IndexDescriptor Mdid="0.24762.1.0" IndexName="inner_table_idx"/>
+            </dxl:BitmapIndexProbe>
+            <dxl:TableDescriptor Mdid="0.24732.1.1" TableName="inner_table">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="4" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="5" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:BitmapTableScan>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -14,7 +14,7 @@ see sql/DynamicBitmapIndexScan.sql
           <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:TraceFlags Value="103027,102146,102024,102029,102120,103001,103014,103015,103022,104004,104005,105000"/>
+      <dxl:TraceFlags Value="102024,102029,102120,102146,103001,103014,103015,103022,103027,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:RelationStatistics Mdid="2.17408.1.1" Name="foo" Rows="1.000000" EmptyRelation="false"/>
@@ -481,7 +481,7 @@ see sql/DynamicBitmapIndexScan.sql
     <dxl:Plan Id="0" SpaceSize="121">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="5184.782389" Rows="1.000000" Width="9"/>
+          <dxl:Cost StartupCost="0" TotalCost="5184.781941" Rows="1.000000" Width="9"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="24" Alias="fid">
@@ -490,9 +490,9 @@ see sql/DynamicBitmapIndexScan.sql
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="5184.782369" Rows="1.000000" Width="9"/>
+            <dxl:Cost StartupCost="0" TotalCost="5184.781921" Rows="1.000000" Width="9"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="24" Alias="fid">
@@ -501,188 +501,188 @@ see sql/DynamicBitmapIndexScan.sql
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-              <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
-              <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-            </dxl:Comparison>
+            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
           </dxl:JoinFilter>
-          <dxl:TableScan>
+          <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="9"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001988" Rows="1.000000" Width="18"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="7" Alias="flex_value_id">
+                <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="24" Alias="fid">
                 <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.17408.1.1" TableName="foo">
-              <dxl:Columns>
-                <dxl:Column ColId="24" Attno="1" ColName="fid" TypeMdid="0.1700.1.0"/>
-                <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-          <dxl:Materialize Eager="false">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr TypeMdid="0.1700.1.0">
+                <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr TypeMdid="0.1700.1.0">
+                <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001931" Rows="1.000000" Width="18"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="7" Alias="flex_value_id">
+                  <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="24" Alias="fid">
+                  <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.001263" Rows="64.000000" Width="9"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="24" Alias="fid">
+                    <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="9"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="24" Alias="fid">
+                      <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.17408.1.1" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="24" Attno="1" ColName="fid" TypeMdid="0.1700.1.0"/>
+                      <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000578" Rows="1.000000" Width="9"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="7" Alias="flex_value_id">
+                    <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+                    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                      <dxl:Ident ColId="8" ColName="language" TypeMdid="0.1043.1.0"/>
+                    </dxl:Cast>
+                    <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAAB1pIUw==" LintValue="686711588"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.16929.1.1" TableName="outer_table">
+                  <dxl:Columns>
+                    <dxl:Column ColId="7" Attno="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                    <dxl:Column ColId="8" Attno="2" ColName="language" TypeMdid="0.1043.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:NestedLoopJoin>
+          </dxl:RedistributeMotion>
+          <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="434.195304" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="3.193481" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
                 <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="flex_value_id">
+                <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+              </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
+            <dxl:PartitionSelector RelationMdid="0.16959.1.1" PartitionLevels="1" ScanId="1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="434.195296" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicBitmapTableScan PartIndexId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="3.193481" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
                   <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="flex_value_id">
+                  <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                  <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
                   <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="434.195289" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                    <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                </dxl:JoinFilter>
-                <dxl:BroadcastMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001803" Rows="64.000000" Width="9"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="7" Alias="flex_value_id">
-                      <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:TableScan>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000578" Rows="1.000000" Width="9"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="7" Alias="flex_value_id">
-                        <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
-                        <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
-                          <dxl:Ident ColId="8" ColName="language" TypeMdid="0.1043.1.0"/>
-                        </dxl:Cast>
-                        <dxl:ConstValue TypeMdid="0.25.1.0" IsNull="false" IsByValue="false" Value="AAAAB1pIUw==" LintValue="686711588"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="0.16929.1.1" TableName="outer_table">
-                      <dxl:Columns>
-                        <dxl:Column ColId="7" Attno="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="8" Attno="2" ColName="language" TypeMdid="0.1043.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:BroadcastMotion>
-                <dxl:Sequence>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3.193480" Rows="1.000000" Width="8"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                      <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="flex_value_id">
-                      <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="0.16959.1.1" PartitionLevels="1" ScanId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="false" IsByValue="true" Value="1"/>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:DynamicBitmapTableScan PartIndexId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="3.193480" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="flex_value_set_id">
-                        <dxl:Ident ColId="0" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="flex_value_id">
-                        <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:RecheckCond>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                        <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                        <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                      </dxl:Comparison>
-                    </dxl:RecheckCond>
-                    <dxl:BitmapIndexProbe>
-                      <dxl:IndexCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                          <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                          <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IndexCondList>
-                      <dxl:IndexDescriptor Mdid="0.17270.1.0" IndexName="inner_table_idx_1_prt_other"/>
-                    </dxl:BitmapIndexProbe>
-                    <dxl:TableDescriptor Mdid="0.16959.1.1" TableName="inner_table">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="3" Attno="4" ColName="flex_partition" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicBitmapTableScan>
-                </dxl:Sequence>
-              </dxl:NestedLoopJoin>
-            </dxl:RedistributeMotion>
-          </dxl:Materialize>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:RecheckCond>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                  <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                </dxl:Comparison>
+              </dxl:RecheckCond>
+              <dxl:BitmapIndexProbe>
+                <dxl:IndexCondList>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                    <dxl:Ident ColId="1" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                    <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  </dxl:Comparison>
+                </dxl:IndexCondList>
+                <dxl:IndexDescriptor Mdid="0.17270.1.0" IndexName="inner_table_idx_1_prt_other"/>
+              </dxl:BitmapIndexProbe>
+              <dxl:TableDescriptor Mdid="0.16959.1.1" TableName="inner_table">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="flex_value_set_id" TypeMdid="0.1700.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="flex_partition" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="5" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="6" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicBitmapTableScan>
+          </dxl:Sequence>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-IndexKeys.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-IndexKeys.mdp
@@ -352,6 +352,18 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
           <dxl:OpClass Mdid="0.7042.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.7027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
       <dxl:Index Mdid="0.65643.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5">
         <dxl:OpClasses>
           <dxl:OpClass Mdid="0.1994.1.0"/>
@@ -462,10 +474,10 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="10">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="868.122120" Rows="3.000000" Width="48"/>
+          <dxl:Cost StartupCost="0" TotalCost="868.122087" Rows="3.000000" Width="48"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -500,7 +512,7 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="868.121584" Rows="3.000000" Width="48"/>
+            <dxl:Cost StartupCost="0" TotalCost="868.121551" Rows="3.000000" Width="48"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -537,7 +549,7 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
           </dxl:JoinFilter>
           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.000487" Rows="2.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.000454" Rows="2.000000" Width="32"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -596,7 +608,7 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
             </dxl:TableScan>
             <dxl:IndexScan IndexScanDirection="Forward">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6.000198" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="6.000165" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="10" Alias="a">
@@ -610,10 +622,16 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter>
-                <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
+                <dxl:And>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                  <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:And>
               </dxl:Filter>
               <dxl:IndexCondList>
                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
@@ -624,12 +642,8 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
                   </dxl:Cast>
                 </dxl:Comparison>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:Comparison>
               </dxl:IndexCondList>
-              <dxl:IndexDescriptor Mdid="0.65602.1.0" IndexName="bar_idx_ab"/>
+              <dxl:IndexDescriptor Mdid="0.65685.1.0" IndexName="bar_idx_a"/>
               <dxl:TableDescriptor Mdid="0.65577.1.0" TableName="bar">
                 <dxl:Columns>
                   <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.1043.1.0" ColWidth="8"/>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
@@ -405,7 +405,7 @@ set optimizer_enable_hashjoin = off;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="6">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.122115" Rows="3.000000" Width="48"/>

--- a/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
@@ -1,27 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Left outer index apply negative test case. Currently LOJ index NLJoin only apply for index on distribution keys.
-So for this query, Orca currently doesn't pick up the index, but planner picks up the index.
-
-create table foo(a int, b int);
-create table bar(a int, b int);
-create index bar_idx_b on bar(b);
-set optimizer_enable_hashjoin=off;
-
-explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
-                                            QUERY PLAN
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324033.07 rows=2 width=16)
-   ->  Nested Loop Left Join  (cost=0.00..1324033.07 rows=1 width=16)
-         Join Filter: foo.a = bar.a AND foo.b = bar.b
-         ->  Table Scan on foo  (cost=0.00..431.00 rows=1 width=8)
-         ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Table Scan on bar  (cost=0.00..431.00 rows=1 width=8)
- Settings:  enable_nestloop=on; optimizer=on
- Optimizer status: PQO version 2.53.11
-(9 rows)
--->
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+	create table foo(a int, b int);
+	create table bar(a int, b int);
+	create index bar_idx_b on bar(b);
+	set optimizer_enable_hashjoin=off;
+
+	explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
+	                                   QUERY PLAN
+	---------------------------------------------------------------------------------
+	 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..437.00 rows=2 width=16)
+	   ->  Nested Loop Left Join  (cost=0.00..437.00 rows=1 width=16)
+	         Join Filter: true
+	         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+	         ->  Index Scan using bar_idx_b on bar  (cost=0.00..6.00 rows=1 width=8)
+	               Index Cond: (b = foo.b)
+	               Filter: (foo.a = a)
+	 Optimizer: Pivotal Optimizer (GPORCA) version 3.51.0
+	(8 rows)
+]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
@@ -273,10 +271,10 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="2">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001164" Rows="2.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="437.000572" Rows="2.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -294,9 +292,9 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false">
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="true" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001045" Rows="2.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="437.000453" Rows="2.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -314,16 +312,7 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:JoinFilter>
-            <dxl:And>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:Comparison>
-            </dxl:And>
+            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="false" IsByValue="true" Value="true"/>
           </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
@@ -352,9 +341,9 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
-          <dxl:Materialize Eager="false">
+          <dxl:IndexScan IndexScanDirection="Forward">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000473" Rows="3.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="6.000375" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="a">
@@ -364,50 +353,33 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b;
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000465" Rows="3.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="a">
-                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="b">
-                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="a">
-                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="b">
-                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="0.24582.1.0" TableName="bar">
-                  <dxl:Columns>
-                    <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:BroadcastMotion>
-          </dxl:Materialize>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:IndexCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:IndexCondList>
+            <dxl:IndexDescriptor Mdid="0.65570.1.0" IndexName="bar_idx_b"/>
+            <dxl:TableDescriptor Mdid="0.24582.1.0" TableName="bar">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:IndexScan>
         </dxl:NestedLoopJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -1099,6 +1099,14 @@ namespace gpopt
 
 			static
 			BOOL FScalarConstBoolNull(CExpression *pexpr);
+
+			static
+			CDistributionSpecHashed * CreateMatchingHashedDistribution
+				(
+				CMemoryPool *mp,
+				CExpression *pexprPred,
+				CDistributionSpecHashed *pdshashed
+				);
 	}; // class CUtils
 
 	// hash set from expressions

--- a/libgpopt/include/gpopt/operators/CLogicalApply.h
+++ b/libgpopt/include/gpopt/operators/CLogicalApply.h
@@ -35,6 +35,9 @@ namespace gpopt
 			// private copy ctor
 			CLogicalApply(const CLogicalApply &);
 
+			// original scalar expression
+			CExpression *m_pexprScalar;
+
 		protected:
 
 			// columns used from Apply's inner child
@@ -71,6 +74,19 @@ namespace gpopt
 			CColRefArray *PdrgPcrInner() const
 			{
 				return m_pdrgpcrInner;
+			}
+
+			// scalar expression accessor
+			CExpression *ScalarExpr()
+			{
+				return m_pexprScalar;
+			}
+
+			// set the scalar expression
+			void
+			SetScalarExpr(CExpression *pexprScalar)
+			{
+				m_pexprScalar = pexprScalar;
 			}
 
 			// return a copy of the operator with remapped columns

--- a/libgpopt/include/gpopt/operators/CLogicalApply.h
+++ b/libgpopt/include/gpopt/operators/CLogicalApply.h
@@ -35,9 +35,6 @@ namespace gpopt
 			// private copy ctor
 			CLogicalApply(const CLogicalApply &);
 
-			// original scalar expression
-			CExpression *m_pexprScalar;
-
 		protected:
 
 			// columns used from Apply's inner child
@@ -46,9 +43,15 @@ namespace gpopt
 			// origin subquery id
 			EOperatorId m_eopidOriginSubq;
 
+			// original scalar expression
+			CExpression *m_pexprScalar;
+
 			// ctor
 			explicit
 			CLogicalApply(CMemoryPool *mp);
+
+			// ctor
+			CLogicalApply(CMemoryPool *mp, CExpression *pexprScalar);
 
 			// ctor
 			CLogicalApply(CMemoryPool *mp, CColRefArray *pdrgpcrInner, EOperatorId eopidOriginSubq);
@@ -80,13 +83,6 @@ namespace gpopt
 			CExpression *ScalarExpr()
 			{
 				return m_pexprScalar;
-			}
-
-			// set the scalar expression
-			void
-			SetScalarExpr(CExpression *pexprScalar)
-			{
-				m_pexprScalar = pexprScalar;
 			}
 
 			// return a copy of the operator with remapped columns

--- a/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
+++ b/libgpopt/include/gpopt/operators/CLogicalIndexApply.h
@@ -35,7 +35,7 @@ namespace gpopt
 		public:
 
 			// ctor
-			CLogicalIndexApply(CMemoryPool *mp,  CColRefArray *pdrgpcrOuterRefs, BOOL fOuterJoin);
+			CLogicalIndexApply(CMemoryPool *mp,  CColRefArray *pdrgpcrOuterRefs, CExpression *pexprScalar, BOOL fOuterJoin);
 
 			// ctor for patterns
 			explicit

--- a/libgpopt/include/gpopt/operators/CPhysicalInnerIndexNLJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalInnerIndexNLJoin.h
@@ -33,17 +33,24 @@ namespace gpopt
 			// columns from outer child used for index lookup in inner child
 			CColRefArray *m_pdrgpcrOuterRefs;
 
+			CExpression *m_pexprScalar;
+
 			// private copy ctor
 			CPhysicalInnerIndexNLJoin(const CPhysicalInnerIndexNLJoin &);
 
 		public:
 
 			// ctor
-			CPhysicalInnerIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array);
+			CPhysicalInnerIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array, CExpression *pexprScalar);
 
 			// dtor
 			virtual
 			~CPhysicalInnerIndexNLJoin();
+
+			CExpression *ScalarExpr()
+			{
+				return m_pexprScalar;
+			}
 
 			// ident accessors
 			virtual

--- a/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalLeftOuterIndexNLJoin.h
@@ -21,17 +21,24 @@ namespace gpopt
 			// columns from outer child used for index lookup in inner child
 			CColRefArray *m_pdrgpcrOuterRefs;
 
+			CExpression *m_pexprScalar;
+
 			// private copy ctor
 			CPhysicalLeftOuterIndexNLJoin(const CPhysicalLeftOuterIndexNLJoin &);
 
 		public:
 
 			// ctor
-			CPhysicalLeftOuterIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array);
+			CPhysicalLeftOuterIndexNLJoin(CMemoryPool *mp, CColRefArray *colref_array, CExpression *pexprScalar);
 
 			// dtor
 			virtual
 			~CPhysicalLeftOuterIndexNLJoin();
+
+			CExpression *ScalarExpr()
+			{
+				return m_pexprScalar;
+			}
 
 			// ident accessors
 			virtual

--- a/libgpopt/include/gpopt/operators/CPhysicalNLJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalNLJoin.h
@@ -34,6 +34,8 @@ namespace gpopt
 			// private copy ctor
 			CPhysicalNLJoin(const CPhysicalNLJoin &);
 
+			CExpression *m_pexprScalar;
+
 		protected:
 			
 			// helper function for computing the required partition propagation 
@@ -57,6 +59,16 @@ namespace gpopt
 			// dtor
 			virtual
 			~CPhysicalNLJoin();
+
+			CExpression *ScalarExpr()
+			{
+				return m_pexprScalar;
+			}
+
+			void SetScalarExpr(CExpression *pexprScalar)
+			{
+				m_pexprScalar = pexprScalar;
+			}
 
 			//-------------------------------------------------------------------------------------
 			// Required Plan Properties

--- a/libgpopt/include/gpopt/operators/CPhysicalNLJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalNLJoin.h
@@ -65,11 +65,6 @@ namespace gpopt
 				return m_pexprScalar;
 			}
 
-			void SetScalarExpr(CExpression *pexprScalar)
-			{
-				m_pexprScalar = pexprScalar;
-			}
-
 			//-------------------------------------------------------------------------------------
 			// Required Plan Properties
 			//-------------------------------------------------------------------------------------

--- a/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
+++ b/libgpopt/include/gpopt/xforms/CXformImplementIndexApply.h
@@ -98,16 +98,12 @@ namespace gpopt
 				// assemble physical operator
 				CPhysicalNLJoin *pop = NULL;
 
-				if (CLogicalIndexApply::PopConvert(popLogicalApply)->FouterJoin())
-					pop = GPOS_NEW(mp) CPhysicalLeftOuterIndexNLJoin(mp, colref_array);
-				else
-					pop = GPOS_NEW(mp) CPhysicalInnerIndexNLJoin(mp, colref_array);
+				pexprOriginalScalar->AddRef();
 
-				if (NULL != pexprOriginalScalar)
-				{
-					pexprOriginalScalar->AddRef();
-					pop->SetScalarExpr(pexprOriginalScalar);
-				}
+				if (CLogicalIndexApply::PopConvert(popLogicalApply)->FouterJoin())
+					pop = GPOS_NEW(mp) CPhysicalLeftOuterIndexNLJoin(mp, colref_array, pexprOriginalScalar);
+				else
+					pop = GPOS_NEW(mp) CPhysicalInnerIndexNLJoin(mp, colref_array, pexprOriginalScalar);
 
 				CExpression *pexprResult =
 						GPOS_NEW(mp) CExpression

--- a/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -60,7 +60,8 @@ namespace gpopt
 				const IMDRelation *pmdrel,
 				const IMDIndex *pmdindex,
 				CPartConstraint *ppartcnstrIndex,
-				CXformResult *pxfres
+				CXformResult *pxfres,
+				CExpression *pexprScalar
 				) const;
 
 			// helper to add IndexApply expression to given xform results container
@@ -138,7 +139,8 @@ namespace gpopt
 				CColRefArray *pdrgpcrOuter,
 				CColRefArray *pdrgpcrOuterNew,
 				CColRefArray *pdrgpcrOuterRefsInScan,
-				ULongPtrArray *pdrgpulIndexesOfRefsInScan
+				ULongPtrArray *pdrgpulIndexesOfRefsInScan,
+				CExpression *pexprScalar
 				) const;
 
 			// create a union-all with the given children

--- a/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -225,7 +225,8 @@ namespace gpopt
 			CLogicalApply *PopLogicalApply
 				(
 				CMemoryPool *mp,
-				CColRefArray *pdrgpcrOuterRefs
+				CColRefArray *pdrgpcrOuterRefs,
+				CExpression *pexprScalar
 				) const = 0;
 
 		public:

--- a/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -166,14 +166,6 @@ namespace gpopt
 				CXformResult *pxfres
 				) const;
 
-			// check whether distribution key and the index key are matched.
-			// always returns true for master only table.
-			BOOL FMatchDistKeyAndIndexKey
-				(
-				const IMDRelation *pmdrel,
-				const IMDIndex *pmdindex
-				) const;
-
 		protected:
 
 			// is the logical join that is being transformed an outer join?
@@ -216,18 +208,6 @@ namespace gpopt
 			// the instance.
 			virtual
 			CLogicalJoin *PopLogicalJoin(CMemoryPool *mp) const = 0;
-
-			// return the new instance of logical apply operator
-			// that it is trying to transform to in the current
-			// xform rule, caller takes the ownership and
-			// responsibility to release the instance.
-			virtual
-			CLogicalApply *PopLogicalApply
-				(
-				CMemoryPool *mp,
-				CColRefArray *pdrgpcrOuterRefs,
-				CExpression *pexprScalar
-				) const = 0;
 
 		public:
 

--- a/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
+++ b/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
@@ -108,10 +108,11 @@ namespace gpopt
 			CLogicalApply *PopLogicalApply
 				(
 				CMemoryPool *mp,
-				CColRefArray *colref_array
+				CColRefArray *colref_array,
+				CExpression *pexprScalar
 				) const
 			{
-				return GPOS_NEW(mp) TApply(mp, colref_array, m_fOuterJoin);
+				return GPOS_NEW(mp) TApply(mp, colref_array, pexprScalar, m_fOuterJoin);
 			}
 
 		public:

--- a/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
+++ b/libgpopt/include/gpopt/xforms/CXformJoin2IndexApplyBase.h
@@ -100,21 +100,6 @@ namespace gpopt
 				return GPOS_NEW(mp) TJoin(mp);
 			}
 
-			// return the new instance of logical apply operator
-			// that it is trying to transform to in the current
-			// xform rule, caller takes the ownership and
-			// responsibility to release the instance.
-			virtual
-			CLogicalApply *PopLogicalApply
-				(
-				CMemoryPool *mp,
-				CColRefArray *colref_array,
-				CExpression *pexprScalar
-				) const
-			{
-				return GPOS_NEW(mp) TApply(mp, colref_array, pexprScalar, m_fOuterJoin);
-			}
-
 		public:
 
 			// ctor

--- a/libgpopt/src/operators/CLogicalApply.cpp
+++ b/libgpopt/src/operators/CLogicalApply.cpp
@@ -32,6 +32,7 @@ CLogicalApply::CLogicalApply
 	)
 	:
 	CLogical(mp),
+	m_pexprScalar(NULL),
 	m_pdrgpcrInner(NULL),
 	m_eopidOriginSubq(COperator::EopSentinel)
 {}
@@ -56,6 +57,7 @@ CLogicalApply::CLogicalApply
 	m_pdrgpcrInner(pdrgpcrInner),
 	m_eopidOriginSubq(eopidOriginSubq)
 {
+	m_pexprScalar = NULL;
 	GPOS_ASSERT(NULL != pdrgpcrInner);
 }
 
@@ -70,6 +72,7 @@ CLogicalApply::CLogicalApply
 CLogicalApply::~CLogicalApply()
 {
 	CRefCount::SafeRelease(m_pdrgpcrInner);
+	CRefCount::SafeRelease(m_pexprScalar);
 }
 
 

--- a/libgpopt/src/operators/CLogicalApply.cpp
+++ b/libgpopt/src/operators/CLogicalApply.cpp
@@ -32,9 +32,9 @@ CLogicalApply::CLogicalApply
 	)
 	:
 	CLogical(mp),
-	m_pexprScalar(NULL),
 	m_pdrgpcrInner(NULL),
-	m_eopidOriginSubq(COperator::EopSentinel)
+	m_eopidOriginSubq(COperator::EopSentinel),
+	m_pexprScalar(NULL)
 {}
 
 
@@ -55,11 +55,24 @@ CLogicalApply::CLogicalApply
 	:
 	CLogical(mp),
 	m_pdrgpcrInner(pdrgpcrInner),
-	m_eopidOriginSubq(eopidOriginSubq)
+	m_eopidOriginSubq(eopidOriginSubq),
+	m_pexprScalar(NULL)
 {
-	m_pexprScalar = NULL;
 	GPOS_ASSERT(NULL != pdrgpcrInner);
 }
+
+// Ctor
+CLogicalApply::CLogicalApply
+	(
+	CMemoryPool *mp,
+	CExpression *pexprScalar
+	)
+	:
+	CLogical(mp),
+	m_pdrgpcrInner(NULL),
+	m_eopidOriginSubq(COperator::EopSentinel),
+	m_pexprScalar(pexprScalar)
+{}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/libgpopt/src/operators/CLogicalIndexApply.cpp
+++ b/libgpopt/src/operators/CLogicalIndexApply.cpp
@@ -27,16 +27,16 @@ CLogicalIndexApply::CLogicalIndexApply
 	(
 	CMemoryPool *mp,
 	CColRefArray *pdrgpcrOuterRefs,
+	CExpression *pexprScalar,
 	BOOL fOuterJoin
 	)
 	:
-	CLogicalApply(mp),
+	CLogicalApply(mp, pexprScalar),
 	m_pdrgpcrOuterRefs(pdrgpcrOuterRefs),
 	m_fOuterJoin(fOuterJoin)
 {
 	GPOS_ASSERT(NULL != pdrgpcrOuterRefs);
 }
-
 
 CLogicalIndexApply::~CLogicalIndexApply()
 {
@@ -130,7 +130,7 @@ CLogicalIndexApply::PopCopyWithRemappedColumns
 {
 	CColRefArray *colref_array = CUtils::PdrgpcrRemap(mp, m_pdrgpcrOuterRefs, colref_mapping, must_exist);
 
-	return GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, m_fOuterJoin);
+	return GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, NULL /* pexprScalar */, m_fOuterJoin);
 }
 
 // EOF

--- a/libgpopt/src/operators/CPhysicalInnerIndexNLJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalInnerIndexNLJoin.cpp
@@ -37,13 +37,16 @@ using namespace gpopt;
 CPhysicalInnerIndexNLJoin::CPhysicalInnerIndexNLJoin
 	(
 	CMemoryPool *mp,
-	CColRefArray *colref_array
+	CColRefArray *colref_array,
+	CExpression *pexprScalar
 	)
 	:
 	CPhysicalInnerNLJoin(mp),
-	m_pdrgpcrOuterRefs(colref_array)
+	m_pdrgpcrOuterRefs(colref_array),
+	m_pexprScalar(pexprScalar)
 {
 	GPOS_ASSERT(NULL != colref_array);
+	GPOS_ASSERT(NULL != pexprScalar);
 }
 
 
@@ -58,6 +61,7 @@ CPhysicalInnerIndexNLJoin::CPhysicalInnerIndexNLJoin
 CPhysicalInnerIndexNLJoin::~CPhysicalInnerIndexNLJoin()
 {
 	m_pdrgpcrOuterRefs->Release();
+	m_pexprScalar->Release();
 }
 
 
@@ -130,7 +134,7 @@ CPhysicalInnerIndexNLJoin::PdsRequired
 	{
 		// check if we could create an equivalent hashed distribution request to the inner child
 		CDistributionSpecHashed *pdshashed = CDistributionSpecHashed::PdsConvert(pdsInner);
-		CExpression *pexprScalar = CPhysicalNLJoin::PopConvert(exprhdl.Pop())->ScalarExpr();
+		CExpression *pexprScalar = CPhysicalInnerIndexNLJoin::PopConvert(exprhdl.Pop())->ScalarExpr();
 		CDistributionSpecHashed *pdshashedMatching = CUtils::CreateMatchingHashedDistribution(mp, pexprScalar, pdshashed);
 		if (NULL != pdshashedMatching)
 		{

--- a/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalLeftOuterIndexNLJoin.cpp
@@ -21,19 +21,22 @@ using namespace gpopt;
 CPhysicalLeftOuterIndexNLJoin::CPhysicalLeftOuterIndexNLJoin
 	(
 	CMemoryPool *mp,
-	CColRefArray *colref_array
+	CColRefArray *colref_array,
+	CExpression *pexprScalar
 	)
 	:
 	CPhysicalLeftOuterNLJoin(mp),
-	m_pdrgpcrOuterRefs(colref_array)
+	m_pdrgpcrOuterRefs(colref_array),
+	m_pexprScalar(pexprScalar)
 {
 	GPOS_ASSERT(NULL != colref_array);
+	GPOS_ASSERT(NULL != pexprScalar);
 }
-
 
 CPhysicalLeftOuterIndexNLJoin::~CPhysicalLeftOuterIndexNLJoin()
 {
 	m_pdrgpcrOuterRefs->Release();
+	m_pexprScalar->Release();
 }
 
 
@@ -90,7 +93,7 @@ CPhysicalLeftOuterIndexNLJoin::PdsRequired
 	{
 		// check if we could create an equivalent hashed distribution request to the inner child
 		CDistributionSpecHashed *pdshashed = CDistributionSpecHashed::PdsConvert(pdsInner);
-		CExpression *pexprScalar = CPhysicalNLJoin::PopConvert(exprhdl.Pop())->ScalarExpr();
+		CExpression *pexprScalar = CPhysicalLeftOuterIndexNLJoin::PopConvert(exprhdl.Pop())->ScalarExpr();
 		CDistributionSpecHashed *pdshashedMatching = CUtils::CreateMatchingHashedDistribution(mp, pexprScalar, pdshashed);
 		if (NULL != pdshashedMatching)
 		{

--- a/libgpopt/src/operators/CPhysicalNLJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalNLJoin.cpp
@@ -48,6 +48,7 @@ CPhysicalNLJoin::CPhysicalNLJoin
 	//		DPE by outer child since a Motion operator gets in between PartitionSelector and DynamicScan
 
 	SetPartPropagateRequests(2);
+	m_pexprScalar = NULL;
 }
 
 
@@ -60,7 +61,9 @@ CPhysicalNLJoin::CPhysicalNLJoin
 //
 //---------------------------------------------------------------------------
 CPhysicalNLJoin::~CPhysicalNLJoin()
-{}
+{
+	CRefCount::SafeRelease(m_pexprScalar);
+}
 
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -298,9 +298,8 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex
 		// and add it to xform results
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
 		pexprOuter->AddRef();
-		CLogicalApply *popLogicalApply = PopLogicalApply(mp, colref_array);
 		pexprScalar->AddRef();
-		popLogicalApply->SetScalarExpr(pexprScalar);
+		CLogicalApply *popLogicalApply = PopLogicalApply(mp, colref_array, pexprScalar);
 		CExpression *pexprIndexApply =
 			GPOS_NEW(mp) CExpression
 				(
@@ -353,9 +352,8 @@ void CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives
 		// and add it to xform results
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
 		pexprOuter->AddRef();
-		CLogicalApply *popLogicalApply = PopLogicalApply(mp, colref_array);
 		pexprScalar->AddRef();
-		popLogicalApply->SetScalarExpr(pexprScalar);
+		CLogicalApply *popLogicalApply = PopLogicalApply(mp, colref_array, pexprScalar);
 		CExpression *pexprIndexApply =
 			GPOS_NEW(mp) CExpression
 				(
@@ -853,9 +851,8 @@ CXformJoin2IndexApply::PexprIndexApplyOverCTEConsumer
 				CXformUtils::PdrgpcrReorderedSubsequence(mp, pdrgpcrOuterNew, pdrgpulIndexesOfRefsInScan);
 	}
 
-	CLogicalApply *popLogicalApply = PopLogicalApply(mp, pdrgpcrOuterRefsInScanNew);
 	pexprScalar->AddRef();
-	popLogicalApply->SetScalarExpr(pexprScalar);
+	CLogicalApply *popLogicalApply = PopLogicalApply(mp, pdrgpcrOuterRefsInScanNew, pexprScalar);
 	return GPOS_NEW(mp) CExpression
 			(
 			mp,

--- a/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -299,7 +299,7 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
 		pexprOuter->AddRef();
 		pexprScalar->AddRef();
-		CLogicalApply *popLogicalApply = PopLogicalApply(mp, colref_array, pexprScalar);
+		CLogicalIndexApply *popLogicalApply = GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, pexprScalar, m_fOuterJoin);
 		CExpression *pexprIndexApply =
 			GPOS_NEW(mp) CExpression
 				(
@@ -353,7 +353,7 @@ void CXformJoin2IndexApply::CreateHomogeneousBitmapIndexApplyAlternatives
 		CColRefArray *colref_array = outer_refs->Pdrgpcr(mp);
 		pexprOuter->AddRef();
 		pexprScalar->AddRef();
-		CLogicalApply *popLogicalApply = PopLogicalApply(mp, colref_array, pexprScalar);
+		CLogicalIndexApply *popLogicalApply = GPOS_NEW(mp) CLogicalIndexApply(mp, colref_array, pexprScalar, m_fOuterJoin);
 		CExpression *pexprIndexApply =
 			GPOS_NEW(mp) CExpression
 				(
@@ -852,7 +852,7 @@ CXformJoin2IndexApply::PexprIndexApplyOverCTEConsumer
 	}
 
 	pexprScalar->AddRef();
-	CLogicalApply *popLogicalApply = PopLogicalApply(mp, pdrgpcrOuterRefsInScanNew, pexprScalar);
+	CLogicalIndexApply *popLogicalApply = GPOS_NEW(mp) CLogicalIndexApply(mp, pdrgpcrOuterRefsInScanNew, pexprScalar, m_fOuterJoin);
 	return GPOS_NEW(mp) CExpression
 			(
 			mp,
@@ -947,39 +947,5 @@ CXformJoin2IndexApply::AddUnionPlanForPartialIndexes
 									);
 	pxfres->Add(pexprAnchor);
 }
-
-// check whether distribution key and the index key are matched.
-// always returns true for master only table.
-BOOL
-CXformJoin2IndexApply::FMatchDistKeyAndIndexKey
-	(
-	const IMDRelation *pmdrel,
-	const IMDIndex *pmdindex
-	) const
-{
-	if (pmdrel->GetRelDistribution() == IMDRelation::EreldistrMasterOnly)
-	{
-		return true;
-	}
-
-	ULONG length = pmdrel->DistrColumnCount();
-	if (length != pmdindex->Keys())
-	{
-		return false;
-	}
-
-	for (ULONG ul = 0; ul < length; ul++)
-	{
-		const IMDColumn *pmdCol = pmdrel->GetDistrColAt(ul);
-		ULONG ulPos = pmdrel->GetPosFromAttno(pmdCol->AttrNum());
-		if (pmdindex->GetKeyPos(ulPos) == gpos::ulong_max)
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
 // EOF
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -79,7 +79,7 @@ Join-INDF Join-INDF-NoBroadcast TimeTypeStatsNotComparable;
 
 CLeftOuterIndexApplyTest:
 IndexApply-LeftOuter-NLJoin LOJ-IndexApply-MultiIndexes LOJ-IndexApply-Negative-NonEqual-Predicate
-LOJ-IndexApply-DistKey-Multiple-Predicates LOJ-IndexApply-MasterOnly-Table LOJ-IndexApply-Negative-NonDistKey
+LOJ-IndexApply-DistKey-Multiple-Predicates LOJ-IndexApply-MasterOnly-Table LOJ-IndexApply-NonDistKey
 LOJ-IndexApply-CompsiteKey-Equiv LOJ-IndexApply-CompsiteKey-NoMotion LOJ-IndexApply-MultiDistKeys-IndexKeys;
 
 CTypeModifierTest:


### PR DESCRIPTION
During optimization, we push down scalar predicates to our children when we can. 
For example, if bar had an index on c, the optimization process would push down the
predicate as below:
```
ScalarBoolOpAnd 
|--  foo.a = bar.b
+-- foo.c = bar.d
```
becomes
```
Filter 
  |-- Index Scan 
  |      +-- foo.c = bar.d
  +-- foo.a = bar.b
```
However in some cases, the original predicate is needed for the
optimization process. This is now saved as m_pexprScalar in
CLogicalApply and CPhysicalNLJoin.

By saving the original scalar predicate, we can use it to generate proper
equivalent distribution specs which removes unnecessary Broadcasts from
the plan for index nested loop joins.

This allows ORCA to generate plans using index nested loop joins on 
queries whose index are not on the distribution key.  