### PR TITLE
[WIP] Prefer gather with limit under it and bump down value of Epsilon

### DIFF
--- a/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
+++ b/data/dxl/minidump/AllSubqueryWithSubqueryInScalar.mdp
@@ -351,9 +351,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoinNotIn" IndexNestedLoopJoin="false">
+        <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoinNotIn" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2155.000479" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="2155.000478" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -389,20 +389,20 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.000464" Rows="3.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.000463" Rows="3.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.000463" Rows="3.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.000462" Rows="3.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>
               <dxl:SortingColumnList/>
-              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false">
+              <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.000409" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.000408" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
@@ -414,7 +414,7 @@
                 </dxl:JoinFilter>
                 <dxl:Assert ErrorCode="P0003">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000078" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="16" Alias="a">
@@ -431,7 +431,7 @@
                   </dxl:AssertConstraintList>
                   <dxl:Window PartitionColumns="">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="29" Alias="row_number">
@@ -444,7 +444,7 @@
                     <dxl:Filter/>
                     <dxl:Limit>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000075" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="16" Alias="a">
@@ -453,7 +453,7 @@
                       </dxl:ProjList>
                       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="16" Alias="a">
@@ -462,29 +462,47 @@
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:Limit>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="16" Alias="a">
                               <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
-                            <dxl:Columns>
-                              <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="16" Alias="a">
+                                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
+                              <dxl:Columns>
+                                <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                          <dxl:LimitCount>
+                            <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:Cast>
+                          </dxl:LimitCount>
+                          <dxl:LimitOffset>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:LimitOffset>
+                        </dxl:Limit>
                       </dxl:GatherMotion>
                       <dxl:LimitCount>
                         <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">

--- a/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
+++ b/data/dxl/minidump/AnySubqueryWithSubqueryInScalar.mdp
@@ -1,59 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
 <!--
      CREATE TABLE foo(a INT);
      CREATE TABLE bar(b INT);
      EXPLAIN SELECT * FROM foo WHERE (SELECT COUNT(*) FROM foo) IN (SELECT 1 FROM bar);
 -->
-<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
         <dxl:CostParams>
-          <dxl:CostParam Name="NLJFactor" Value="1.000000" LowerBound="0.500000" UpperBound="1.500000"/>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="7" ArrayExpansionThreshold="25" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="10000000"/>
-      <dxl:TraceFlags Value="103027,101013,102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,104003,104004,104005,104006,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:RelationStatistics Mdid="2.377093.1.0" Name="bar" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.377093.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
-        <dxl:Columns>
-          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:Triggers/>
-        <dxl:CheckConstraints/>
-      </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.377090.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Relation Mdid="0.377090.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+      <dxl:RelationStatistics Mdid="2.32768.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.32768.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -84,8 +52,51 @@
         <dxl:Triggers/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.377090.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.377090.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.32771.1.0" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.32771.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.15.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.852.1.0"/>
+        <dxl:Commutator Mdid="0.416.1.0"/>
+        <dxl:InverseOp Mdid="0.36.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
@@ -159,7 +170,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -229,27 +240,16 @@
           <dxl:OpClass Mdid="0.3028.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.32771.1.0.0" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:ColumnStatistics Mdid="1.377093.1.0.0" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
       <dxl:MDScalarComparison Mdid="4.20.1.0;23.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.20.1.0" RightType="0.23.1.0" OperatorMdid="0.416.1.0"/>
-      <dxl:GPDBFunc Mdid="0.474.1.0" Name="int84eq" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
-        <dxl:ResultType Mdid="0.16.1.0"/>
-      </dxl:GPDBFunc>
-      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.66.1.0"/>
-        <dxl:Commutator Mdid="0.521.1.0"/>
-        <dxl:InverseOp Mdid="0.525.1.0"/>
-        <dxl:OpClasses>
-          <dxl:OpClass Mdid="0.1976.1.0"/>
-          <dxl:OpClass Mdid="0.3027.1.0"/>
-        </dxl:OpClasses>
-      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.32768.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBFunc Mdid="0.481.1.0" Name="int8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
       </dxl:GPDBFunc>
@@ -266,18 +266,6 @@
           <dxl:OpClass Mdid="0.3027.1.0"/>
         </dxl:OpClasses>
       </dxl:GPDBScalarOp>
-      <dxl:GPDBScalarOp Mdid="0.2799.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
-        <dxl:LeftType Mdid="0.27.1.0"/>
-        <dxl:RightType Mdid="0.27.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.2791.1.0"/>
-        <dxl:Commutator Mdid="0.2800.1.0"/>
-        <dxl:InverseOp Mdid="0.2802.1.0"/>
-        <dxl:OpClasses>
-          <dxl:OpClass Mdid="0.2789.1.0"/>
-        </dxl:OpClasses>
-      </dxl:GPDBScalarOp>
-      <dxl:ColumnStatistics Mdid="1.377090.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
@@ -300,7 +288,7 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:LogicalGet>
-                <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
+                <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo">
                   <dxl:Columns>
                     <dxl:Column ColId="18" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                     <dxl:Column ColId="19" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -322,7 +310,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:LogicalGet>
-              <dxl:TableDescriptor Mdid="0.377093.1.0" TableName="bar">
+              <dxl:TableDescriptor Mdid="0.32771.1.0" TableName="bar">
                 <dxl:Columns>
                   <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -338,7 +326,7 @@
           </dxl:LogicalProject>
         </dxl:SubqueryAny>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
+          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -353,10 +341,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="420">
+    <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6896.001505" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1765376.381464" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -367,7 +355,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6896.001490" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1765376.381449" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -388,7 +376,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
+            <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -481,7 +469,7 @@
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.377090.1.0" TableName="foo">
+                          <dxl:TableDescriptor Mdid="0.32768.1.0" TableName="foo">
                             <dxl:Columns>
                               <dxl:Column ColId="17" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                               <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
@@ -522,7 +510,7 @@
                       </dxl:Properties>
                       <dxl:ProjList/>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.377093.1.0" TableName="bar">
+                      <dxl:TableDescriptor Mdid="0.32771.1.0" TableName="bar">
                         <dxl:Columns>
                           <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                           <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>

--- a/data/dxl/minidump/BitmapIndexScanCost.mdp
+++ b/data/dxl/minidump/BitmapIndexScanCost.mdp
@@ -319,7 +319,7 @@
     <dxl:Plan Id="0" SpaceSize="138">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="454.683299" Rows="10.000000" Width="66"/>
+          <dxl:Cost StartupCost="0" TotalCost="454.683148" Rows="10.000000" Width="66"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="message_id">
@@ -333,7 +333,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="true" OuterRefAsParam="true">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="454.681828" Rows="10.000000" Width="66"/>
+            <dxl:Cost StartupCost="0" TotalCost="454.681677" Rows="10.000000" Width="66"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="message_id">
@@ -349,7 +349,7 @@
           </dxl:JoinFilter>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="441.907091" Rows="10.000000" Width="33"/>
+              <dxl:Cost StartupCost="0" TotalCost="441.906941" Rows="10.000000" Width="33"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="6"/>
@@ -362,7 +362,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="441.907040" Rows="10.000000" Width="33"/>
+                <dxl:Cost StartupCost="0" TotalCost="441.906889" Rows="10.000000" Width="33"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="6" Alias="message_id">
@@ -377,7 +377,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="441.907040" Rows="10.000000" Width="33"/>
+                  <dxl:Cost StartupCost="0" TotalCost="441.906889" Rows="10.000000" Width="33"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="6" Alias="message_id">
@@ -393,7 +393,7 @@
                 </dxl:HashExprList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="441.907009" Rows="10.000000" Width="33"/>
+                    <dxl:Cost StartupCost="0" TotalCost="441.906858" Rows="10.000000" Width="33"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="6"/>
@@ -406,7 +406,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="441.907005" Rows="10.000000" Width="33"/>
+                      <dxl:Cost StartupCost="0" TotalCost="441.906855" Rows="10.000000" Width="33"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="6" Alias="message_id">
@@ -421,7 +421,7 @@
                     <dxl:LimitOffset/>
                     <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="441.907005" Rows="10.000000" Width="33"/>
