### PR TITLE
WIP: Add new nth-root method to calculate join damping factor

### DIFF
--- a/data/dxl/minidump/MultiplePredJoinCardinality.mdp
+++ b/data/dxl/minidump/MultiplePredJoinCardinality.mdp
@@ -1,0 +1,4828 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+    <dxl:Comment><![CDATA[
+Objective: The join cardinality estimate for multiple uncorrelated columns should be accurate.
+The query returns 1-5 rows when run, and we should estimate 50-100 rows or lower when
+optimizer_damping_factor_join is set to 0. When `optimizer_damping_factor_join` is set
+to .01 (the default), we estimate ~1500 rows returned.
+
+create table t1 (a int, b int) distributed by (a);
+create table t2 (a int, b int) distributed by (a);
+insert into t1 select floor(random()*1000),floor(random()*1000) from generate_series(1,1000)i;
+insert into t2 select floor(random()*1000),floor(random()*1000) from generate_series(1,1000)i;
+analyze t1;
+analyze t2;
+explain select * from foo, bar where foo.a=bar.a and foo.b=bar.b;
+
+                                   QUERY PLAN
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.27 rows=62 width=16)
+   ->  Hash Join  (cost=0.00..862.27 rows=21 width=16)
+         Hash Cond: foo.a = bar.a AND foo.b = bar.b
+         ->  Table Scan on foo  (cost=0.00..431.01 rows=334 width=8)
+         ->  Hash  (cost=431.01..431.01 rows=334 width=8)
+               ->  Table Scan on bar  (cost=0.00..431.01 rows=334 width=8)
+ Settings:  optimizer=on; optimizer_damping_factor_join=0
+ Optimizer status: PQO version 3.86.0
+(8 rows)
+	]]>
+    </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="7000" Rank="7001"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102113,102120,102146,102147,103001,103014,103015,103022,103027,103029,104003,104004,104005,104006,105000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="false" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="false" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.5228913.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000387" DistinctValues="0.129444">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003872" DistinctValues="1.294444">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000774" DistinctValues="0.258889">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001162" DistinctValues="0.388333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000774" DistinctValues="0.258889">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000290" DistinctValues="0.041667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.125000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.125000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002033" DistinctValues="0.291667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002033" DistinctValues="0.291667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.125000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="43"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000804" DistinctValues="0.115385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="43"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001072" DistinctValues="0.153846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001340" DistinctValues="0.192308">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000804" DistinctValues="0.115385">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.076923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000804" DistinctValues="0.115385">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000348" DistinctValues="0.066500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001742" DistinctValues="0.332500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002091" DistinctValues="0.399000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002788" DistinctValues="0.532000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000498" DistinctValues="0.095000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000996" DistinctValues="0.190000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003983" DistinctValues="0.760000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001494" DistinctValues="0.285000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="111"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000536" DistinctValues="0.256154">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="111"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="112"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="112"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="112"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003217" DistinctValues="1.536923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="112"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003217" DistinctValues="1.536923">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="124"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="125"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000581" DistinctValues="0.360833">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004066" DistinctValues="2.525833">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="138"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="138"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="138"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.443333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="142"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.574545">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="142"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003168" DistinctValues="1.968182">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="151"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="151"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="151"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001267" DistinctValues="0.787273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="151"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001901" DistinctValues="1.453636">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005069" DistinctValues="3.876364">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="185"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.110000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="185"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.110000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="195"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="195"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001394" DistinctValues="0.666000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="195"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="198"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="198"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000929" DistinctValues="0.444000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="198"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001608" DistinctValues="0.999231">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="203"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="203"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="203"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005362" DistinctValues="3.330769">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="214"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005898" DistinctValues="4.510000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="225"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="225"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="225"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001072" DistinctValues="0.820000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="225"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="234"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001267" DistinctValues="0.787273">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="234"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003168" DistinctValues="1.968182">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="241"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="241"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="241"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.574545">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="241"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="245"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="245"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="252"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="252"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="258"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="277"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="277"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="286"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.938182">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="286"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004435" DistinctValues="3.391818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003485" DistinctValues="2.665000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="303"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="303"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="303"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003485" DistinctValues="2.665000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="303"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="309"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002145" DistinctValues="1.332308">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="309"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="313"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="313"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001072" DistinctValues="0.666154">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="313"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="315"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003753" DistinctValues="2.331538">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="322"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004182" DistinctValues="3.198000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="335"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="335"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="335"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002788" DistinctValues="2.132000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="335"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="339"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="5.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="339"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="344"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="344"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="344"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="345"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="354"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="354"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="363"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="363"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="369"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="369"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="369"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="371"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003802" DistinctValues="2.907273">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="371"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="377"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="377"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003168" DistinctValues="2.422727">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="377"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001162" DistinctValues="0.555000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="382"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="384"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="384"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="384"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.110000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="384"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003485" DistinctValues="1.665000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="388"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="394"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="394"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="394"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.541250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="395"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006099" DistinctValues="3.788750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="397"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="404"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000465" DistinctValues="0.222000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="404"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="406"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="406"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003253" DistinctValues="1.554000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="406"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="413"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="413"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003253" DistinctValues="1.554000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="413"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000697" DistinctValues="0.333000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="421"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="421"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004879" DistinctValues="2.331000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="421"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="428"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="428"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001394" DistinctValues="0.666000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="428"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000634" DistinctValues="0.484545">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="432"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="432"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="432"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006336" DistinctValues="4.845455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="432"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="442"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="442"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="448"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="448"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000871" DistinctValues="0.666250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="452"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="453"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="453"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006099" DistinctValues="4.663750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="453"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="466"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.938182">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004435" DistinctValues="3.391818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="477"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="477"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="483"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="483"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="483"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="483"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000996" DistinctValues="0.761429">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="492"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005974" DistinctValues="4.568571">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="499"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000581" DistinctValues="0.360833">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.082500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004647" DistinctValues="2.886667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="511"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="511"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="522"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004356" DistinctValues="3.331250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="535"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="535"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="535"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002614" DistinctValues="1.998750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="535"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="538"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001394" DistinctValues="1.066000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="538"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="541"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="541"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="541"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005576" DistinctValues="4.264000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="541"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="553"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003983" DistinctValues="3.045714">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="553"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="557"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="557"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="557"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002987" DistinctValues="2.284286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="557"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002535" DistinctValues="1.938182">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="567"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="567"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="567"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004435" DistinctValues="3.391818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="574"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="574"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="581"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002788" DistinctValues="1.332000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="581"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="585"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="585"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="585"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="586"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="586"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004182" DistinctValues="1.998000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="593"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="593"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="603"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="603"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002614" DistinctValues="1.998750">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="613"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="613"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="613"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004356" DistinctValues="3.331250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="613"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="618"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="618"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="628"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="634"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="634"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001901" DistinctValues="1.453636">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="683"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005069" DistinctValues="3.876364">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005663" DistinctValues="4.330625">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="704"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001307" DistinctValues="0.999375">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="704"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="707"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="719"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="719"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="738"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="744"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="744"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002323" DistinctValues="1.776667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004647" DistinctValues="3.553333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="762"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="762"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="771"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005421" DistinctValues="4.145556">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="771"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001549" DistinctValues="1.184444">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002788" DistinctValues="1.732000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="792"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="792"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004182" DistinctValues="2.598000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="792"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001394" DistinctValues="1.066000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="799"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="801"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="801"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="801"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005576" DistinctValues="4.264000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="823"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005227" DistinctValues="3.997500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="823"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="832"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="832"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="832"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001742" DistinctValues="1.332500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="835"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="835"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="846"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="846"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="856"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="856"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="868"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004182" DistinctValues="3.198000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="868"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002788" DistinctValues="2.132000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000634" DistinctValues="0.211818">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="879"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="879"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002535" DistinctValues="0.847273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="879"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="883"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001901" DistinctValues="0.635455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="883"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="886"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="886"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="886"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="887"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001901" DistinctValues="0.635455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005069" DistinctValues="3.876364">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="904"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="904"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="904"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001901" DistinctValues="1.453636">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="904"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="907"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="907"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="915"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="925"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="925"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="935"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000774" DistinctValues="0.481111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="935"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="936"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="936"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="937"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006196" DistinctValues="3.848889">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="945"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001162" DistinctValues="0.888333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="945"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="946"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="946"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="946"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005808" DistinctValues="4.441667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="946"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="951"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="951"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="958"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="958"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="974"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="974"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="984"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="994"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006970" DistinctValues="6.330000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="994"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.5228913.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004487" DistinctValues="2.815714">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002493" DistinctValues="1.564286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001309" DistinctValues="0.258750">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002181" DistinctValues="0.431250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000872" DistinctValues="0.172500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001309" DistinctValues="0.258750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001309" DistinctValues="0.258750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.336923">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001611" DistinctValues="1.010769">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004832" DistinctValues="3.032308">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001904" DistinctValues="0.649091">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003173" DistinctValues="1.081818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001904" DistinctValues="0.649091">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.260000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.520000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.520000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004295" DistinctValues="2.080000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000776" DistinctValues="0.375556">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006204" DistinctValues="3.004444">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005906" DistinctValues="3.706154">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="87"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.673846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="101"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000332" DistinctValues="0.047619">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="102"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001330" DistinctValues="0.190476">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="106"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000665" DistinctValues="0.095238">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002991" DistinctValues="0.428571">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="109"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001662" DistinctValues="0.238095">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="123"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="123"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="123"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005119" DistinctValues="3.212000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="135"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="135"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="135"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001861" DistinctValues="1.168000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="136"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="147"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="154"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="154"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="172"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="172"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="181"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="181"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="191"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="191"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="196"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003723" DistinctValues="2.869333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="196"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003257" DistinctValues="2.510667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="211"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004295" DistinctValues="2.695385">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="219"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="219"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001074" DistinctValues="0.673846">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="219"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001611" DistinctValues="1.010769">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="224"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="224"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="231"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="231"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="237"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="247"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001662" DistinctValues="1.042857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="247"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="252"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="252"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="252"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003656" DistinctValues="2.294286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="252"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="263"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="263"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001662" DistinctValues="1.042857">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="278"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="283"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="283"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="294"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="294"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="307"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="307"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="315"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002792" DistinctValues="2.152000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="315"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="321"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004188" DistinctValues="3.228000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002538" DistinctValues="1.592727">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004442" DistinctValues="2.787273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="341"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="341"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="341"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="342"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="350"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000997" DistinctValues="0.625714">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="350"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="359"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="359"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="359"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002493" DistinctValues="1.564286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="359"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="378"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="378"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="387"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="387"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="397"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="398"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="415"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="415"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="419"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000499" DistinctValues="0.312857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="419"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005484" DistinctValues="3.441429">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000997" DistinctValues="0.625714">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="433"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="433"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.751111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="441"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="443"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="443"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="443"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.751111">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="443"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="445"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="445"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="445"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.751111">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="445"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="447"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002327" DistinctValues="1.126667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000698" DistinctValues="0.438000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004188" DistinctValues="2.628000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.314000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="465"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="465"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002792" DistinctValues="1.352000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="478"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="478"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000698" DistinctValues="0.338000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="478"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="496"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="496"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="496"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="502"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="502"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="508"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="508"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="508"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="508"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005817" DistinctValues="4.483333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001163" DistinctValues="0.896667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="522"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="522"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="528"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="528"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="536"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003490" DistinctValues="1.690000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="536"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="542"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="542"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="543"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="543"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="543"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="0.845000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="549"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001163" DistinctValues="0.896667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="549"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005817" DistinctValues="4.483333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="567"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="569"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="575"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="584"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="584"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="591"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="596"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005235" DistinctValues="3.285000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="596"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="605"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="605"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="606"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="606"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.095000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="606"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.614000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="612"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="612"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="612"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004886" DistinctValues="3.766000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="612"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="619"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="619"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="628"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="628"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000537" DistinctValues="0.260000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="629"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="631"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="631"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002148" DistinctValues="1.040000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="635"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="635"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="635"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004295" DistinctValues="2.080000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="635"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="643"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="643"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="648"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="648"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="655"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="655"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="655"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="661"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="661"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001396" DistinctValues="0.876000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="671"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="671"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000931" DistinctValues="0.584000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="671"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="673"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="673"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="673"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004653" DistinctValues="2.920000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="673"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="688"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001396" DistinctValues="0.876000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="688"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="689"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="689"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002792" DistinctValues="1.752000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="689"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002792" DistinctValues="1.752000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="693"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="693"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="699"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005235" DistinctValues="4.035000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="699"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="705"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="705"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="705"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001745" DistinctValues="1.345000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="705"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="707"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="707"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001396" DistinctValues="0.876000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="716"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="716"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003490" DistinctValues="2.190000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="716"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="721"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="721"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="721"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.314000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="721"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="724"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000776" DistinctValues="0.486667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="724"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004653" DistinctValues="2.920000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="731"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="731"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="731"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001551" DistinctValues="0.973333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="731"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="733"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="749"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003989" DistinctValues="3.074286">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="749"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002991" DistinctValues="2.305714">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="763"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="763"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="773"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="773"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004886" DistinctValues="3.766000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="793"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="793"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002094" DistinctValues="1.614000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="793"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="796"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="796"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002939" DistinctValues="2.265263">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004041" DistinctValues="3.114737">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004653" DistinctValues="2.920000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="829"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002327" DistinctValues="1.460000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="839"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000872" DistinctValues="0.672500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="839"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006107" DistinctValues="4.707500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="847"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003807" DistinctValues="2.934545">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="847"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003173" DistinctValues="2.445455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="5.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="883"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="883"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="884"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="892"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="892"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="899"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000465" DistinctValues="0.358667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="899"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006515" DistinctValues="5.021333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="914"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002617" DistinctValues="2.017500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="914"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="917"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="917"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="917"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004362" DistinctValues="3.362500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="917"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002181" DistinctValues="1.368750">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="931"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="931"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="931"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003926" DistinctValues="2.463750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="931"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000872" DistinctValues="0.547500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001994" DistinctValues="1.537143">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="942"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="944"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="944"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004986" DistinctValues="3.842857">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="944"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="949"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="949"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="954"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004986" DistinctValues="3.842857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="954"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="959"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001994" DistinctValues="1.537143">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="961"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="0.206957">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="961"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="963"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="963"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="0.206957">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="963"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004249" DistinctValues="1.448696">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="979"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000607" DistinctValues="0.206957">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="979"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="981"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000910" DistinctValues="0.310435">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="984"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="984"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="992"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006980" DistinctValues="6.380000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="992"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="998"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="998"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.5228916.1.0" Name="bar" Rows="1000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.5228916.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.5228913.1.0" Name="foo" Rows="1000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.5228913.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.5228916.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.000391" DistinctValues="0.245000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004296" DistinctValues="2.695000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.470000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002460" DistinctValues="0.493500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000703" DistinctValues="0.141000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001054" DistinctValues="0.211500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="32"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002812" DistinctValues="0.564000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="32"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002460" DistinctValues="0.843500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001054" DistinctValues="0.361500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001054" DistinctValues="0.361500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="54"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002460" DistinctValues="0.843500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="54"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003835" DistinctValues="2.405455">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003195" DistinctValues="2.004545">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002109" DistinctValues="1.323000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001406" DistinctValues="0.882000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.205000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.117500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="0.352500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.235000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.125000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002636" DistinctValues="0.375000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="99"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="0.250000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="111"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="111"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.125000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="111"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="113"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="113"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="114"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="114"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.125000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="114"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="116"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="116"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.128182">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="117"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="119"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="119"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="119"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.128182">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="121"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="121"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="121"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003835" DistinctValues="0.769091">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="133"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="133"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="133"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000959" DistinctValues="0.192273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="133"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="136"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="136"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000959" DistinctValues="0.192273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="136"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="139"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="139"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="139"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000937" DistinctValues="0.321333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="152"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="152"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="152"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001406" DistinctValues="0.482000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="152"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="155"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="155"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003281" DistinctValues="1.124667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="155"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="162"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001406" DistinctValues="0.482000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="166"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005113" DistinctValues="3.934545">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="166"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001917" DistinctValues="1.475455">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000370" DistinctValues="0.126842">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="178"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="178"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="178"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003330" DistinctValues="1.141579">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="178"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="187"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="187"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="187"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="188"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="188"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001850" DistinctValues="0.634211">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="188"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="193"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="193"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001480" DistinctValues="0.507368">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="193"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="197"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="197"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="204"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005272" DistinctValues="3.307500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="212"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="212"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002511" DistinctValues="1.217857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="213"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="218"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="218"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001506" DistinctValues="0.730714">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="218"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="221"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.487143">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="221"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="223"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="223"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002009" DistinctValues="0.974286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="223"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="237"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="254"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="5.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="254"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="262"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="262"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="263"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="276"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="276"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="282"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005468" DistinctValues="4.207778">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="282"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="289"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="289"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="289"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001562" DistinctValues="1.202222">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="289"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="291"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="291"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="303"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004474" DistinctValues="3.442727">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="303"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002556" DistinctValues="1.967273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="314"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="314"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.284167">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="321"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="322"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="322"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002929" DistinctValues="1.420833">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="322"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="1.705000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="327"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="333"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="333"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001850" DistinctValues="0.897368">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="348"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="348"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="348"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001480" DistinctValues="0.717895">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="348"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002960" DistinctValues="1.435789">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000740" DistinctValues="0.358947">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="362"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="362"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="372"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001562" DistinctValues="1.202222">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="372"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005468" DistinctValues="4.207778">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="381"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="5.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="381"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="388"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="389"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="395"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="395"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="403"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="403"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="405"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005272" DistinctValues="3.307500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="405"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="411"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002929" DistinctValues="1.420833">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="417"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="417"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="417"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="0.852500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="417"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.136667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="424"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="424"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="425"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="439"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="439"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="449"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.630000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="449"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006026" DistinctValues="3.780000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="467"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="467"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="473"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.772857">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="473"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="474"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="474"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006026" DistinctValues="4.637143">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="474"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="485"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="485"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="499"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="499"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="507"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="507"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="513"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.470000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="513"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="516"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="516"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="517"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="517"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004687" DistinctValues="2.940000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="517"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="523"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005624" DistinctValues="4.328000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="523"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="531"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="531"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="531"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001406" DistinctValues="1.082000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="531"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="533"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="533"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="539"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="539"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="544"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.352500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="544"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="546"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005272" DistinctValues="4.057500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="546"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="552"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="552"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="561"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.735000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="561"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004101" DistinctValues="2.572500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="573"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="601"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="601"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="609"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="609"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="614"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="614"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="623"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="623"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="638"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="638"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="642"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="642"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="642"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.705000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="646"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="646"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.450833">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="651"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="651"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="651"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006444" DistinctValues="4.959167">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="651"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="674"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="674"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="697"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="697"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="712"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004394" DistinctValues="3.381250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="712"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="717"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="717"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="717"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002636" DistinctValues="2.028750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="717"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.400909">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="727"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="727"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="727"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005113" DistinctValues="3.207273">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="727"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="735"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="735"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="735"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001278" DistinctValues="0.801818">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="735"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004687" DistinctValues="2.940000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002343" DistinctValues="1.470000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="749"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="749"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="749"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002109" DistinctValues="1.323000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="753"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002109" DistinctValues="1.323000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="753"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="756"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002812" DistinctValues="1.764000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="756"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="777"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000781" DistinctValues="0.601111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="777"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="778"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006249" DistinctValues="4.808889">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="778"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="786"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="786"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="795"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="795"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.630000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003013" DistinctValues="1.890000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="806"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="806"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003013" DistinctValues="1.890000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="806"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="809"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006026" DistinctValues="4.637143">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="809"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="821"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="821"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001004" DistinctValues="0.772857">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="821"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="823"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="823"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="832"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="832"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="841"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003906" DistinctValues="3.005556">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="841"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="846"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="846"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="846"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003124" DistinctValues="2.404444">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="846"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="858"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="858"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="863"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="863"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="873"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001562" DistinctValues="1.202222">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="873"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="875"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="875"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="875"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005468" DistinctValues="4.207778">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="875"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="882"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="882"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002009" DistinctValues="1.260000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="891"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.205000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="891"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="898"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="898"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="898"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001506" DistinctValues="0.945000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="898"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001172" DistinctValues="0.901667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005858" DistinctValues="4.508333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="907"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="907"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="919"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="926"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000639" DistinctValues="0.400909">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="926"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="927"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="927"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001917" DistinctValues="1.202727">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="927"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004474" DistinctValues="2.806364">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="937"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000586" DistinctValues="0.450833">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="937"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="938"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="938"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006444" DistinctValues="4.959167">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="938"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="949"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="949"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="956"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.551250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="956"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="957"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="957"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="957"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002636" DistinctValues="1.653750">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="957"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003515" DistinctValues="2.205000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="964"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000879" DistinctValues="0.551250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="964"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="965"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001757" DistinctValues="1.102500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="965"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="967"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="967"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="967"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004394" DistinctValues="2.756250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="967"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="979"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="979"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="987"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007030" DistinctValues="6.410000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="987"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.5228916.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000408" DistinctValues="0.058824">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001631" DistinctValues="0.235294">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.287500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.287500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003032" DistinctValues="1.006250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001299" DistinctValues="0.431250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.287500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001459" DistinctValues="0.694737">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001459" DistinctValues="0.694737">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004012" DistinctValues="1.910526">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000408" DistinctValues="0.058824">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001631" DistinctValues="0.235294">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000815" DistinctValues="0.117647">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001631" DistinctValues="0.235294">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="77"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.176471">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="77"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003300" DistinctValues="1.571429">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000660" DistinctValues="0.314286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000660" DistinctValues="0.314286">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="101"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004851" DistinctValues="3.710000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="115"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="115"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002079" DistinctValues="1.590000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="115"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="118"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004798" DistinctValues="3.669231">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="118"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="127"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="127"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="127"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.630769">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="127"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="131"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="131"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="143"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="143"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="146"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005864" DistinctValues="4.484615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="146"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="157"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="157"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="157"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001066" DistinctValues="0.815385">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="157"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="159"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="159"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="163"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004764" DistinctValues="2.956250">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="174"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001299" DistinctValues="0.806250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="174"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="177"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.537500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="177"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="179"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000693" DistinctValues="0.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="179"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.007000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006237" DistinctValues="4.770000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="189"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="189"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="199"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004851" DistinctValues="3.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="199"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="206"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002079" DistinctValues="1.290000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="206"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="209"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="222"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="222"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="227"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="227"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003465" DistinctValues="2.650000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="236"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003465" DistinctValues="2.650000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="236"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="239"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="239"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="248"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="248"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="255"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002835" DistinctValues="1.759091">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="264"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="264"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="264"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004095" DistinctValues="2.540909">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="264"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="277"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="277"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="278"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="288"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003080" DistinctValues="1.466667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="288"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="292"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="292"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="292"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="295"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="295"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="295"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001540" DistinctValues="0.733333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="295"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="297"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="297"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="298"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="305"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="311"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000770" DistinctValues="0.477778">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="311"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="312"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="312"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="312"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006160" DistinctValues="3.822222">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="312"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.225000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="321"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="327"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="328"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="328"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001732" DistinctValues="1.075000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="328"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.323077">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="334"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001599" DistinctValues="0.992308">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="334"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="337"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="337"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="337"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003198" DistinctValues="1.984615">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="337"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="343"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001223" DistinctValues="0.758824">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="343"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="346"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="346"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="346"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002446" DistinctValues="1.517647">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="346"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003261" DistinctValues="2.023529">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="366"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="366"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="373"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000577" DistinctValues="0.358333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="373"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="374"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.225000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="374"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="383"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="383"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="383"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001155" DistinctValues="0.716667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="383"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="385"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="385"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="393"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002599" DistinctValues="1.987500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="393"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="396"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004331" DistinctValues="3.312500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="396"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="401"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="401"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="407"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="5.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="407"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="411"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="411"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="416"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="416"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="416"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="416"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="418"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="418"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="423"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="423"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="431"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="431"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="433"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="433"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="447"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003080" DistinctValues="1.911111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="447"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="451"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="452"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="452"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003850" DistinctValues="2.388889">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="452"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="457"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="457"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="466"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003960" DistinctValues="3.028571">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="466"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002970" DistinctValues="2.271429">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="473"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="473"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="479"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="479"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="487"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004158" DistinctValues="3.180000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="487"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="493"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002772" DistinctValues="2.120000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="493"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="497"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="497"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="501"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="503"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="503"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="511"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="511"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="518"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="518"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="519"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="519"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="519"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="519"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="523"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005864" DistinctValues="4.484615">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="523"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="534"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="534"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="534"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001066" DistinctValues="0.815385">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="534"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="536"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000577" DistinctValues="0.358333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="536"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="537"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="537"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="537"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001732" DistinctValues="1.075000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="537"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004620" DistinctValues="2.866667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="548"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="548"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="555"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="555"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="563"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="563"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="565"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.662500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="565"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="566"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006064" DistinctValues="4.637500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="573"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="573"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="578"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000533" DistinctValues="0.330769">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="578"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="579"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="579"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004265" DistinctValues="2.646154">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="579"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="587"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.323077">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="587"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="591"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="591"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="602"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="602"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="608"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="608"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="617"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="617"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="625"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="625"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="625"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="625"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="631"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="631"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="642"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005775" DistinctValues="4.416667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="642"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="652"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="652"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="652"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001155" DistinctValues="0.883333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="652"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="654"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002599" DistinctValues="1.987500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="654"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="657"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="657"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="657"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004331" DistinctValues="3.312500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="657"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="662"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="662"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="668"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001980" DistinctValues="1.514286">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="668"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004950" DistinctValues="3.785714">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="675"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.537500">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="675"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="677"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="677"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.000866" DistinctValues="0.537500">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="677"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="679"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="679"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="679"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.225000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="679"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="691"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="691"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="703"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="703"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="725"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="725"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="733"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004158" DistinctValues="3.180000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="733"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="739"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="739"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002772" DistinctValues="2.120000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="739"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="743"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001732" DistinctValues="1.325000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="743"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="745"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005197" DistinctValues="3.975000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="745"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="751"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003080" DistinctValues="2.355556">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="751"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="755"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="755"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003850" DistinctValues="2.944444">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="755"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002772" DistinctValues="1.320000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="764"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="764"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="765"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="765"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="766"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="766"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004158" DistinctValues="1.980000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="766"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="772"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001299" DistinctValues="0.993750">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="772"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="775"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005631" DistinctValues="4.306250">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="788"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="3.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="788"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="798"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="799"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="799"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001155" DistinctValues="0.883333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="801"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="803"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005775" DistinctValues="4.416667">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="803"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="813"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="813"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="827"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="827"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="834"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="834"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="848"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.433333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="848"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="851"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="851"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001540" DistinctValues="0.955556">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="851"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="853"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003080" DistinctValues="1.911111">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="853"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="857"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="857"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="864"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005544" DistinctValues="4.240000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="864"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="872"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="872"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="872"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001386" DistinctValues="1.060000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="872"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="874"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001260" DistinctValues="0.600000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="874"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="876"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="876"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001260" DistinctValues="0.600000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="876"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="878"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="878"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004410" DistinctValues="2.100000">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="878"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="885"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="885"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="885"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="886"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="896"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="896"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="902"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="902"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="909"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="909"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="919"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001066" DistinctValues="0.661538">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="919"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="921"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="921"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="921"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003732" DistinctValues="2.315385">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="921"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="928"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="928"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002132" DistinctValues="1.323077">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="928"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="932"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="932"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="942"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="942"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="952"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="6.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="952"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.006930" DistinctValues="5.300000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="969"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="969"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="969"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001260" DistinctValues="0.963636">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="972"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="972"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005670" DistinctValues="4.336364">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="972"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="981"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.001540" DistinctValues="1.177778">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="981"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="983"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="983"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.005390" DistinctValues="4.122222">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="983"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.002310" DistinctValues="1.766667">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="993"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.003000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="993"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="993"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.004620" DistinctValues="3.533333">
+          <dxl:LowerBound Closed="false" TypeMdid="0.23.1.0" Value="993"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="999"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:OpClasses>
+          <dxl:OpClass Mdid="0.1976.1.0"/>
+          <dxl:OpClass Mdid="0.1977.1.0"/>
+          <dxl:OpClass Mdid="0.3027.1.0"/>
+        </dxl:OpClasses>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.5228913.1.0" TableName="foo">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.5228916.1.0" TableName="bar">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:And>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="16">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.273335" Rows="61.198807" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="b">
+            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.269686" Rows="61.198807" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.006967" Rows="1000.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.5228913.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.006967" Rows="1000.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.5228916.1.0" TableName="bar">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libgpopt/src/engine/CStatisticsConfig.cpp
+++ b/libgpopt/src/engine/CStatisticsConfig.cpp
@@ -43,7 +43,7 @@ CStatisticsConfig::CStatisticsConfig
 	m_phsmdidcolinfo(NULL)
 {
 	GPOS_ASSERT(CDouble(0.0) < damping_factor_filter);
-	GPOS_ASSERT(CDouble(0.0) < damping_factor_join);
+	GPOS_ASSERT(CDouble(0.0) <= damping_factor_join);
 	GPOS_ASSERT(CDouble(0.0) < damping_factor_groupby);
 
 	//m_phmmdidcolinfo = New(m_mp) HMMDIdMissingstatscol(m_mp);

--- a/scripts/fix_mdps.py
+++ b/scripts/fix_mdps.py
@@ -72,7 +72,7 @@ def processLogFile(logFileLines):
             current_file = line.split()[-1]
             current_file = current_file.split('\"')[0]
             if read_plan > 0:
-                print "Log file contains partial plans for %, please update this file by hand" % (current_file)
+                print "Log file contains partial plans for %s, please update this file by hand" % (current_file)
                 read_plan = 0
         elif actualPlanMatch:
             read_plan = 1

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -146,7 +146,7 @@ CICGMiscTest:
 BroadcastSkewedHashjoin OrderByNullsFirst ConvertHashToRandomSelect ConvertHashToRandomInsert HJN-DeeperOuter CTAS CTAS-Random CheckAsUser
 ProjectRepeatedColumn1 ProjectRepeatedColumn2 NLJ-BC-Outer-Spool-Inner Self-Comparison Self-Comparison-Nullable
 SelectCheckConstraint ExpandJoinOrder SelectOnBpchar EqualityJoin EffectsOfJoinFilter InnerJoin-With-OuterRefs
-UDA-AnyElement-1 UDA-AnyElement-2 MinCardinalityNaryJoin Project-With-NonScalar-Func SixWayDPv2;
+UDA-AnyElement-1 UDA-AnyElement-2 MinCardinalityNaryJoin Project-With-NonScalar-Func SixWayDPv2 MultiplePredJoinCardinality;
 
 CArrayCmpTest:
 ArrayConcat ArrayRef FoldedArrayCmp IN-ArrayCmp NOT-IN-ArrayCmp ArrayCmpAll UDA-AnyArray InClauseWithMCV


### PR DESCRIPTION
The join damping factor controls how much impact successive predicates
have on the cardinality of a join. For example, given the join condition
"a=b and c=d and e=f", we currently sort the predicates descending by
selectivity and the 2nd predicate does not have as much influence as the
first, depending on the `optimizer_join_factor` GUC. By default, this is
set to .01, meaning the 2nd predicate's contribution to the cardinality
is multiplied by (.01)^2, and the 3rd predicate is multiplied by (.01)^3.

This effectively assumes that predicates are fairly highly correlated.
Although increasing the default value of this GUC was considered (which
would make the assumption that the columns are a bit more independent),
another approach is to scale the successive predicates down moderately
based on their selectivity.

This new method (I'll call it the nth root method) makes successive
predicates have a smaller and smaller impact to account for the higher
probability that there is some correlation between the columns.

For example, given ANDed predicates with selectivities [.5, .3, .1], the
cumulative selectivity would be:
S = S1 * sqrt(S2) * 4root(S3)
.15 = .5 * sqrt(.3) * 4root(.1)
For scale factors, this is equivalent to SF1 * sqrt(SF2) * 4root(SF3)

Using this nth-root method causes us to estimate much lower
cardinalities than before for joins with multiple predicates, causing
plans to use more indexes. This method will not be used by default and
will only be used when the `optimizer_join_factor` GUC is set to 0.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Ashuka Xue <axue@pivotal.io>