### PR TITLE
Add shorthand script to reinstall after switching versions

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cmake -GNinja -H. -Bbuild
+ninja install -C build


### PR DESCRIPTION
Each time I go through these steps:

git fetch
git co v3.X.X
cmake
ninja

... I can't remember the exact steps recommended by the README.

So, I've added the steps from the readme into a script called
reinstall.sh in the root directory. Now I can do:

git fetch
git co v3.x.x
./reinstall.sh