+                        <dxl:Cost StartupCost="0" TotalCost="441.906855" Rows="10.000000" Width="33"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="6" Alias="message_id">
@@ -432,7 +432,7 @@
                       <dxl:SortingColumnList/>
                       <dxl:Limit>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="441.906235" Rows="10.000000" Width="33"/>
+                          <dxl:Cost StartupCost="0" TotalCost="441.906084" Rows="10.000000" Width="33"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="6" Alias="message_id">
@@ -441,7 +441,7 @@
                         </dxl:ProjList>
                         <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="441.905905" Rows="10.000000" Width="33"/>
+                            <dxl:Cost StartupCost="0" TotalCost="441.905754" Rows="10.000000" Width="33"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="6" Alias="message_id">
@@ -452,7 +452,7 @@
                           <dxl:SortingColumnList/>
                           <dxl:Limit>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="441.894138" Rows="10.000000" Width="33"/>
+                              <dxl:Cost StartupCost="0" TotalCost="441.894105" Rows="10.000000" Width="33"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="6" Alias="message_id">

--- a/data/dxl/minidump/CTAS-with-Limit.mdp
+++ b/data/dxl/minidump/CTAS-with-Limit.mdp
@@ -633,7 +633,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="0,1" VarTypeModList="-1,-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1994.200543" Rows="99570.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1994.170857" Rows="99570.000000" Width="8"/>
         </dxl:Properties>
         <dxl:Columns>
           <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
@@ -650,7 +650,7 @@
         </dxl:ProjList>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="438.419293" Rows="99570.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="438.389607" Rows="99570.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -667,7 +667,7 @@
           <dxl:OneTimeFilter/>
           <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="438.021013" Rows="99570.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="437.991327" Rows="99570.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -681,7 +681,7 @@
             <dxl:SortingColumnList/>
             <dxl:Limit>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="435.952612" Rows="99570.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="435.922927" Rows="99570.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -693,7 +693,7 @@
               </dxl:ProjList>
               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="435.156052" Rows="99570.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="435.126367" Rows="99570.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -705,9 +705,9 @@
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
-                <dxl:TableScan>
+                <dxl:Limit>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.693671" Rows="99570.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="432.187538" Rows="99570.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -717,21 +717,40 @@
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="0.49342.1.0" TableName="test1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.693671" Rows="99570.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="0.49342.1.0" TableName="test1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:LimitCount>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="100000"/>
+                  </dxl:LimitCount>
+                  <dxl:LimitOffset>
+                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                  </dxl:LimitOffset>
+                </dxl:Limit>
               </dxl:GatherMotion>
               <dxl:LimitCount>
                 <dxl:ConstValue TypeMdid="0.20.1.0" Value="100000"/>

--- a/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
+++ b/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
@@ -309,7 +309,7 @@
     <dxl:Plan Id="0" SpaceSize="188">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.151091" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.150712" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="c1">
@@ -320,7 +320,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.151076" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.150697" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="c1">
@@ -386,7 +386,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:TableScan>

--- a/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
+++ b/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
@@ -705,7 +705,7 @@
     <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324039.870686" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324039.870306" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -716,7 +716,7 @@
         <dxl:SortingColumnList/>
         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324039.870671" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324039.870291" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -757,13 +757,13 @@
           </dxl:TableScan>
           <dxl:Materialize Eager="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.007626" Rows="3.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.007625" Rows="3.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
             <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.007625" Rows="3.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.007624" Rows="3.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter/>

--- a/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
+++ b/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
@@ -320,7 +320,7 @@
     <dxl:Plan Id="0" SpaceSize="84">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.157856" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.156338" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -333,7 +333,7 @@
             <dxl:ParamList/>
             <dxl:Materialize Eager="true">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="8" Alias="b">
@@ -343,7 +343,7 @@
               <dxl:Filter/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="b">
@@ -352,7 +352,7 @@
                 </dxl:ProjList>
                 <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000050" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="b">
@@ -363,7 +363,7 @@
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="8" Alias="b">

--- a/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
+++ b/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
@@ -285,7 +285,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:DMLInsert Columns="1" ActionCol="14" OidCol="0" CtidCol="0" SegmentIdCol="0" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="882688.057927" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="882688.057775" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo>
           <dxl:KeyValue>
@@ -311,7 +311,7 @@
         </dxl:TableDescriptor>
         <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="882688.047511" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="882688.047358" Rows="1.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="1" Alias="?column?">
@@ -330,7 +330,7 @@
           </dxl:HashExprList>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="882688.047490" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="882688.047337" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="?column?">
@@ -344,7 +344,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="882688.047482" Rows="1.000000" Width="1"/>
+                <dxl:Cost StartupCost="0" TotalCost="882688.047329" Rows="1.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList/>
               <dxl:Filter>
@@ -353,7 +353,7 @@
                   <dxl:ParamList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000031" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="a">
@@ -362,7 +362,7 @@
                     </dxl:ProjList>
                     <dxl:Materialize Eager="true">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="2" Alias="a">
@@ -372,7 +372,7 @@
                       <dxl:Filter/>
                       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="1.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="2" Alias="a">
@@ -381,29 +381,45 @@
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:Limit>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="2" Alias="a">
                               <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="0.16391.1.0" TableName="t1">
-                            <dxl:Columns>
-                              <dxl:Column ColId="2" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="2" Alias="a">
+                                <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="0.16391.1.0" TableName="t1">
+                              <dxl:Columns>
+                                <dxl:Column ColId="2" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                          <dxl:LimitCount>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                          </dxl:LimitCount>
+                          <dxl:LimitOffset>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:LimitOffset>
+                        </dxl:Limit>
                       </dxl:GatherMotion>
                     </dxl:Materialize>
                     <dxl:LimitCount>

--- a/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -724,7 +724,7 @@
     <dxl:Plan Id="0" SpaceSize="342">
       <dxl:DMLDelete Columns="0" ActionCol="21" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.965580" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.965565" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -746,7 +746,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.942142" Rows="1.000000" Width="18"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.942127" Rows="1.000000" Width="18"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -766,7 +766,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.942136" Rows="1.000000" Width="14"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.942121" Rows="1.000000" Width="14"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -818,7 +818,7 @@
             </dxl:TableScan>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.941257" Rows="10.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.941242" Rows="10.000000" Width="4"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="8"/>
@@ -831,7 +831,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.941236" Rows="10.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.941221" Rows="10.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="8" Alias="a">
@@ -846,7 +846,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.941105" Rows="10.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.941090" Rows="10.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="8" Alias="a">
@@ -862,7 +862,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.941063" Rows="10.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.941048" Rows="10.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="8"/>
@@ -875,7 +875,7 @@
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.941042" Rows="10.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.941027" Rows="10.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="8" Alias="a">
@@ -890,7 +890,7 @@
                       <dxl:LimitOffset/>
                       <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.940911" Rows="10.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.940896" Rows="10.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="8" Alias="a">
@@ -901,7 +901,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:Limit>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.940807" Rows="10.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.940792" Rows="10.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="8" Alias="a">
@@ -910,7 +910,7 @@
                           </dxl:ProjList>
                           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="0">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.940767" Rows="10.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.940752" Rows="10.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="8" Alias="a">
@@ -921,7 +921,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:Limit>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.940618" Rows="10.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.940605" Rows="10.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="8" Alias="a">

--- a/data/dxl/minidump/DonotPushPartConstThruLimit.mdp
+++ b/data/dxl/minidump/DonotPushPartConstThruLimit.mdp
@@ -261,7 +261,7 @@ select * from (select * from h order by j limit 2) x where j = 2;
     <dxl:Plan Id="0" SpaceSize="7">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="1.333334" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000185" Rows="1.333334" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="j">
@@ -280,7 +280,7 @@ select * from (select * from h order by j limit 2) x where j = 2;
         <dxl:OneTimeFilter/>
         <dxl:Limit>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000119" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="j">
@@ -292,7 +292,7 @@ select * from (select * from h order by j limit 2) x where j = 2;
           </dxl:ProjList>
           <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000109" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="j">
@@ -308,7 +308,7 @@ select * from (select * from h order by j limit 2) x where j = 2;
             </dxl:SortingColumnList>
             <dxl:Limit>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000049" Rows="2.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="2.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="j">

--- a/data/dxl/minidump/EagerAggSubquery.mdp
+++ b/data/dxl/minidump/EagerAggSubquery.mdp
@@ -376,7 +376,7 @@
     <dxl:Plan Id="0" SpaceSize="11640">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324463.236868" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.236830" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="1" Alias="g1">
@@ -393,7 +393,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324463.236808" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324463.236770" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="1"/>
@@ -415,7 +415,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324463.236789" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324463.236751" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="g1">
@@ -437,7 +437,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324463.236789" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324463.236751" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="g1">
@@ -462,7 +462,7 @@
               </dxl:HashExprList>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324463.236764" Rows="1.000000" Width="16"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324463.236726" Rows="1.000000" Width="16"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="g1">
@@ -485,7 +485,7 @@
                 </dxl:HashCondList>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.236242" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.236204" Rows="1.000000" Width="16"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="0"/>
@@ -507,7 +507,7 @@
                   <dxl:Filter/>
                   <dxl:Sort SortDiscardDuplicates="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.236221" Rows="1.000000" Width="12"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.236183" Rows="1.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="j1">
@@ -529,7 +529,7 @@
                     <dxl:LimitOffset/>
                     <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.236221" Rows="1.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.236183" Rows="1.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="0" Alias="j1">
@@ -607,25 +607,37 @@
                               <dxl:ProjList/>
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
-                              <dxl:TableScan>
+                              <dxl:Limit>
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="20" Attno="1" ColName="j2" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList/>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.16388.1.0" TableName="bar">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="20" Attno="1" ColName="j2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                                <dxl:LimitCount>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                </dxl:LimitCount>
+                                <dxl:LimitOffset>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:LimitOffset>
+                              </dxl:Limit>
                             </dxl:GatherMotion>
                             <dxl:LimitCount>
                               <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
+++ b/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
@@ -715,7 +715,7 @@ EXPLAIN SELECT * FROM foo WHERE a IN (SELECT b+1 FROM bar);
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000686" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000685" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:TableScan>

--- a/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
+++ b/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
@@ -721,7 +721,7 @@ EXPLAIN SELECT * FROM foo WHERE 1+a IN (SELECT b+1 FROM bar);
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000686" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000685" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:TableScan>

--- a/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
+++ b/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
@@ -622,7 +622,7 @@ SELECT * FROM foo WHERE 2 IN (SELECT b+1 FROM bar);
     <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.004400" Rows="40.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.004399" Rows="40.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -712,7 +712,7 @@ SELECT * FROM foo WHERE 2 IN (SELECT b+1 FROM bar);
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000686" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000685" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:TableScan>

--- a/data/dxl/minidump/InferPredicatesForLimit.mdp
+++ b/data/dxl/minidump/InferPredicatesForLimit.mdp
@@ -276,7 +276,7 @@ a < 2 should also be outside the limit but not below.
     <dxl:Plan Id="0" SpaceSize="38">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.000626" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.000625" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="?column?">
@@ -287,14 +287,14 @@ a < 2 should also be outside the limit but not below.
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000622" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000621" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashJoin JoinType="Inner">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000618" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000617" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -307,7 +307,7 @@ a < 2 should also be outside the limit but not below.
             </dxl:HashCondList>
             <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000275" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000274" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -318,7 +318,7 @@ a < 2 should also be outside the limit but not below.
               <dxl:SortingColumnList/>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000265" Rows="1.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000264" Rows="1.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -340,7 +340,7 @@ a < 2 should also be outside the limit but not below.
                 <dxl:OneTimeFilter/>
                 <dxl:Limit>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000199" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000198" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -352,7 +352,7 @@ a < 2 should also be outside the limit but not below.
                   </dxl:ProjList>
                   <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000191" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000190" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -364,7 +364,7 @@ a < 2 should also be outside the limit but not below.
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
-                    <dxl:TableScan>
+                    <dxl:Limit>
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
@@ -376,36 +376,55 @@ a < 2 should also be outside the limit but not below.
                           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:And>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
                             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
                             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          </dxl:Comparison>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:And>
-                      </dxl:Filter>
-                      <dxl:TableDescriptor Mdid="0.49155.1.1" TableName="foo">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter>
+                          <dxl:And>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            </dxl:Comparison>
+                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:Comparison>
+                          </dxl:And>
+                        </dxl:Filter>
+                        <dxl:TableDescriptor Mdid="0.49155.1.1" TableName="foo">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:LimitCount>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                      </dxl:LimitCount>
+                      <dxl:LimitOffset>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                      </dxl:LimitOffset>
+                    </dxl:Limit>
                   </dxl:GatherMotion>
                   <dxl:LimitCount>
                     <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5771,7 +5771,7 @@
     <dxl:Plan Id="0" SpaceSize="44722048">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2587.959383" Rows="1.000000" Width="24"/>
+          <dxl:Cost StartupCost="0" TotalCost="2587.959382" Rows="1.000000" Width="24"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5786,7 +5786,7 @@
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2587.959359" Rows="1.000000" Width="24"/>
+            <dxl:Cost StartupCost="0" TotalCost="2587.959358" Rows="1.000000" Width="24"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="111" Alias="?column?">
@@ -5804,13 +5804,13 @@
             <dxl:SortingColumn ColId="110" SortOperatorMdid="0.413.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
             <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
           </dxl:SortingColumnList>
-          <dxl:Result>
+          <dxl:Limit>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="2587.959270" Rows="1.000000" Width="24"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="111" Alias="?column?">
-                <dxl:ConstValue TypeMdid="0.705.1.0" Value="bXBwaDIxAA=="/>
+                <dxl:Ident ColId="111" ColName="?column?" TypeMdid="0.705.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="1" Alias="s_name">
                 <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
@@ -5819,66 +5819,68 @@
                 <dxl:Ident ColId="110" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:OneTimeFilter/>
-            <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="2587.959262" Rows="1.000000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="2587.959270" Rows="1.000000" Width="24"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="110" Alias="count">
-                  <dxl:Ident ColId="110" ColName="count" TypeMdid="0.20.1.0"/>
+                <dxl:ProjElem ColId="111" Alias="?column?">
+                  <dxl:ConstValue TypeMdid="0.705.1.0" Value="bXBwaDIxAA=="/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="s_name">
                   <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="110" Alias="count">
+                  <dxl:Ident ColId="110" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList>
-                <dxl:SortingColumn ColId="110" SortOperatorMdid="0.413.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
-                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              </dxl:SortingColumnList>
-              <dxl:LimitCount/>
-              <dxl:LimitOffset/>
-              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:OneTimeFilter/>
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="2587.959262" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="1"/>
-                </dxl:GroupingColumns>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="110" Alias="count">
-                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
-                      <dxl:Ident ColId="112" ColName="ColRef_0112" TypeMdid="0.25.1.0"/>
-                    </dxl:AggFunc>
+                    <dxl:Ident ColId="110" ColName="count" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="1" Alias="s_name">
                     <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="110" SortOperatorMdid="0.413.1.0" SortOperatorName="&gt;" SortNullsFirst="true"/>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
                 <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="2587.959222" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="2587.959262" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>
-                    <dxl:GroupingColumn ColId="112"/>
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="110" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal">
+                        <dxl:Ident ColId="112" ColName="ColRef_0112" TypeMdid="0.25.1.0"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="1" Alias="s_name">
                       <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="112" Alias="ColRef_0112">
-                      <dxl:Ident ColId="112" ColName="ColRef_0112" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2587.959168" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2587.959222" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="1"/>
+                      <dxl:GroupingColumn ColId="112"/>
+                    </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="s_name">
                         <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
@@ -5888,13 +5890,7 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="112" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
                         <dxl:Cost StartupCost="0" TotalCost="2587.959168" Rows="1.000000" Width="34"/>
                       </dxl:Properties>
@@ -5907,20 +5903,16 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.1042.1.0">
-                          <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="112" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="2587.959115" Rows="1.000000" Width="34"/>
+                          <dxl:Cost StartupCost="0" TotalCost="2587.959168" Rows="1.000000" Width="34"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns>
-                          <dxl:GroupingColumn ColId="1"/>
-                          <dxl:GroupingColumn ColId="112"/>
-                        </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="1" Alias="s_name">
                             <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
@@ -5930,79 +5922,76 @@
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr TypeMdid="0.1042.1.0">
+                            <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="2587.959074" Rows="1.000000" Width="34"/>
+                            <dxl:Cost StartupCost="0" TotalCost="2587.959115" Rows="1.000000" Width="34"/>
                           </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="1"/>
+                            <dxl:GroupingColumn ColId="112"/>
+                          </dxl:GroupingColumns>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="112" Alias="ColRef_0112">
-                              <dxl:Ident ColId="112" ColName="ColRef_0112" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
                             <dxl:ProjElem ColId="1" Alias="s_name">
                               <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                             </dxl:ProjElem>
+                            <dxl:ProjElem ColId="112" Alias="ColRef_0112">
+                              <dxl:Ident ColId="112" ColName="ColRef_0112" TypeMdid="0.25.1.0"/>
+                            </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:SortingColumnList>
-                            <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            <dxl:SortingColumn ColId="112" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          </dxl:SortingColumnList>
-                          <dxl:LimitCount/>
-                          <dxl:LimitOffset/>
-                          <dxl:Result>
+                          <dxl:Sort SortDiscardDuplicates="false">
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="2587.959074" Rows="1.000000" Width="34"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="112" Alias="ColRef_0112">
-                                <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
-                                  <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="65">
-                                    <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                  </dxl:CoerceViaIO>
-                                  <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="88">
-                                    <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
-                                  </dxl:CoerceViaIO>
-                                </dxl:OpExpr>
+                                <dxl:Ident ColId="112" ColName="ColRef_0112" TypeMdid="0.25.1.0"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="1" Alias="s_name">
                                 <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:HashJoin JoinType="Inner">
+                            <dxl:SortingColumnList>
+                              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1058.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              <dxl:SortingColumn ColId="112" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            </dxl:SortingColumnList>
+                            <dxl:LimitCount/>
+                            <dxl:LimitOffset/>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="2587.959040" Rows="1.000000" Width="38"/>
+                                <dxl:Cost StartupCost="0" TotalCost="2587.959074" Rows="1.000000" Width="34"/>
                               </dxl:Properties>
                               <dxl:ProjList>
+                                <dxl:ProjElem ColId="112" Alias="ColRef_0112">
+                                  <dxl:OpExpr OperatorName="||" OperatorMdid="0.654.1.0" OperatorType="0.25.1.0">
+                                    <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="65">
+                                      <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                    </dxl:CoerceViaIO>
+                                    <dxl:CoerceViaIO TypeMdid="0.25.1.0" CoercionForm="1" Location="88">
+                                      <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
+                                    </dxl:CoerceViaIO>
+                                  </dxl:OpExpr>
+                                </dxl:ProjElem>
                                 <dxl:ProjElem ColId="1" Alias="s_name">
                                   <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                                 </dxl:ProjElem>
-                                <dxl:ProjElem ColId="41" Alias="l_orderkey">
-                                  <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="44" Alias="l_linenumber">
-                                  <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:JoinFilter/>
-                              <dxl:HashCondList>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="30" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:HashCondList>
+                              <dxl:OneTimeFilter/>
                               <dxl:HashJoin JoinType="Inner">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="2156.957335" Rows="1.000000" Width="42"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="2587.959040" Rows="1.000000" Width="38"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="1" Alias="s_name">
                                     <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="3" Alias="s_nationkey">
-                                    <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                   <dxl:ProjElem ColId="41" Alias="l_orderkey">
                                     <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
@@ -6014,43 +6003,14 @@
                                 <dxl:Filter/>
                                 <dxl:JoinFilter/>
                                 <dxl:HashCondList>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                                    <dxl:Ident ColId="14" ColName="o_orderkey" TypeMdid="0.20.1.0"/>
-                                    <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                    <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                                    <dxl:Ident ColId="30" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
                                   </dxl:Comparison>
                                 </dxl:HashCondList>
-                                <dxl:TableScan>
+                                <dxl:HashJoin JoinType="Inner">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.058247" Rows="499.333333" Width="8"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="14" Alias="o_orderkey">
-                                      <dxl:Ident ColId="14" ColName="o_orderkey" TypeMdid="0.20.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                                      <dxl:Ident ColId="16" ColName="o_orderstatus" TypeMdid="0.1042.1.0" TypeModifier="5"/>
-                                      <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" Value="AAAABUY=" LintValue="160743980"/>
-                                    </dxl:Comparison>
-                                  </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.31262.1.0" TableName="heap_orders">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="14" Attno="1" ColName="o_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                                      <dxl:Column ColId="16" Attno="3" ColName="o_orderstatus" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
-                                      <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1725.868149" Rows="3.000000" Width="42"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="2156.957335" Rows="1.000000" Width="42"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6067,10 +6027,45 @@
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
                                   <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:HashJoin JoinType="Inner">
+                                  <dxl:JoinFilter/>
+                                  <dxl:HashCondList>
+                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                                      <dxl:Ident ColId="14" ColName="o_orderkey" TypeMdid="0.20.1.0"/>
+                                      <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                    </dxl:Comparison>
+                                  </dxl:HashCondList>
+                                  <dxl:TableScan>
                                     <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1725.867397" Rows="1.000000" Width="42"/>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.058247" Rows="499.333333" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="14" Alias="o_orderkey">
+                                        <dxl:Ident ColId="14" ColName="o_orderkey" TypeMdid="0.20.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                                        <dxl:Ident ColId="16" ColName="o_orderstatus" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                                        <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAABUY=" LintValue="160743980"/>
+                                      </dxl:Comparison>
+                                    </dxl:Filter>
+                                    <dxl:TableDescriptor Mdid="0.31262.1.0" TableName="heap_orders">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="14" Attno="1" ColName="o_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                                        <dxl:Column ColId="16" Attno="3" ColName="o_orderstatus" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="2"/>
+                                        <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                  <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="1725.868149" Rows="3.000000" Width="42"/>
                                     </dxl:Properties>
                                     <dxl:ProjList>
                                       <dxl:ProjElem ColId="1" Alias="s_name">
@@ -6087,64 +6082,67 @@
                                       </dxl:ProjElem>
                                     </dxl:ProjList>
                                     <dxl:Filter/>
-                                    <dxl:JoinFilter/>
-                                    <dxl:HashCondList>
-                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                        <dxl:Ident ColId="0" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
-                                        <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                                      </dxl:Comparison>
-                                    </dxl:HashCondList>
-                                    <dxl:TableScan>
+                                    <dxl:SortingColumnList/>
+                                    <dxl:HashJoin JoinType="Inner">
                                       <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="431.003208" Rows="100.000000" Width="34"/>
+                                        <dxl:Cost StartupCost="0" TotalCost="1725.867397" Rows="1.000000" Width="42"/>
                                       </dxl:Properties>
                                       <dxl:ProjList>
-                                        <dxl:ProjElem ColId="0" Alias="s_suppkey">
-                                          <dxl:Ident ColId="0" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
-                                        </dxl:ProjElem>
                                         <dxl:ProjElem ColId="1" Alias="s_name">
                                           <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                                         </dxl:ProjElem>
                                         <dxl:ProjElem ColId="3" Alias="s_nationkey">
                                           <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:TableDescriptor Mdid="0.31274.1.0" TableName="heap_supplier">
-                                        <dxl:Columns>
-                                          <dxl:Column ColId="0" Attno="1" ColName="s_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="1" Attno="2" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29" ColWidth="26"/>
-                                          <dxl:Column ColId="3" Attno="4" ColName="s_nationkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                          <dxl:Column ColId="8" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="9" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="10" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="11" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="12" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                          <dxl:Column ColId="13" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                        </dxl:Columns>
-                                      </dxl:TableDescriptor>
-                                    </dxl:TableScan>
-                                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="1294.855085" Rows="3.000000" Width="16"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
                                         <dxl:ProjElem ColId="41" Alias="l_orderkey">
                                           <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="43" Alias="l_suppkey">
-                                          <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
                                         <dxl:ProjElem ColId="44" Alias="l_linenumber">
                                           <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
                                         </dxl:ProjElem>
                                       </dxl:ProjList>
                                       <dxl:Filter/>
-                                      <dxl:SortingColumnList/>
-                                      <dxl:Result>
+                                      <dxl:JoinFilter/>
+                                      <dxl:HashCondList>
+                                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                                          <dxl:Ident ColId="0" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                                          <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                                        </dxl:Comparison>
+                                      </dxl:HashCondList>
+                                      <dxl:TableScan>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="1294.854799" Rows="1.000000" Width="16"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.003208" Rows="100.000000" Width="34"/>
+                                        </dxl:Properties>
+                                        <dxl:ProjList>
+                                          <dxl:ProjElem ColId="0" Alias="s_suppkey">
+                                            <dxl:Ident ColId="0" ColName="s_suppkey" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="1" Alias="s_name">
+                                            <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
+                                          </dxl:ProjElem>
+                                          <dxl:ProjElem ColId="3" Alias="s_nationkey">
+                                            <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
+                                          </dxl:ProjElem>
+                                        </dxl:ProjList>
+                                        <dxl:Filter/>
+                                        <dxl:TableDescriptor Mdid="0.31274.1.0" TableName="heap_supplier">
+                                          <dxl:Columns>
+                                            <dxl:Column ColId="0" Attno="1" ColName="s_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="1" Attno="2" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29" ColWidth="26"/>
+                                            <dxl:Column ColId="3" Attno="4" ColName="s_nationkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="7" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                            <dxl:Column ColId="8" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="9" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="10" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="11" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="12" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                            <dxl:Column ColId="13" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                          </dxl:Columns>
+                                        </dxl:TableDescriptor>
+                                      </dxl:TableScan>
+                                      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                        <dxl:Properties>
+                                          <dxl:Cost StartupCost="0" TotalCost="1294.855085" Rows="3.000000" Width="16"/>
                                         </dxl:Properties>
                                         <dxl:ProjList>
                                           <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6157,15 +6155,11 @@
                                             <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
                                           </dxl:ProjElem>
                                         </dxl:ProjList>
-                                        <dxl:Filter>
-                                          <dxl:IsNull>
-                                            <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                          </dxl:IsNull>
-                                        </dxl:Filter>
-                                        <dxl:OneTimeFilter/>
-                                        <dxl:HashJoin JoinType="Inner">
+                                        <dxl:Filter/>
+                                        <dxl:SortingColumnList/>
+                                        <dxl:Result>
                                           <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="1294.769805" Rows="7750.211056" Width="24"/>
+                                            <dxl:Cost StartupCost="0" TotalCost="1294.854799" Rows="1.000000" Width="16"/>
                                           </dxl:Properties>
                                           <dxl:ProjList>
                                             <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6177,26 +6171,16 @@
                                             <dxl:ProjElem ColId="44" Alias="l_linenumber">
                                               <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
                                             </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="87" Alias="l_orderkey">
-                                              <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                            </dxl:ProjElem>
                                           </dxl:ProjList>
-                                          <dxl:Filter/>
-                                          <dxl:JoinFilter>
-                                            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                                              <dxl:Ident ColId="66" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                                              <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                                            </dxl:Comparison>
-                                          </dxl:JoinFilter>
-                                          <dxl:HashCondList>
-                                            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                                              <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                              <dxl:Ident ColId="64" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                            </dxl:Comparison>
-                                          </dxl:HashCondList>
-                                          <dxl:HashJoin JoinType="Left">
+                                          <dxl:Filter>
+                                            <dxl:IsNull>
+                                              <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                            </dxl:IsNull>
+                                          </dxl:Filter>
+                                          <dxl:OneTimeFilter/>
+                                          <dxl:HashJoin JoinType="Inner">
                                             <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="862.712892" Rows="1923.935215" Width="24"/>
+                                              <dxl:Cost StartupCost="0" TotalCost="1294.769805" Rows="7750.211056" Width="24"/>
                                             </dxl:Properties>
                                             <dxl:ProjList>
                                               <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6215,19 +6199,19 @@
                                             <dxl:Filter/>
                                             <dxl:JoinFilter>
                                               <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                                                <dxl:Ident ColId="89" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                                                <dxl:Ident ColId="66" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                                                 <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                                               </dxl:Comparison>
                                             </dxl:JoinFilter>
                                             <dxl:HashCondList>
                                               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                                 <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                                <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                <dxl:Ident ColId="64" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
                                               </dxl:Comparison>
                                             </dxl:HashCondList>
-                                            <dxl:TableScan>
+                                            <dxl:HashJoin JoinType="Left">
                                               <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.165872" Rows="1194.000000" Width="16"/>
+                                                <dxl:Cost StartupCost="0" TotalCost="862.712892" Rows="1923.935215" Width="24"/>
                                               </dxl:Properties>
                                               <dxl:ProjList>
                                                 <dxl:ProjElem ColId="41" Alias="l_orderkey">
@@ -6239,155 +6223,193 @@
                                                 <dxl:ProjElem ColId="44" Alias="l_linenumber">
                                                   <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
                                                 </dxl:ProjElem>
-                                              </dxl:ProjList>
-                                              <dxl:Filter>
-                                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                                                  <dxl:Ident ColId="53" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
-                                                  <dxl:Ident ColId="52" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-                                                </dxl:Comparison>
-                                              </dxl:Filter>
-                                              <dxl:TableDescriptor Mdid="0.31256.1.0" TableName="heap_lineitem">
-                                                <dxl:Columns>
-                                                  <dxl:Column ColId="41" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                                                  <dxl:Column ColId="43" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="44" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="52" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="53" Attno="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                                  <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                </dxl:Columns>
-                                              </dxl:TableDescriptor>
-                                            </dxl:TableScan>
-                                            <dxl:TableScan>
-                                              <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.162911" Rows="1194.000000" Width="12"/>
-                                              </dxl:Properties>
-                                              <dxl:ProjList>
                                                 <dxl:ProjElem ColId="87" Alias="l_orderkey">
                                                   <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
                                                 </dxl:ProjElem>
-                                                <dxl:ProjElem ColId="89" Alias="l_suppkey">
+                                              </dxl:ProjList>
+                                              <dxl:Filter/>
+                                              <dxl:JoinFilter>
+                                                <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
                                                   <dxl:Ident ColId="89" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                                                  <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                                                </dxl:Comparison>
+                                              </dxl:JoinFilter>
+                                              <dxl:HashCondList>
+                                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                                                  <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                  <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                </dxl:Comparison>
+                                              </dxl:HashCondList>
+                                              <dxl:TableScan>
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.165872" Rows="1194.000000" Width="16"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="41" Alias="l_orderkey">
+                                                    <dxl:Ident ColId="41" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="43" Alias="l_suppkey">
+                                                    <dxl:Ident ColId="43" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="44" Alias="l_linenumber">
+                                                    <dxl:Ident ColId="44" ColName="l_linenumber" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter>
+                                                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
+                                                    <dxl:Ident ColId="53" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
+                                                    <dxl:Ident ColId="52" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                                                  </dxl:Comparison>
+                                                </dxl:Filter>
+                                                <dxl:TableDescriptor Mdid="0.31256.1.0" TableName="heap_lineitem">
+                                                  <dxl:Columns>
+                                                    <dxl:Column ColId="41" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                                                    <dxl:Column ColId="43" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="44" Attno="4" ColName="l_linenumber" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="52" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="53" Attno="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                    <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                  </dxl:Columns>
+                                                </dxl:TableDescriptor>
+                                              </dxl:TableScan>
+                                              <dxl:TableScan>
+                                                <dxl:Properties>
+                                                  <dxl:Cost StartupCost="0" TotalCost="431.162911" Rows="1194.000000" Width="12"/>
+                                                </dxl:Properties>
+                                                <dxl:ProjList>
+                                                  <dxl:ProjElem ColId="87" Alias="l_orderkey">
+                                                    <dxl:Ident ColId="87" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                  </dxl:ProjElem>
+                                                  <dxl:ProjElem ColId="89" Alias="l_suppkey">
+                                                    <dxl:Ident ColId="89" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
+                                                  </dxl:ProjElem>
+                                                </dxl:ProjList>
+                                                <dxl:Filter>
+                                                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
+                                                    <dxl:Ident ColId="99" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
+                                                    <dxl:Ident ColId="98" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
+                                                  </dxl:Comparison>
+                                                </dxl:Filter>
+                                                <dxl:TableDescriptor Mdid="0.31256.1.0" TableName="heap_lineitem">
+                                                  <dxl:Columns>
+                                                    <dxl:Column ColId="87" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                                                    <dxl:Column ColId="89" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="98" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="99" Attno="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="103" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                    <dxl:Column ColId="104" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="105" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="106" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="107" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="108" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                    <dxl:Column ColId="109" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                  </dxl:Columns>
+                                                </dxl:TableDescriptor>
+                                              </dxl:TableScan>
+                                            </dxl:HashJoin>
+                                            <dxl:TableScan>
+                                              <dxl:Properties>
+                                                <dxl:Cost StartupCost="0" TotalCost="431.137578" Rows="2984.979105" Width="12"/>
+                                              </dxl:Properties>
+                                              <dxl:ProjList>
+                                                <dxl:ProjElem ColId="64" Alias="l_orderkey">
+                                                  <dxl:Ident ColId="64" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                </dxl:ProjElem>
+                                                <dxl:ProjElem ColId="66" Alias="l_suppkey">
+                                                  <dxl:Ident ColId="66" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                                                 </dxl:ProjElem>
                                               </dxl:ProjList>
                                               <dxl:Filter>
-                                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.1097.1.0">
-                                                  <dxl:Ident ColId="99" ColName="l_receiptdate" TypeMdid="0.1082.1.0"/>
-                                                  <dxl:Ident ColId="98" ColName="l_commitdate" TypeMdid="0.1082.1.0"/>
-                                                </dxl:Comparison>
+                                                <dxl:Not>
+                                                  <dxl:IsNull>
+                                                    <dxl:Ident ColId="64" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
+                                                  </dxl:IsNull>
+                                                </dxl:Not>
                                               </dxl:Filter>
                                               <dxl:TableDescriptor Mdid="0.31256.1.0" TableName="heap_lineitem">
                                                 <dxl:Columns>
-                                                  <dxl:Column ColId="87" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                                                  <dxl:Column ColId="89" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="98" Attno="12" ColName="l_commitdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="99" Attno="13" ColName="l_receiptdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="103" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                                  <dxl:Column ColId="104" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="105" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="106" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="107" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="108" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                                  <dxl:Column ColId="109" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="64" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
+                                                  <dxl:Column ColId="66" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                                  <dxl:Column ColId="81" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="82" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="83" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="84" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="85" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                                  <dxl:Column ColId="86" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                                                 </dxl:Columns>
                                               </dxl:TableDescriptor>
                                             </dxl:TableScan>
                                           </dxl:HashJoin>
-                                          <dxl:TableScan>
-                                            <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="431.137578" Rows="2984.979105" Width="12"/>
-                                            </dxl:Properties>
-                                            <dxl:ProjList>
-                                              <dxl:ProjElem ColId="64" Alias="l_orderkey">
-                                                <dxl:Ident ColId="64" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                              </dxl:ProjElem>
-                                              <dxl:ProjElem ColId="66" Alias="l_suppkey">
-                                                <dxl:Ident ColId="66" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
-                                              </dxl:ProjElem>
-                                            </dxl:ProjList>
-                                            <dxl:Filter>
-                                              <dxl:Not>
-                                                <dxl:IsNull>
-                                                  <dxl:Ident ColId="64" ColName="l_orderkey" TypeMdid="0.20.1.0"/>
-                                                </dxl:IsNull>
-                                              </dxl:Not>
-                                            </dxl:Filter>
-                                            <dxl:TableDescriptor Mdid="0.31256.1.0" TableName="heap_lineitem">
-                                              <dxl:Columns>
-                                                <dxl:Column ColId="64" Attno="1" ColName="l_orderkey" TypeMdid="0.20.1.0" ColWidth="8"/>
-                                                <dxl:Column ColId="66" Attno="3" ColName="l_suppkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                                <dxl:Column ColId="81" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                <dxl:Column ColId="82" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                <dxl:Column ColId="83" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                <dxl:Column ColId="84" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                <dxl:Column ColId="85" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                                <dxl:Column ColId="86" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                              </dxl:Columns>
-                                            </dxl:TableDescriptor>
-                                          </dxl:TableScan>
-                                        </dxl:HashJoin>
-                                      </dxl:Result>
-                                    </dxl:BroadcastMotion>
-                                  </dxl:HashJoin>
-                                </dxl:BroadcastMotion>
-                              </dxl:HashJoin>
-                              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.001182" Rows="3.000000" Width="4"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="30" Alias="n_nationkey">
-                                    <dxl:Ident ColId="30" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:SortingColumnList/>
-                                <dxl:TableScan>
+                                        </dxl:Result>
+                                      </dxl:BroadcastMotion>
+                                    </dxl:HashJoin>
+                                  </dxl:BroadcastMotion>
+                                </dxl:HashJoin>
+                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000967" Rows="1.000000" Width="4"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.001182" Rows="3.000000" Width="4"/>
                                   </dxl:Properties>
                                   <dxl:ProjList>
                                     <dxl:ProjElem ColId="30" Alias="n_nationkey">
                                       <dxl:Ident ColId="30" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
                                     </dxl:ProjElem>
                                   </dxl:ProjList>
-                                  <dxl:Filter>
-                                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
-                                      <dxl:Ident ColId="31" ColName="n_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
-                                      <dxl:ConstValue TypeMdid="0.1042.1.0" IsNull="false" Value="AAAADk1PWkFNQklRVUU=" LintValue="217359228"/>
-                                    </dxl:Comparison>
-                                  </dxl:Filter>
-                                  <dxl:TableDescriptor Mdid="0.31259.1.0" TableName="heap_nation">
-                                    <dxl:Columns>
-                                      <dxl:Column ColId="30" Attno="1" ColName="n_nationkey" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="31" Attno="2" ColName="n_name" TypeMdid="0.1042.1.0" TypeModifier="29" ColWidth="26"/>
-                                      <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                      <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                      <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    </dxl:Columns>
-                                  </dxl:TableDescriptor>
-                                </dxl:TableScan>
-                              </dxl:BroadcastMotion>
-                            </dxl:HashJoin>
-                          </dxl:Result>
-                        </dxl:Sort>
-                      </dxl:Aggregate>
-                    </dxl:RedistributeMotion>
-                  </dxl:Sort>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000967" Rows="1.000000" Width="4"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="30" Alias="n_nationkey">
+                                        <dxl:Ident ColId="30" ColName="n_nationkey" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter>
+                                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+                                        <dxl:Ident ColId="31" ColName="n_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
+                                        <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAADk1PWkFNQklRVUU=" LintValue="217359228"/>
+                                      </dxl:Comparison>
+                                    </dxl:Filter>
+                                    <dxl:TableDescriptor Mdid="0.31259.1.0" TableName="heap_nation">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="30" Attno="1" ColName="n_nationkey" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="31" Attno="2" ColName="n_name" TypeMdid="0.1042.1.0" TypeModifier="29" ColWidth="26"/>
+                                        <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:BroadcastMotion>
+                              </dxl:HashJoin>
+                            </dxl:Result>
+                          </dxl:Sort>
+                        </dxl:Aggregate>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
                 </dxl:Aggregate>
-              </dxl:Aggregate>
-            </dxl:Sort>
-          </dxl:Result>
+              </dxl:Sort>
+            </dxl:Result>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="100"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
         </dxl:GatherMotion>
         <dxl:LimitCount>
           <dxl:ConstValue TypeMdid="0.20.1.0" Value="100"/>

--- a/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -457,7 +457,7 @@ SQL:
     <dxl:Plan Id="0" SpaceSize="3512">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.103418" Rows="10.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.103310" Rows="10.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -472,7 +472,7 @@ SQL:
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.103218" Rows="10.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.103110" Rows="10.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -491,7 +491,7 @@ SQL:
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.102320" Rows="10.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.102220" Rows="10.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">

--- a/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
+++ b/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
@@ -705,7 +705,7 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
     <dxl:Plan Id="0" SpaceSize="6716">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.006784" Rows="40.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.006783" Rows="40.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -795,7 +795,7 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.001973" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.001972" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
@@ -859,25 +859,37 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
                               <dxl:ProjList/>
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
-                              <dxl:TableScan>
+                              <dxl:Limit>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.155655.1.0" TableName="jank">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="17" Attno="1" ColName="d" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="1"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList/>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.155655.1.0" TableName="jank">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="17" Attno="1" ColName="d" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                                <dxl:LimitCount>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                </dxl:LimitCount>
+                                <dxl:LimitOffset>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:LimitOffset>
+                              </dxl:Limit>
                             </dxl:GatherMotion>
                             <dxl:LimitCount>
                               <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -1199,7 +1199,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
     <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000139" Rows="1.000000" Width="17"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000138" Rows="1.000000" Width="17"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="col1">
@@ -1217,7 +1217,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000122" Rows="1.000000" Width="17"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000121" Rows="1.000000" Width="17"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="col1">
@@ -1238,7 +1238,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
             <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
             <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
           </dxl:SortingColumnList>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:Limit>
             <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
             </dxl:Properties>
@@ -1256,14 +1256,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
                 <dxl:Ident ColId="3" ColName="col4" TypeMdid="0.16.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:Sequence>
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
               </dxl:Properties>
@@ -1281,31 +1274,14 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
                   <dxl:Ident ColId="3" ColName="col4" TypeMdid="0.16.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:PartitionSelector RelationMdid="0.8685596.1.1" PartitionLevels="1" ScanId="1">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:PartEqFilters>
-                  <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
-                </dxl:PartEqFilters>
-                <dxl:PartFilters>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:PartFilters>
-                <dxl:ResidualFilter>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                </dxl:ResidualFilter>
-                <dxl:PropagationExpression>
-                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                </dxl:PropagationExpression>
-                <dxl:PrintableFilter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                    <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.1700.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
-                  </dxl:Comparison>
-                </dxl:PrintableFilter>
-              </dxl:PartitionSelector>
-              <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:Filter/>
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.1754.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:Sequence>
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
                 </dxl:Properties>
@@ -1323,30 +1299,79 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
                     <dxl:Ident ColId="3" ColName="col4" TypeMdid="0.16.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                    <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.1700.1.0"/>
+                <dxl:PartitionSelector RelationMdid="0.8685596.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
                     <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="0.8685596.1.1" TableName="pt_lt_tab">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="col1" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="col2" TypeMdid="0.1700.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="col3" TypeMdid="0.25.1.0"/>
-                    <dxl:Column ColId="3" Attno="4" ColName="col4" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:DynamicTableScan>
-            </dxl:Sequence>
-          </dxl:Sort>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                      <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.1700.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
+                    </dxl:Comparison>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000045" Rows="1.000000" Width="17"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="col1">
+                      <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="col2">
+                      <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.1700.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="col3">
+                      <dxl:Ident ColId="2" ColName="col3" TypeMdid="0.25.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="3" Alias="col4">
+                      <dxl:Ident ColId="3" ColName="col4" TypeMdid="0.16.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                      <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.1700.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACgAAAAAPAA==" DoubleValue="15.000000"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="0.8685596.1.1" TableName="pt_lt_tab">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="col1" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="col2" TypeMdid="0.1700.1.0"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="col3" TypeMdid="0.25.1.0"/>
+                      <dxl:Column ColId="3" Attno="4" ColName="col4" TypeMdid="0.16.1.0"/>
+                      <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Sort>
+            <dxl:LimitCount>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>
+            </dxl:LimitCount>
+            <dxl:LimitOffset>
+              <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+            </dxl:LimitOffset>
+          </dxl:Limit>
         </dxl:GatherMotion>
         <dxl:LimitCount>
           <dxl:ConstValue TypeMdid="0.20.1.0" Value="5"/>

--- a/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
+++ b/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
@@ -547,12 +547,12 @@ explain select * from t1 where a = 1 and b in (select b from t2);
               <dxl:SortingColumnList/>
               <dxl:Limit>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000065" Rows="1.000000" Width="1"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="1"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="1"/>
                   </dxl:Properties>
                   <dxl:ProjList/>
                   <dxl:Filter/>

--- a/data/dxl/minidump/Remove-Distinct-From-Subquery.mdp
+++ b/data/dxl/minidump/Remove-Distinct-From-Subquery.mdp
@@ -617,25 +617,37 @@ select * from bar where c not in (select distinct a from foo);
                     <dxl:ProjList/>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
-                    <dxl:TableScan>
+                    <dxl:Limit>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList/>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="0.188698.1.0" TableName="foo">
-                        <dxl:Columns>
-                          <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList/>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="0.188698.1.0" TableName="foo">
+                          <dxl:Columns>
+                            <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                      <dxl:LimitCount>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                      </dxl:LimitCount>
+                      <dxl:LimitOffset>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                      </dxl:LimitOffset>
+                    </dxl:Limit>
                   </dxl:GatherMotion>
                   <dxl:LimitCount>
                     <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/data/dxl/minidump/ScalarSubqueryCountStar.mdp
+++ b/data/dxl/minidump/ScalarSubqueryCountStar.mdp
@@ -380,7 +380,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000072" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000071" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="18" Alias="count">
@@ -389,7 +389,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                     </dxl:ProjList>
                     <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="18" Alias="count">
@@ -398,7 +398,7 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
-                      <dxl:Result>
+                      <dxl:Limit>
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
@@ -407,42 +407,36 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                             <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Result>
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
                           </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="9"/>
-                          </dxl:GroupingColumns>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="18" Alias="count">
-                              <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="9" Alias="c">
-                              <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="18" ColName="count" TypeMdid="0.20.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:OneTimeFilter/>
+                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="8"/>
                             </dxl:Properties>
+                            <dxl:GroupingColumns>
+                              <dxl:GroupingColumn ColId="9"/>
+                            </dxl:GroupingColumns>
                             <dxl:ProjList>
+                              <dxl:ProjElem ColId="18" Alias="count">
+                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="9" Alias="c">
                                 <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:LimitCount/>
-                            <dxl:LimitOffset/>
-                            <dxl:TableScan>
+                            <dxl:Sort SortDiscardDuplicates="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="9" Alias="c">
@@ -450,22 +444,44 @@ EXPLAIN SELECT (SELECT COUNT(*) FROM bar GROUP BY c LIMIT 1) FROM foo;
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="0.922002.1.1" TableName="bar">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                  <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                  <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                  <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:Sort>
-                        </dxl:Aggregate>
-                      </dxl:Result>
+                              <dxl:SortingColumnList>
+                                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                              </dxl:SortingColumnList>
+                              <dxl:LimitCount/>
+                              <dxl:LimitOffset/>
+                              <dxl:TableScan>
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="c">
+                                    <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:TableDescriptor Mdid="0.922002.1.1" TableName="bar">
+                                  <dxl:Columns>
+                                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                  </dxl:Columns>
+                                </dxl:TableDescriptor>
+                              </dxl:TableScan>
+                            </dxl:Sort>
+                          </dxl:Aggregate>
+                        </dxl:Result>
+                        <dxl:LimitCount>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                        </dxl:LimitCount>
+                        <dxl:LimitOffset>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:LimitOffset>
+                      </dxl:Limit>
                     </dxl:GatherMotion>
                     <dxl:LimitCount>
                       <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
+++ b/data/dxl/minidump/ScalarSubqueryCountStarInJoin.mdp
@@ -563,47 +563,37 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                         <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
-                        <dxl:Result>
+                        <dxl:Limit>
                           <dxl:Properties>
                             <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                          <dxl:Result>
                             <dxl:Properties>
                               <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
-                            <dxl:GroupingColumns>
-                              <dxl:GroupingColumn ColId="9"/>
-                            </dxl:GroupingColumns>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="18" Alias="count">
-                                <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="9" Alias="c">
-                                <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
+                            <dxl:ProjList/>
                             <dxl:Filter/>
-                            <dxl:Sort SortDiscardDuplicates="false">
+                            <dxl:OneTimeFilter/>
+                            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
+                              <dxl:GroupingColumns>
+                                <dxl:GroupingColumn ColId="9"/>
+                              </dxl:GroupingColumns>
                               <dxl:ProjList>
+                                <dxl:ProjElem ColId="18" Alias="count">
+                                  <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal"/>
+                                </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="c">
                                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList>
-                                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              </dxl:SortingColumnList>
-                              <dxl:LimitCount/>
-                              <dxl:LimitOffset/>
-                              <dxl:TableScan>
+                              <dxl:Sort SortDiscardDuplicates="false">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="9" Alias="c">
@@ -611,22 +601,44 @@ SELECT (SELECT jazz.count FROM (SELECT count(*) FROM bar GROUP BY c LIMIT 1) AS 
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="0.16423.1.1" TableName="bar">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Sort>
-                          </dxl:Aggregate>
-                        </dxl:Result>
+                                <dxl:SortingColumnList>
+                                  <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                                </dxl:SortingColumnList>
+                                <dxl:LimitCount/>
+                                <dxl:LimitOffset/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="9" Alias="c">
+                                      <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="0.16423.1.1" TableName="bar">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="9" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:Sort>
+                            </dxl:Aggregate>
+                          </dxl:Result>
+                          <dxl:LimitCount>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                          </dxl:LimitCount>
+                          <dxl:LimitOffset>
+                            <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                          </dxl:LimitOffset>
+                        </dxl:Limit>
                       </dxl:GatherMotion>
                       <dxl:LimitCount>
                         <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>

--- a/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
+++ b/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
@@ -804,7 +804,7 @@ explain select * from foo where foo.a = 10 and exists (select * from bar);
                   <dxl:SortingColumnList/>
                   <dxl:Limit>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.755405" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.755404" Rows="1.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList/>
                     <dxl:TableScan>

--- a/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -535,7 +535,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
     <dxl:Plan Id="0" SpaceSize="3040">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.005263" Rows="10.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.005233" Rows="10.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -547,7 +547,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.005183" Rows="10.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.005153" Rows="10.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -564,7 +564,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.004885" Rows="10.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.004858" Rows="10.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -687,12 +687,12 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
                       <dxl:SortingColumnList/>
                       <dxl:Limit>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000157" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000156" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
                         <dxl:ProjList/>
                         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000156" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000155" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>

--- a/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2465,7 +2465,7 @@
     <dxl:Plan Id="0" SpaceSize="1734">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356710917.776380" Rows="10002.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -2482,7 +2482,7 @@
         <dxl:SortingColumnList/>
         <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356710917.717692" Rows="10002.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356710917.329090" Rows="10002.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -2510,7 +2510,7 @@
                   </dxl:ParamList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324049.882899" Rows="3.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324049.882520" Rows="3.000000" Width="1"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="39" Alias="ColRef_0039">
@@ -2524,12 +2524,12 @@
                               <dxl:Ident ColId="38" ColName="ColRef_0038" TypeMdid="0.20.1.0"/>
                               <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                             </dxl:Comparison>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                             <dxl:If TypeMdid="0.16.1.0">
                               <dxl:IsNull>
                                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:IsNull>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                               <dxl:If TypeMdid="0.16.1.0">
                                 <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
                                   <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
@@ -2547,7 +2547,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324049.882898" Rows="3.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324049.882519" Rows="3.000000" Width="16"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns/>
                       <dxl:ProjList>
@@ -2565,7 +2565,7 @@
                       <dxl:Filter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324049.879311" Rows="3003.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324049.878931" Rows="3003.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="35" Alias="ColRef_0035">
@@ -2592,7 +2592,7 @@
                         <dxl:OneTimeFilter/>
                         <dxl:Materialize Eager="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324049.871303" Rows="3003.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324049.870923" Rows="3003.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="12" Alias="c">
@@ -2602,7 +2602,7 @@
                           <dxl:Filter/>
                           <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324049.867299" Rows="3003.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324049.866919" Rows="3003.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="12" Alias="c">
@@ -2613,7 +2613,7 @@
                             <dxl:SortingColumnList/>
                             <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324049.795627" Rows="1001.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="1324049.795248" Rows="1001.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="12" Alias="c">
@@ -2675,7 +2675,7 @@
                                       <dxl:SortingColumnList/>
                                       <dxl:Limit>
                                         <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="431.000841" Rows="1.000000" Width="1"/>
+                                          <dxl:Cost StartupCost="0" TotalCost="431.000840" Rows="1.000000" Width="1"/>
                                         </dxl:Properties>
                                         <dxl:ProjList/>
                                         <dxl:TableScan>

--- a/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
+++ b/libgpdbcost/include/gpdbcost/CCostModelParamsGPDB.h
@@ -103,7 +103,7 @@ namespace gpopt
 				EcpBitmapNDVThreshold, // bitmap NDV threshold
 				EcpBitmapScanRebindCost, // cost of rebind operation in a bitmap scan
 				EcpPenalizeHJSkewUpperLimit, // upper limit for penalizing a skewed hashjoin operator
-
+				EcpLocalLimitReward, // cost we save from having a limit under a gather
 				EcpSentinel
 			};
 
@@ -323,6 +323,10 @@ namespace gpopt
 			// upper limit for penalizing a skewed hash operator
 			static
 			const CDouble DPenalizeHJSkewUpperLimit;
+
+			// default value of rewarding a local limit under a gather motion
+			static
+			const CDouble DLocalLimitReward;
 
 			// private copy ctor
 			CCostModelParamsGPDB(CCostModelParamsGPDB &);

--- a/libgpdbcost/src/CCostModelParamsGPDB.cpp
+++ b/libgpdbcost/src/CCostModelParamsGPDB.cpp
@@ -171,6 +171,9 @@ const CDouble CCostModelParamsGPDB::DBitmapScanRebindCost(0.06);
 // see CCostModelGPDB::CostHashJoin() for why this is needed
 const CDouble CCostModelParamsGPDB::DPenalizeHJSkewUpperLimit(10.0);
 
+// see CCostModelGPDB::CostMotion() for why is it needed
+const CDouble CCostModelParamsGPDB::DLocalLimitReward(0.99);
+
 #define GPOPT_COSTPARAM_NAME_MAX_LENGTH		80
 
 // parameter names in the same order of param enumeration
@@ -303,6 +306,7 @@ CCostModelParamsGPDB::CCostModelParamsGPDB
 	m_rgpcp[EcpBitmapNDVThreshold] = GPOS_NEW(mp) SCostParam(EcpBitmapNDVThreshold, DBitmapNDVThreshold, DBitmapNDVThreshold - 1.0, DBitmapNDVThreshold + 1.0);
 	m_rgpcp[EcpBitmapScanRebindCost] = GPOS_NEW(mp) SCostParam(EcpBitmapScanRebindCost, DBitmapScanRebindCost, DBitmapScanRebindCost - 1.0, DBitmapScanRebindCost + 1.0);
 	m_rgpcp[EcpPenalizeHJSkewUpperLimit] = GPOS_NEW(mp) SCostParam(EcpPenalizeHJSkewUpperLimit, DPenalizeHJSkewUpperLimit, DPenalizeHJSkewUpperLimit - 1.0, DPenalizeHJSkewUpperLimit + 1.0);
+	m_rgpcp[EcpLocalLimitReward] = GPOS_NEW(mp) SCostParam(EcpLocalLimitReward, DLocalLimitReward, DLocalLimitReward - 0.0001, DLocalLimitReward + 0.0001);
 }
 
 

--- a/libnaucrates/src/statistics/CStatistics.cpp
+++ b/libnaucrates/src/statistics/CStatistics.cpp
@@ -42,7 +42,7 @@ using namespace gpopt;
 const CDouble CStatistics::DefaultRelationRows(1000.0);
 
 // epsilon to be used for various computations
-const CDouble CStatistics::Epsilon(0.001);
+const CDouble CStatistics::Epsilon(0.00001);
 
 // minimum number of rows in relation
 const CDouble CStatistics::MinRows(1.0);


### PR DESCRIPTION
This PR has two commits - WIP is because we are still running the test pipelines, code is largely ready to review

- Given our optimization framework produces two alternatives like below :

1) Limit (global)
    Gather
	Limit (local)
	  <Expression Tree>

2) Limit (global)
     Gather
	<Expression Tree>

We would like to pick the case 1 always. It is possible that our cardinality estimation severely
underestimated the cardinality and we can lose the benefit of having a local limit under gather.

- 0.001 was too high a value for Epsilon. In billion+ rows table with highly selective predicate,
we ended up severely under estimating the cardinality of predicate.

Co-authored-by: Sambitesh Dash sdash@pivotal.io
Co-authored-by: Chris Hajas chajas@pivotal.io
