### PR TITLE
Support opfamilies/opclass for distribution in ORCA

### DIFF
--- a/data/dxl/expressiontests/DifferencePlan.xml
+++ b/data/dxl/expressiontests/DifferencePlan.xml
@@ -37,7 +37,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="foo.b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/DynamicGetMultiJoinPlan.xml
+++ b/data/dxl/expressiontests/DynamicGetMultiJoinPlan.xml
@@ -48,7 +48,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="foo1.j" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
@@ -170,7 +170,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="12" ColName="foo2.k" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -228,7 +228,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="22" ColName="foo3.k" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/expressiontests/DynamicGetUnionAllOuterJoinPlan.xml
+++ b/data/dxl/expressiontests/DynamicGetUnionAllOuterJoinPlan.xml
@@ -180,7 +180,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="18" ColName="s.c" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
@@ -225,7 +225,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="19" ColName="s.d" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/expressiontests/HashDistributePlan.xml
+++ b/data/dxl/expressiontests/HashDistributePlan.xml
@@ -77,7 +77,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="188" ColName="s.s2" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/HashJoinPlan.xml
+++ b/data/dxl/expressiontests/HashJoinPlan.xml
@@ -56,10 +56,10 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="0" ColName="t1.a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="t1.b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
@@ -122,10 +122,10 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="3" ColName="t2.a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="4" ColName="t2.b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/expressiontests/IntersectPlan.xml
+++ b/data/dxl/expressiontests/IntersectPlan.xml
@@ -37,7 +37,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="foo.b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/LeftOuterJoinHJPlan.xml
+++ b/data/dxl/expressiontests/LeftOuterJoinHJPlan.xml
@@ -62,7 +62,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="0" ColName="r.a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
@@ -102,7 +102,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="2" ColName="t.e" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/LeftOuterJoinNLPlan.xml
+++ b/data/dxl/expressiontests/LeftOuterJoinNLPlan.xml
@@ -62,7 +62,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="0" ColName="r.a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>
@@ -102,7 +102,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="2" ColName="t.e" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/MultipleWindowFuncPlan.xml
+++ b/data/dxl/expressiontests/MultipleWindowFuncPlan.xml
@@ -131,7 +131,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="s.e" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/expressiontests/UnionAllPlan.xml
+++ b/data/dxl/expressiontests/UnionAllPlan.xml
@@ -58,7 +58,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="11" ColName="r.b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/UnionPlan.xml
+++ b/data/dxl/expressiontests/UnionPlan.xml
@@ -37,7 +37,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/expressiontests/WinFunc-Multiple-DQA-Query-PartitionBy-DifferentColumn.xml
+++ b/data/dxl/expressiontests/WinFunc-Multiple-DQA-Query-PartitionBy-DifferentColumn.xml
@@ -478,7 +478,7 @@ SQL: select count(distinct a) over(partition by a), sum(distinct a) over(partiti
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -795,7 +795,7 @@ SQL: select count(distinct a) over(partition by a), sum(distinct a) over(partiti
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="44" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/expressiontests/WindowPlan.xml
+++ b/data/dxl/expressiontests/WindowPlan.xml
@@ -78,7 +78,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="d" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/expressiontests/WindowWithFramePlan.xml
+++ b/data/dxl/expressiontests/WindowWithFramePlan.xml
@@ -76,7 +76,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="s.c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/expressiontests/WindowWithNoLeadingEdgePlan.xml
+++ b/data/dxl/expressiontests/WindowWithNoLeadingEdgePlan.xml
@@ -76,7 +76,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="s.c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/106-way-join.mdp
+++ b/data/dxl/minidump/106-way-join.mdp
@@ -16836,7 +16836,7 @@ group by	pa11.dcal_month_id,
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="dpg_program_key" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -17502,7 +17502,7 @@ group by	pa11.dcal_month_id,
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="dcal_month_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -39698,7 +39698,7 @@ group by	pa11.dcal_month_id,
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1053" ColName="dcal_month_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/3WayJoinUsingOperatorsOfNonDefaultOpfamily.mdp
+++ b/data/dxl/minidump/3WayJoinUsingOperatorsOfNonDefaultOpfamily.mdp
@@ -1,0 +1,583 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    CREATE FUNCTION abseq(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) = abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |=| (
+      PROCEDURE = abseq,
+      LEFTARG = int,
+      RIGHTARG = int,
+      COMMUTATOR = |=|,
+      hashes, merges);
+
+    CREATE FUNCTION abshashfunc(int) RETURNS int AS
+    $$
+      begin return hashint4(abs($1)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR CLASS abs_int_hash_ops FOR TYPE int4
+      USING hash AS
+      OPERATOR 1 |=|,
+      FUNCTION 1 abshashfunc(int);
+
+    CREATE FUNCTION abslt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) < abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |<| (
+      PROCEDURE = abslt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION absgt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) > abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |>| (
+      PROCEDURE = absgt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION abscmp(int, int) RETURNS int AS
+    $$
+      begin return btint4cmp(abs($1),abs($2)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR CLASS abs_int_btree_ops FOR TYPE int4
+      USING btree AS
+      OPERATOR 1 |<|,
+      OPERATOR 3 |=|,
+      OPERATOR 5 |>|,
+      FUNCTION 1 abscmp(int, int);
+
+    drop table if exists atab_old_hash;
+    drop table if exists btab_old_hash;
+    CREATE TABLE atab_old_hash (a int) DISTRIBUTED BY (a);
+    CREATE TABLE btab_old_hash (b int) DISTRIBUTED BY (b);
+    CREATE TABLE ctab_old_hash (c int) DISTRIBUTED BY (c);
+
+    INSERT INTO atab_old_hash VALUES (-1), (0), (1);
+    INSERT INTO btab_old_hash VALUES (-1), (0), (1), (2);
+
+    set optimizer_join_order = query;
+
+		SELECT a, b FROM atab_old_hash, btab_old_hash, ctab_old_hash where a |=| c and b |=| c;
+
+    Although both the join predicates belong to the same, ORCA currently does
+    not merge them into equivalent classes, because the operator belongs to a
+    non-default opfamily for the int4 type.
+    That is, ORCA does not infer a |=| b from the predicates. Thus by forcing a
+    join between atab_old_hash and btab_old_hash, we should see a CROSS JOIN.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102002,102003,102073,102074,102120,102144,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.16386.1.0" Name="|=|" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.16385.1.0"/>
+        <dxl:Commutator Mdid="0.16386.1.0"/>
+        <dxl:HashOpfamily Mdid="0.32768.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.32768.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.16393.1.0"/>
+          <dxl:Opfamily Mdid="0.32768.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.0" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.16399.1.0" Name="atab_old_hash" Rows="3.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16399.1.0" Name="atab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16402.1.0" Name="btab_old_hash" Rows="4.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.16402.1.0" Name="btab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.106691.1.0.0" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.106691.1.0" Name="ctab_old_hash" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.106691.1.0" Name="ctab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="c" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16399.1.0" TableName="atab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16402.1.0" TableName="btab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.106691.1.0" TableName="ctab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="17" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="17" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="17" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:And>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="18">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324463.445645" Rows="3.413333" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="b">
+            <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324463.445543" Rows="3.413333" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="b">
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="16" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="16" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.444169" Rows="12.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="b">
+                <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.32768.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr Opfamily="0.32768.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.444069" Rows="12.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="b">
+                  <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000241" Rows="9.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.16399.1.0" TableName="atab_old_hash">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="4.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="b">
+                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16402.1.0" TableName="btab_old_hash">
+                  <dxl:Columns>
+                    <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:NestedLoopJoin>
+          </dxl:RedistributeMotion>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="16" Alias="c">
+                <dxl:Ident ColId="16" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.32768.1.0">
+                <dxl:Ident ColId="16" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+              <dxl:HashExpr Opfamily="0.32768.1.0">
+                <dxl:Ident ColId="16" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="16" Alias="c">
+                  <dxl:Ident ColId="16" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.106691.1.0" TableName="ctab_old_hash">
+                <dxl:Columns>
+                  <dxl:Column ColId="16" Attno="1" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/AggregateWithSkew.mdp
+++ b/data/dxl/minidump/AggregateWithSkew.mdp
@@ -694,7 +694,7 @@ group by b;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -730,10 +730,10 @@ group by b;
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -814,22 +814,22 @@
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
                               <dxl:HashExprList>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.25.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.27.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.16.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.16.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
                                 </dxl:HashExpr>
                               </dxl:HashExprList>

--- a/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1451,7 +1451,7 @@ ORDER BY 1 asc ;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/data/dxl/minidump/BitmapIndexScan.mdp
@@ -465,10 +465,10 @@ see sql/BitmapIndexScan.sql
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="23" ColName="fid" TypeMdid="0.1700.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="6" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/BitmapIndexScanCost.mdp
+++ b/data/dxl/minidump/BitmapIndexScanCost.mdp
@@ -387,7 +387,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.25.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="6" ColName="message_id" TypeMdid="0.25.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/Blocking-Spool-Parallel-Union-All.mdp
+++ b/data/dxl/minidump/Blocking-Spool-Parallel-Union-All.mdp
@@ -887,7 +887,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -986,7 +986,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="26" ColName="c2" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithDP.mdp
+++ b/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithDP.mdp
@@ -3846,7 +3846,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1 FROM foo10 FOO10 WHERE FOO10.i2 = 'EN' ) FOO1
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="12" ColName="m9" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -3971,7 +3971,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1 FROM foo10 FOO10 WHERE FOO10.i2 = 'EN' ) FOO1
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithOutDP.mdp
+++ b/data/dxl/minidump/CJoinOrderDPTest/JoinOrderWithOutDP.mdp
@@ -1817,7 +1817,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="5" ColName="m2" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1865,7 +1865,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="9" ColName="m6" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -1919,7 +1919,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="12" ColName="m9" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -2044,7 +2044,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -2082,7 +2082,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="16" ColName="h1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -2120,7 +2120,7 @@ INNER JOIN  (SELECT FOO10.i1 AS i1
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="20" ColName="g1" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/NoOpMotionUsesOnlyGroupOutputColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/NoOpMotionUsesOnlyGroupOutputColumns.mdp
@@ -320,7 +320,7 @@ EXPLAIN SELECT b, a FROM foo UNION ALL SELECT b, a FROM foo INTERSECT ALL SELECT
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -367,7 +367,7 @@ EXPLAIN SELECT b, a FROM foo UNION ALL SELECT b, a FROM foo INTERSECT ALL SELECT
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-ConstTable.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-ConstTable.mdp
@@ -270,7 +270,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -311,7 +311,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="2" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -351,7 +351,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Insert.mdp
@@ -249,7 +249,7 @@ INSERT INTO t VALUES (11),(12),(13);
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="column1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -278,7 +278,7 @@ INSERT INTO t VALUES (11),(12),(13);
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="column1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -307,7 +307,7 @@ INSERT INTO t VALUES (11),(12),(13);
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="2" ColName="column1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Select.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelAppend-Select.mdp
@@ -333,7 +333,7 @@ explain select * from foo union select * from bar;
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -380,7 +380,7 @@ explain select * from foo union select * from bar;
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNoRedistributableColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNoRedistributableColumns.mdp
@@ -280,7 +280,7 @@ EXPLAIN SELECT xmin FROM tbl1 UNION ALL SELECT xmin FROM tbl2;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -338,7 +338,7 @@ EXPLAIN SELECT xmin FROM tbl1 UNION ALL SELECT xmin FROM tbl2;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNotEqualNumOfDistrColumns.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithNotEqualNumOfDistrColumns.mdp
@@ -286,7 +286,7 @@ EXPLAIN SELECT a,b FROM foo UNION ALL SELECT c,d FROM bar;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -333,10 +333,10 @@ EXPLAIN SELECT a,b FROM foo UNION ALL SELECT c,d FROM bar;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithSingleNotRedistributableColumn.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/ParallelUnionAllWithSingleNotRedistributableColumn.mdp
@@ -307,10 +307,10 @@ EXPLAIN SELECT * FROM foo UNION ALL SELECT * FROM bar;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -364,10 +364,10 @@ EXPLAIN SELECT * FROM foo UNION ALL SELECT * FROM bar;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="d" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/RedundantMotionParallelUnionAll.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/RedundantMotionParallelUnionAll.mdp
@@ -410,7 +410,7 @@ select * from t, (select * from t union all select * from t) tt where t.c = tt.c
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -457,7 +457,7 @@ select * from t, (select * from t union all select * from t) tt where t.c = tt.c
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="18" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/CPhysicalParallelUnionAllTest/TwoHashedTables.mdp
+++ b/data/dxl/minidump/CPhysicalParallelUnionAllTest/TwoHashedTables.mdp
@@ -264,7 +264,7 @@ EXPLAIN SELECT * FROM foo UNION ALL SELECT * FROM bar;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -304,7 +304,7 @@ EXPLAIN SELECT * FROM foo UNION ALL SELECT * FROM bar;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="8" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
+++ b/data/dxl/minidump/CTAS-With-Global-Local-Agg.mdp
@@ -808,7 +808,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="9" ColName="unnest" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
+++ b/data/dxl/minidump/CTAS-with-hashed-distributed-external-table.mdp
@@ -284,7 +284,7 @@ EXPLAIN CREATE TABLE Test AS SELECT * FROM test_gpfdist_ext DISTRIBUTED BY (a);
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CTAS.mdp
+++ b/data/dxl/minidump/CTAS.mdp
@@ -275,7 +275,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CTE-12.mdp
+++ b/data/dxl/minidump/CTE-12.mdp
@@ -3470,7 +3470,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1042.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="33" ColName="code" TypeMdid="0.1042.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CTE-Join-Redistribute-Producer.mdp
+++ b/data/dxl/minidump/CTE-Join-Redistribute-Producer.mdp
@@ -476,7 +476,7 @@ with v as (select * from t1) select * from v v1, v v2 where v1.b=v2.b;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/CTE-Preds2.mdp
+++ b/data/dxl/minidump/CTE-Preds2.mdp
@@ -358,10 +358,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="27" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="28" ColName="j" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/CTE-volatile.mdp
+++ b/data/dxl/minidump/CTE-volatile.mdp
@@ -476,7 +476,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.701.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="a" TypeMdid="0.701.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -536,10 +536,10 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.27.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/CTEWithVolatileFunction.mdp
+++ b/data/dxl/minidump/CTEWithVolatileFunction.mdp
@@ -258,7 +258,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.20.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="nextval" TypeMdid="0.20.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -4047,10 +4047,10 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                 <dxl:Filter/>
                                                 <dxl:SortingColumnList/>
                                                 <dxl:HashExprList>
-                                                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                                                  <dxl:HashExpr>
                                                     <dxl:Ident ColId="94" ColName="element_id" TypeMdid="0.1043.1.0"/>
                                                   </dxl:HashExpr>
-                                                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                                                  <dxl:HashExpr>
                                                     <dxl:Ident ColId="119" ColName="?column?" TypeMdid="0.23.1.0"/>
                                                   </dxl:HashExpr>
                                                 </dxl:HashExprList>
@@ -4174,10 +4174,10 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.1043.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="41" ColName="element_id" TypeMdid="0.1043.1.0"/>
                           </dxl:HashExpr>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="66" ColName="?column?" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -4480,10 +4480,10 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                           <dxl:Filter/>
                                                           <dxl:SortingColumnList/>
                                                           <dxl:HashExprList>
-                                                            <dxl:HashExpr TypeMdid="0.1043.1.0">
+                                                            <dxl:HashExpr>
                                                               <dxl:Ident ColId="149" ColName="element_id" TypeMdid="0.1043.1.0"/>
                                                             </dxl:HashExpr>
-                                                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                                                            <dxl:HashExpr>
                                                               <dxl:Ident ColId="174" ColName="?column?" TypeMdid="0.23.1.0"/>
                                                             </dxl:HashExpr>
                                                           </dxl:HashExprList>

--- a/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -10945,13 +10945,13 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1042.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="i_item_id" TypeMdid="0.1042.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="4" ColName="i_item_desc" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="5" ColName="i_current_price" TypeMdid="0.1700.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CollapseNot.mdp
+++ b/data/dxl/minidump/CollapseNot.mdp
@@ -424,10 +424,10 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.27.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/ComputedGroupByCol.mdp
+++ b/data/dxl/minidump/ComputedGroupByCol.mdp
@@ -379,7 +379,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="?column?" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp
+++ b/data/dxl/minidump/ConstTblGetUnderSubqWithNoOuterRef.mdp
@@ -559,7 +559,7 @@ SELECT * FROM foo,bar WHERE a=(VALUES (1));
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="18" ColName="column1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ConvertHashToRandomInsert.mdp
+++ b/data/dxl/minidump/ConvertHashToRandomInsert.mdp
@@ -717,7 +717,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="5" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -757,7 +757,7 @@ explain analyze insert into t1 select t2.a,t3.b from t2, t3 where t2.a = t3.a;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/ConvertHashToRandomSelect.mdp
+++ b/data/dxl/minidump/ConvertHashToRandomSelect.mdp
@@ -264,7 +264,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
+++ b/data/dxl/minidump/CorrelatedNLJWithTrueCondition.mdp
@@ -476,7 +476,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="8" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -581,25 +581,25 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="0" ColName="u_vtgnr" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="u_zj" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="u_folio" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.27.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.25.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="20" ColName="max" TypeMdid="0.25.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.25.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="21" ColName="substr" TypeMdid="0.25.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -869,7 +869,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                                 <dxl:Filter/>
                                 <dxl:SortingColumnList/>
                                 <dxl:HashExprList>
-                                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                                  <dxl:HashExpr>
                                     <dxl:Ident ColId="10" ColName="u_vtgnr" TypeMdid="0.1043.1.0"/>
                                   </dxl:HashExpr>
                                 </dxl:HashExprList>
@@ -1003,7 +1003,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
                               <dxl:HashExprList>
-                                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="0" ColName="u_vtgnr" TypeMdid="0.1043.1.0"/>
                                 </dxl:HashExpr>
                               </dxl:HashExprList>

--- a/data/dxl/minidump/DML-Function-With-SQL-Access.mdp
+++ b/data/dxl/minidump/DML-Function-With-SQL-Access.mdp
@@ -287,7 +287,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="8" ColName="test_func_pg_stats" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/DML-Replicated-Input.mdp
+++ b/data/dxl/minidump/DML-Replicated-Input.mdp
@@ -394,7 +394,7 @@ WHERE  sach_vsnr = 465132477;
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="sach_vsnr" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
+++ b/data/dxl/minidump/DML-UnionAll-With-Universal-Child.mdp
@@ -307,7 +307,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
+++ b/data/dxl/minidump/DML-With-CorrelatedNLJ-With-Universal-Child.mdp
@@ -324,7 +324,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
+++ b/data/dxl/minidump/DML-With-Join-With-Universal-Child.mdp
@@ -275,7 +275,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="2" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
+++ b/data/dxl/minidump/DML-With-WindowFunc-OuterRef.mdp
@@ -401,7 +401,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.20.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="16" ColName="row_number" TypeMdid="0.20.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -495,7 +495,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.20.1.0">
+                  <dxl:HashExpr>
                     <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                       <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                     </dxl:Cast>

--- a/data/dxl/minidump/DMLCollapseProject.mdp
+++ b/data/dxl/minidump/DMLCollapseProject.mdp
@@ -422,7 +422,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.1042.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="ttype" TypeMdid="0.1042.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/DPE-IN.mdp
+++ b/data/dxl/minidump/DPE-IN.mdp
@@ -906,7 +906,7 @@ select * from P,X where P.a=X.a  and X.a  in (1,2);
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/DPE-NOT-IN.mdp
+++ b/data/dxl/minidump/DPE-NOT-IN.mdp
@@ -890,7 +890,7 @@ select * from P,X where P.a=X.a  and X.a not in (1,2);
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/DPE-with-unsupported-pred.mdp
+++ b/data/dxl/minidump/DPE-with-unsupported-pred.mdp
@@ -2123,7 +2123,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/DPv2QueryOnly.mdp
+++ b/data/dxl/minidump/DPv2QueryOnly.mdp
@@ -6564,7 +6564,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -6611,7 +6611,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="10" ColName="b2" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/DQA-1-RegularAgg.mdp
+++ b/data/dxl/minidump/DQA-1-RegularAgg.mdp
@@ -358,7 +358,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/DQA-2-RegularAgg.mdp
+++ b/data/dxl/minidump/DQA-2-RegularAgg.mdp
@@ -417,7 +417,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/DQA-SplitScalar.mdp
+++ b/data/dxl/minidump/DQA-SplitScalar.mdp
@@ -399,7 +399,7 @@ drop table if exists foo;
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
+++ b/data/dxl/minidump/DQA-SplitScalarWithAggAndGuc.mdp
@@ -439,7 +439,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
+++ b/data/dxl/minidump/DQA-SplitScalarWithGuc.mdp
@@ -398,7 +398,7 @@ explain select count(distinct b ) from foo;
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
+++ b/data/dxl/minidump/Delete-With-Limit-In-Subquery.mdp
@@ -856,7 +856,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -507,7 +507,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
+++ b/data/dxl/minidump/DontAddRedistributeBeforeInsert-1.mdp
@@ -463,10 +463,10 @@ Physical plan:
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/DqaHavingMax.mdp
+++ b/data/dxl/minidump/DqaHavingMax.mdp
@@ -682,7 +682,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/DqaNoRedistribute.mdp
+++ b/data/dxl/minidump/DqaNoRedistribute.mdp
@@ -755,7 +755,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/DuplicateGrpCol.mdp
+++ b/data/dxl/minidump/DuplicateGrpCol.mdp
@@ -461,10 +461,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="?column?" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -518,10 +518,10 @@ see sql/DynamicBitmapIndexScan.sql
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="24" ColName="fid" TypeMdid="0.1700.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="7" ColName="flex_value_id" TypeMdid="0.1700.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1629,7 +1629,7 @@ WHERE
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="45" ColName="ws_bill_customer_sk" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -1661,7 +1661,7 @@ WHERE
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="41" ColName="ws_sold_date_sk" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>
@@ -1819,7 +1819,7 @@ WHERE
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="124" ColName="cs_ship_customer_sk" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggEmptyInput.mdp
+++ b/data/dxl/minidump/EagerAggEmptyInput.mdp
@@ -411,10 +411,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggExpression.mdp
+++ b/data/dxl/minidump/EagerAggExpression.mdp
@@ -3401,7 +3401,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
+++ b/data/dxl/minidump/EagerAggGroupColumnInJoin.mdp
@@ -424,7 +424,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggMax.mdp
+++ b/data/dxl/minidump/EagerAggMax.mdp
@@ -410,10 +410,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggMaxWithNestedLoop.mdp
+++ b/data/dxl/minidump/EagerAggMaxWithNestedLoop.mdp
@@ -4373,10 +4373,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="g2" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="g1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggMinMax.mdp
+++ b/data/dxl/minidump/EagerAggMinMax.mdp
@@ -3420,7 +3420,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggSubquery.mdp
+++ b/data/dxl/minidump/EagerAggSubquery.mdp
@@ -453,10 +453,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="g2" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/EagerAggUnsupportedAgg.mdp
+++ b/data/dxl/minidump/EagerAggUnsupportedAgg.mdp
@@ -3425,7 +3425,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="g1" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/Equiv-HashedDistr-1.mdp
+++ b/data/dxl/minidump/Equiv-HashedDistr-1.mdp
@@ -2006,7 +2006,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -2047,7 +2047,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="24" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/Equiv-HashedDistr-2.mdp
+++ b/data/dxl/minidump/Equiv-HashedDistr-2.mdp
@@ -2014,7 +2014,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -2055,7 +2055,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="24" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
+++ b/data/dxl/minidump/Equivalence-class-project-over-LOJ.mdp
@@ -475,7 +475,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="9" ColName="id" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/minidump/ExceptAllCompatibleDataType.mdp
+++ b/data/dxl/minidump/ExceptAllCompatibleDataType.mdp
@@ -553,7 +553,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.20.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="11" ColName="a" TypeMdid="0.20.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -624,10 +624,10 @@
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.20.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="11" ColName="a" TypeMdid="0.20.1.0"/>
                             </dxl:HashExpr>
-                            <dxl:HashExpr TypeMdid="0.26.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="12" ColName="b" TypeMdid="0.26.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>
@@ -782,7 +782,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.20.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                   <dxl:Ident ColId="24" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:Cast>

--- a/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -733,22 +733,22 @@
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
-                          <dxl:HashExpr TypeMdid="0.25.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
                           </dxl:HashExpr>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
-                          <dxl:HashExpr TypeMdid="0.27.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                           </dxl:HashExpr>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
-                          <dxl:HashExpr TypeMdid="0.16.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/minidump/ExpandJoinOrder.mdp
+++ b/data/dxl/minidump/ExpandJoinOrder.mdp
@@ -1721,7 +1721,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
                           <dxl:Ident ColId="42" ColName="c598" TypeMdid="0.25.1.0"/>
                         </dxl:FuncExpr>
@@ -2171,7 +2171,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:FuncExpr FuncId="0.1381.1.0" FuncRetSet="false" TypeMdid="0.23.1.0">
                           <dxl:Ident ColId="17" ColName="c920" TypeMdid="0.25.1.0"/>
                         </dxl:FuncExpr>

--- a/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
+++ b/data/dxl/minidump/ExpandNAryJoinGreedyWithLOJOnly.mdp
@@ -4014,7 +4014,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -4099,7 +4099,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4147,7 +4147,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="41" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -4219,7 +4219,7 @@
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="22" ColName="c" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -4261,7 +4261,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>
@@ -4309,7 +4309,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="31" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>
@@ -4354,7 +4354,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="51" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -4399,7 +4399,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
+++ b/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
@@ -486,7 +486,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -615,7 +615,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ExtractPredicateFromDisj.mdp
+++ b/data/dxl/minidump/ExtractPredicateFromDisj.mdp
@@ -14854,10 +14854,10 @@ WHERE ((sale_type = 's'::text AND dyear = 2001 AND year_total &gt; 0::numeric) O
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="61" ColName="d_year" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="63" ColName="d_moy" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -638,7 +638,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -710,10 +710,10 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="22" ColName="cid" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="23" ColName="date_sk" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/minidump/FullJoin-Caps.mdp
+++ b/data/dxl/minidump/FullJoin-Caps.mdp
@@ -399,7 +399,7 @@ explain select * from edges e1 full outer join edges e2 on (e1.grp = e2.grp and 
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="DEST" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/FullJoin-InnerNotOnDistributionColumn.mdp
+++ b/data/dxl/minidump/FullJoin-InnerNotOnDistributionColumn.mdp
@@ -405,7 +405,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/FullJoin-NonDefaultOpfamily.mdp
+++ b/data/dxl/minidump/FullJoin-NonDefaultOpfamily.mdp
@@ -1,0 +1,854 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    CREATE FUNCTION abseq(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) = abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |=| (
+      PROCEDURE = abseq,
+      LEFTARG = int,
+      RIGHTARG = int,
+      COMMUTATOR = |=|,
+      hashes, merges);
+
+    CREATE FUNCTION abshashfunc(int) RETURNS int AS
+    $$
+      begin return hashint4(abs($1)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR CLASS abs_int_hash_ops FOR TYPE int4
+      USING hash AS
+      OPERATOR 1 |=|,
+      FUNCTION 1 abshashfunc(int);
+
+    CREATE FUNCTION abslt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) < abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |<| (
+      PROCEDURE = abslt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION absgt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) > abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |>| (
+      PROCEDURE = absgt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION abscmp(int, int) RETURNS int AS
+    $$
+      begin return btint4cmp(abs($1),abs($2)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR CLASS abs_int_btree_ops FOR TYPE int4
+      USING btree AS
+      OPERATOR 1 |<|,
+      OPERATOR 3 |=|,
+      OPERATOR 5 |>|,
+      FUNCTION 1 abscmp(int, int);
+
+    drop table if exists atab_old_hash;
+    drop table if exists btab_old_hash;
+    CREATE TABLE atab_old_hash (a int) DISTRIBUTED BY (a);
+    CREATE TABLE btab_old_hash (b int) DISTRIBUTED BY (b);
+
+    INSERT INTO atab_old_hash VALUES (-1), (0), (1);
+    INSERT INTO btab_old_hash VALUES (-1), (0), (1), (2);
+
+    set optimizer_expand_fulljoin=1;
+
+    SELECT a, b FROM atab_old_hash full join btab_old_hash on (a |=| b);
+
+    Expect Merge Join using UNION ALL (Append)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103032,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.16386.1.0" Name="|=|" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.16385.1.0"/>
+        <dxl:Commutator Mdid="0.16386.1.0"/>
+        <dxl:HashOpfamily Mdid="0.32768.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.32768.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.16393.1.0"/>
+          <dxl:Opfamily Mdid="0.32768.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="4.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.0" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.16399.1.0" Name="atab_old_hash" Rows="3.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16399.1.0" Name="atab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16402.1.0" Name="btab_old_hash" Rows="4.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.16402.1.0" Name="btab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.3" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.2" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.5" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.4" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.5" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.4" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.3" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.2" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.1" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Full">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16399.1.0" TableName="atab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16402.1.0" TableName="btab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="288">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="2586.001617" Rows="10.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="b">
+            <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Sequence>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="2586.001319" Rows="10.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="b">
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:CTEProducer CTEId="0" Columns="16,17,18,19,20,21,22,23">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000083" Rows="3.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="16" Alias="a">
+                <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="ctid">
+                <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="xmin">
+                <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="cmin">
+                <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="xmax">
+                <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="21" Alias="cmax">
+                <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="22" Alias="tableoid">
+                <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="23" Alias="gp_segment_id">
+                <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="34"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="16" Alias="a">
+                  <dxl:Ident ColId="16" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="ctid">
+                  <dxl:Ident ColId="17" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="xmin">
+                  <dxl:Ident ColId="18" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="cmin">
+                  <dxl:Ident ColId="19" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="xmax">
+                  <dxl:Ident ColId="20" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="21" Alias="cmax">
+                  <dxl:Ident ColId="21" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="22" Alias="tableoid">
+                  <dxl:Ident ColId="22" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="23" Alias="gp_segment_id">
+                  <dxl:Ident ColId="23" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.16399.1.0" TableName="atab_old_hash">
+                <dxl:Columns>
+                  <dxl:Column ColId="16" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="18" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="19" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="20" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="21" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="22" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="23" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:CTEProducer>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="2155.001209" Rows="10.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="b">
+                <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:CTEProducer CTEId="1" Columns="24,25,26,27,28,29,30,31">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000111" Rows="4.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="24" Alias="b">
+                  <dxl:Ident ColId="24" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="25" Alias="ctid">
+                  <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="26" Alias="xmin">
+                  <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="27" Alias="cmin">
+                  <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="28" Alias="xmax">
+                  <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="29" Alias="cmax">
+                  <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="30" Alias="tableoid">
+                  <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="31" Alias="gp_segment_id">
+                  <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="4.000000" Width="34"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="24" Alias="b">
+                    <dxl:Ident ColId="24" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="25" Alias="ctid">
+                    <dxl:Ident ColId="25" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="26" Alias="xmin">
+                    <dxl:Ident ColId="26" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="27" Alias="cmin">
+                    <dxl:Ident ColId="27" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="28" Alias="xmax">
+                    <dxl:Ident ColId="28" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="29" Alias="cmax">
+                    <dxl:Ident ColId="29" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="30" Alias="tableoid">
+                    <dxl:Ident ColId="30" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="31" Alias="gp_segment_id">
+                    <dxl:Ident ColId="31" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16402.1.0" TableName="btab_old_hash">
+                  <dxl:Columns>
+                    <dxl:Column ColId="24" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="25" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="26" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="27" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="28" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="29" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="30" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:CTEProducer>
+            <dxl:Append IsTarget="false" IsZapped="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1724.001072" Rows="10.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="b">
+                  <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:HashJoin JoinType="Left">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000538" Rows="6.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="b">
+                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:Comparison>
+                </dxl:HashCondList>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000022" Rows="3.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.32768.1.0">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="3.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="3.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="ctid">
+                          <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="xmin">
+                          <dxl:Ident ColId="2" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="3" Alias="cmin">
+                          <dxl:Ident ColId="3" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="4" Alias="xmax">
+                          <dxl:Ident ColId="4" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="5" Alias="cmax">
+                          <dxl:Ident ColId="5" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="6" Alias="tableoid">
+                          <dxl:Ident ColId="6" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                          <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="4.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="b">
+                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.32768.1.0">
+                      <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="4.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="8" Alias="b">
+                        <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:CTEConsumer CTEId="1" Columns="8,9,10,11,12,13,14,15">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="4.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="8" Alias="b">
+                          <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="ctid">
+                          <dxl:Ident ColId="9" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="xmin">
+                          <dxl:Ident ColId="10" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="11" Alias="cmin">
+                          <dxl:Ident ColId="11" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="12" Alias="xmax">
+                          <dxl:Ident ColId="12" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="13" Alias="cmax">
+                          <dxl:Ident ColId="13" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="14" Alias="tableoid">
+                          <dxl:Ident ColId="14" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="15" Alias="gp_segment_id">
+                          <dxl:Ident ColId="15" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Result>
+                </dxl:RedistributeMotion>
+              </dxl:HashJoin>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000507" Rows="4.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="48" Alias="a">
+                    <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="40" Alias="b">
+                    <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:HashJoin JoinType="LeftAntiSemiJoin">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.000496" Rows="4.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="40" Alias="b">
+                      <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+                      <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000030" Rows="4.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="40" Alias="b">
+                        <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.32768.1.0">
+                        <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="4.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="40" Alias="b">
+                          <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:CTEConsumer CTEId="1" Columns="40,41,42,43,44,45,46,47">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="4.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="40" Alias="b">
+                            <dxl:Ident ColId="40" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="41" Alias="ctid">
+                            <dxl:Ident ColId="41" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="42" Alias="xmin">
+                            <dxl:Ident ColId="42" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="43" Alias="cmin">
+                            <dxl:Ident ColId="43" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="44" Alias="xmax">
+                            <dxl:Ident ColId="44" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="45" Alias="cmax">
+                            <dxl:Ident ColId="45" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="46" Alias="tableoid">
+                            <dxl:Ident ColId="46" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="47" Alias="gp_segment_id">
+                            <dxl:Ident ColId="47" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Result>
+                  </dxl:RedistributeMotion>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000022" Rows="3.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="32" Alias="a">
+                        <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.32768.1.0">
+                        <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="3.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="32" Alias="a">
+                          <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:CTEConsumer CTEId="0" Columns="32,33,34,35,36,37,38,39">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="3.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="32" Alias="a">
+                            <dxl:Ident ColId="32" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="33" Alias="ctid">
+                            <dxl:Ident ColId="33" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="34" Alias="xmin">
+                            <dxl:Ident ColId="34" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="35" Alias="cmin">
+                            <dxl:Ident ColId="35" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="36" Alias="xmax">
+                            <dxl:Ident ColId="36" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="37" Alias="cmax">
+                            <dxl:Ident ColId="37" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="38" Alias="tableoid">
+                            <dxl:Ident ColId="38" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="39" Alias="gp_segment_id">
+                            <dxl:Ident ColId="39" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Result>
+                  </dxl:RedistributeMotion>
+                </dxl:HashJoin>
+              </dxl:Result>
+            </dxl:Append>
+          </dxl:Sequence>
+        </dxl:Sequence>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/FullJoin-NotOnDistributionColumn.mdp
+++ b/data/dxl/minidump/FullJoin-NotOnDistributionColumn.mdp
@@ -369,7 +369,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -435,7 +435,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/FullJoin-Replicated.mdp
+++ b/data/dxl/minidump/FullJoin-Replicated.mdp
@@ -336,7 +336,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -402,7 +402,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -567,7 +567,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -697,7 +697,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/FullJoin-SubqueryWithRedistribute.mdp
+++ b/data/dxl/minidump/FullJoin-SubqueryWithRedistribute.mdp
@@ -357,7 +357,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -11041,13 +11041,13 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1042.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="i_item_id" TypeMdid="0.1042.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="4" ColName="i_item_desc" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="5" ColName="i_current_price" TypeMdid="0.1700.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6435,7 +6435,7 @@ ORDER BY s_name;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -6505,7 +6505,7 @@ ORDER BY s_name;
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="18" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -6555,10 +6555,10 @@ ORDER BY s_name;
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="17" ColName="ps_partkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="18" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -6693,10 +6693,10 @@ ORDER BY s_name;
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="38" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="39" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>

--- a/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -466,7 +466,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.313.1.0">
                   <dxl:Ident ColId="9" ColName="i" TypeMdid="0.21.1.0"/>
                 </dxl:Cast>

--- a/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
+++ b/data/dxl/minidump/HJN-Redistribute-One-Side.mdp
@@ -4859,7 +4859,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="24" ColName="o_custkey" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
+++ b/data/dxl/minidump/IndexApply-ForPartialIndex.mdp
@@ -451,7 +451,7 @@ explain select t1.a from t1, foo_prt t2, t3 where (t1.b = t2.a) and t2.a = t3.b;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -542,7 +542,7 @@ explain select t1.a from t1, foo_prt t2, t3 where (t1.b = t2.a) and t2.a = t3.b;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="14" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
+++ b/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
@@ -594,7 +594,7 @@ ORDER BY 1 asc ;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="event_ts" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -892,7 +892,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -942,7 +942,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -932,7 +932,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -892,7 +892,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -942,7 +942,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
+++ b/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
@@ -580,7 +580,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -1452,7 +1452,7 @@ ORDER BY 1 asc ;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="23" ColName="fivemin" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -437,7 +437,7 @@ Table X (int i, int j) is distributed by i, column i has index
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="?column?" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/InferPredicates.mdp
+++ b/data/dxl/minidump/InferPredicates.mdp
@@ -409,7 +409,7 @@ explain select 1+row_number() over(partition by foo.c) from foo, bar where foo.a
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -598,7 +598,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.25.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="38" ColName="?column?" TypeMdid="0.25.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -704,7 +704,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.1042.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="21" ColName="countrycode" TypeMdid="0.1042.1.0" TypeModifier="7"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/minidump/Insert.mdp
+++ b/data/dxl/minidump/Insert.mdp
@@ -237,7 +237,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/InsertAssertSort.mdp
+++ b/data/dxl/minidump/InsertAssertSort.mdp
@@ -441,13 +441,13 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertCheckConstraint.mdp
+++ b/data/dxl/minidump/InsertCheckConstraint.mdp
@@ -342,7 +342,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertConstTuple.mdp
+++ b/data/dxl/minidump/InsertConstTuple.mdp
@@ -241,7 +241,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
+++ b/data/dxl/minidump/InsertConstTupleVolatileFunction.mdp
@@ -275,7 +275,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
+++ b/data/dxl/minidump/InsertDirectedDispatchNullValue.mdp
@@ -266,7 +266,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="3" ColName="col1" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertIntoNonNullAfterDroppingColumn.mdp
+++ b/data/dxl/minidump/InsertIntoNonNullAfterDroppingColumn.mdp
@@ -224,7 +224,7 @@ EXPLAIN INSERT INTO ColumnMapping VALUES (NULL);
         <dxl:Filter/>
         <dxl:SortingColumnList/>
         <dxl:HashExprList>
-          <dxl:HashExpr TypeMdid="0.23.1.0">
+          <dxl:HashExpr>
             <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
           </dxl:HashExpr>
         </dxl:HashExprList>

--- a/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -363,7 +363,7 @@ explain insert into pt2 select * from r;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
+++ b/data/dxl/minidump/InsertNULLNotNULLConstraint.mdp
@@ -208,7 +208,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertNoEnforceConstraints.mdp
+++ b/data/dxl/minidump/InsertNoEnforceConstraints.mdp
@@ -265,7 +265,7 @@ insert into constraints_tab values (NULL, -1);
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.25.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="notnullcol" TypeMdid="0.25.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/InsertPrimaryKeyFromMOTable.mdp
+++ b/data/dxl/minidump/InsertPrimaryKeyFromMOTable.mdp
@@ -280,7 +280,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/InsertProjectSort.mdp
+++ b/data/dxl/minidump/InsertProjectSort.mdp
@@ -407,13 +407,13 @@ explain insert into tbl_cds_buysell_orders_new (a,b,c)
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/InsertWithDroppedCol.mdp
+++ b/data/dxl/minidump/InsertWithDroppedCol.mdp
@@ -289,7 +289,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/minidump/Intersect-OuterRefs.mdp
+++ b/data/dxl/minidump/Intersect-OuterRefs.mdp
@@ -1481,7 +1481,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1565,7 +1565,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
+++ b/data/dxl/minidump/JOIN-Pred-Cast-Int4.mdp
@@ -525,7 +525,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.20.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:Cast>

--- a/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
+++ b/data/dxl/minidump/JOIN-cast2text-int4-Eq-cast2text-double.mdp
@@ -525,7 +525,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.25.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.1688.1.0">
                   <dxl:Ident ColId="8" ColName="i" TypeMdid="0.1700.1.0"/>
                 </dxl:Cast>
@@ -567,7 +567,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.25.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.112.1.0">
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:Cast>

--- a/data/dxl/minidump/JOIN-int4-Eq-double.mdp
+++ b/data/dxl/minidump/JOIN-int4-Eq-double.mdp
@@ -525,7 +525,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1700.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.1700.1.0" FuncId="0.1740.1.0">
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:Cast>

--- a/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
+++ b/data/dxl/minidump/JOIN-int4-Eq-int2.mdp
@@ -424,7 +424,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.313.1.0">
                   <dxl:Ident ColId="8" ColName="i" TypeMdid="0.21.1.0"/>
                 </dxl:Cast>

--- a/data/dxl/minidump/Join-INDF-Nulls-Not-Collocated.mdp
+++ b/data/dxl/minidump/Join-INDF-Nulls-Not-Collocated.mdp
@@ -346,7 +346,7 @@ select * from foo, (select NULL a from bar) other where foo.a is not distinct fr
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3927,16 +3927,16 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="27" ColName="year" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="29" ColName="month" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="38" ColName="shop_code" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="39" ColName="shop_name" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/JoinAbsEqWithoutOpfamilies.mdp
+++ b/data/dxl/minidump/JoinAbsEqWithoutOpfamilies.mdp
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    CREATE FUNCTION abseq(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) = abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |=| (
+      PROCEDURE = abseq,
+      LEFTARG = int,
+      RIGHTARG = int,
+      COMMUTATOR = |=|,
+      hashes, merges);
+
+    CREATE FUNCTION abshashfunc(int) RETURNS int AS
+    $$
+      begin return hashint4(abs($1)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE FUNCTION abslt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) < abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |<| (
+      PROCEDURE = abslt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION absgt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) > abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |>| (
+      PROCEDURE = absgt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION abscmp(int, int) RETURNS int AS
+    $$
+      begin return btint4cmp(abs($1),abs($2)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    drop table if exists atab_old_hash;
+    drop table if exists btab_old_hash;
+    CREATE TABLE atab_old_hash (a int) DISTRIBUTED BY (a);
+    CREATE TABLE btab_old_hash (b int) DISTRIBUTED BY (b);
+
+    INSERT INTO atab_old_hash VALUES (-1), (0), (1);
+    INSERT INTO btab_old_hash VALUES (-1), (0), (1), (2);
+
+    set optimizer_expand_fulljoin=1;
+
+    SELECT a, b FROM atab_old_hash inner join btab_old_hash on (a |=| b);
+
+    The operator |=| is not defined in any operator class/family. As such, it
+    cannot be used for a distributed joining. So expect a CROSS JOIN with a join
+    predicate.
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.16386.1.0" Name="|=|" ComparisonType="Other" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.16385.1.0"/>
+        <dxl:Commutator Mdid="0.16386.1.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.16402.1.0.0" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.16399.1.0" Name="atab_old_hash" Rows="3.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16399.1.0" Name="atab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16402.1.0" Name="btab_old_hash" Rows="4.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.16402.1.0" Name="btab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16399.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16399.1.0" TableName="atab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.16402.1.0" TableName="btab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="6">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.872057" Rows="4.800000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="b">
+            <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.871914" Rows="4.800000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="b">
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.16386.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="4.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="b">
+                <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.16402.1.0" TableName="btab_old_hash">
+              <dxl:Columns>
+                <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000253" Rows="9.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000241" Rows="9.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.16399.1.0" TableName="atab_old_hash">
+                  <dxl:Columns>
+                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/JoinCitextVarchar.mdp
+++ b/data/dxl/minidump/JoinCitextVarchar.mdp
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+	<dxl:Comment><![CDATA[
+		create extension citext;
+		create table tc (a int, c citext) ;
+		create table tt (b int, v varchar) distributed by (v);
+
+		insert into tc values (1, 'a'), (1, 'A');
+		insert into tt values (1, 'a'), (1, 'A');
+
+		insert into tc values (1, 'b'), (1, 'B');
+		insert into tt values (1, 'b'), (1, 'B');
+
+		select * from tc, tt where c = v;
+	]]>
+	</dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:MDCast Mdid="3.20788.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.20788.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:RelationStatistics Mdid="2.20877.1.0" Name="tc" Rows="4.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.20877.1.0" Name="tc" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="2" Mdid="0.20788.1.0" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.20883.1.0" Name="tt" Rows="4.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.20883.1.0" Name="tt" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="1" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="v" Attno="2" Mdid="0.1043.1.0" Nullable="true" ColWidth="2">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.25.1.0" Name="text" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1009.1.0"/>
+        <dxl:MinAgg Mdid="0.2145.1.0"/>
+        <dxl:MaxAgg Mdid="0.2129.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.20788.1.0;1043.1.0" Name="varchar" BinaryCoercible="true" SourceTypeId="0.20788.1.0" DestinationTypeId="0.1043.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.20883.1.0.1" Name="v" Width="2.000000" NullFreq="0.000000" NdvRemain="4.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:Type Mdid="0.20788.1.0" Name="citext" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.20827.1.0"/>
+        <dxl:EqualityOp Mdid="0.20812.1.0"/>
+        <dxl:InequalityOp Mdid="0.20811.1.0"/>
+        <dxl:LessThanOp Mdid="0.20815.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.20816.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.20813.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.20814.1.0"/>
+        <dxl:ComparisonOp Mdid="0.20817.1.0"/>
+        <dxl:ArrayType Mdid="0.20793.1.0"/>
+        <dxl:MinAgg Mdid="0.20833.1.0"/>
+        <dxl:MaxAgg Mdid="0.20834.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.20877.1.0.1" Name="c" Width="2.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20788.1.0" Value="AAAABWE=" LintValue="1075015857"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20788.1.0" Value="AAAABWE=" LintValue="1075015857"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.20788.1.0" Value="AAAABWI=" LintValue="4226146208"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.20788.1.0" Value="AAAABWI=" LintValue="4226146208"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.20877.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBScalarOp Mdid="0.98.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.25.1.0"/>
+        <dxl:RightType Mdid="0.25.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.67.1.0"/>
+        <dxl:Commutator Mdid="0.98.1.0"/>
+        <dxl:InverseOp Mdid="0.531.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7105.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1994.1.0"/>
+          <dxl:Opfamily Mdid="0.1995.1.0"/>
+          <dxl:Opfamily Mdid="0.2095.1.0"/>
+          <dxl:Opfamily Mdid="0.2229.1.0"/>
+          <dxl:Opfamily Mdid="0.4017.1.0"/>
+          <dxl:Opfamily Mdid="0.4056.1.0"/>
+          <dxl:Opfamily Mdid="0.7105.1.0"/>
+          <dxl:Opfamily Mdid="0.12866.1.0"/>
+          <dxl:Opfamily Mdid="0.12900.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="c" TypeMdid="0.20788.1.0"/>
+        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="v" TypeMdid="0.1043.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.20877.1.0" TableName="tc">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="c" TypeMdid="0.20788.1.0" ColWidth="2"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.20883.1.0" TableName="tt">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="v" TypeMdid="0.1043.1.0" ColWidth="2"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.20788.1.0"/>
+          </dxl:Cast>
+          <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+            <dxl:Ident ColId="11" ColName="v" TypeMdid="0.1043.1.0"/>
+          </dxl:Cast>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="10">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.001378" Rows="4.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="c">
+            <dxl:Ident ColId="1" ColName="c" TypeMdid="0.20788.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="b">
+            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="v">
+            <dxl:Ident ColId="10" ColName="v" TypeMdid="0.1043.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.001200" Rows="4.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="c">
+              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.20788.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="b">
+              <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="v">
+              <dxl:Ident ColId="10" ColName="v" TypeMdid="0.1043.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="1" ColName="c" TypeMdid="0.20788.1.0"/>
+              </dxl:Cast>
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="10" ColName="v" TypeMdid="0.1043.1.0"/>
+              </dxl:Cast>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="4.000000" Width="6"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="c">
+                <dxl:Ident ColId="1" ColName="c" TypeMdid="0.20788.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.1995.1.0">
+                <dxl:Ident ColId="1" ColName="c" TypeMdid="0.20788.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="4.000000" Width="6"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="c">
+                  <dxl:Ident ColId="1" ColName="c" TypeMdid="0.20788.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.20877.1.0" TableName="tc">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="c" TypeMdid="0.20788.1.0" ColWidth="2"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="4.000000" Width="6"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="b">
+                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="v">
+                <dxl:Ident ColId="10" ColName="v" TypeMdid="0.1043.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.20883.1.0" TableName="tt">
+              <dxl:Columns>
+                <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="2" ColName="v" TypeMdid="0.1043.1.0" ColWidth="2"/>
+                <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp.mdp
+++ b/data/dxl/minidump/JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp.mdp
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    CREATE FUNCTION abseq(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) = abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |=| (
+      PROCEDURE = abseq,
+      LEFTARG = int,
+      RIGHTARG = int,
+      COMMUTATOR = |=|,
+      hashes, merges);
+
+    CREATE FUNCTION abshashfunc(int) RETURNS int AS
+    $$
+      begin return hashint4(abs($1)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR CLASS abs_int_hash_ops FOR TYPE int4
+      USING hash AS
+      OPERATOR 1 |=|,
+      FUNCTION 1 abshashfunc(int);
+
+    CREATE FUNCTION abslt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) < abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |<| (
+      PROCEDURE = abslt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION absgt(int, int) RETURNS BOOL AS
+    $$
+      begin return abs($1) > abs($2); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR |>| (
+      PROCEDURE = absgt,
+      LEFTARG = int,
+      RIGHTARG = int);
+
+    CREATE FUNCTION abscmp(int, int) RETURNS int AS
+    $$
+      begin return btint4cmp(abs($1),abs($2)); end;
+    $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+
+    CREATE OPERATOR CLASS abs_int_btree_ops FOR TYPE int4
+      USING btree AS
+      OPERATOR 1 |<|,
+      OPERATOR 3 |=|,
+      OPERATOR 5 |>|,
+      FUNCTION 1 abscmp(int, int);
+
+    drop table if exists atab_old_hash;
+    drop table if exists btab_old_hash;
+    CREATE TABLE atab_old_hash (a int) DISTRIBUTED BY (a);
+    CREATE TABLE btab_old_hash (b int) DISTRIBUTED BY (b);
+
+    INSERT INTO atab_old_hash VALUES (-1), (0), (1);
+    INSERT INTO btab_old_hash VALUES (-1), (0), (1), (2);
+
+    SELECT a, b FROM atab_old_hash, btab_old_hash WHERE a |=| b;
+
+    Expect Redistribute Motions on both side of the join!
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.20775.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.500000" DistinctValues="1.500000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.20752.1.0" Name="|=|" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.20751.1.0"/>
+        <dxl:Commutator Mdid="0.20752.1.0"/>
+        <dxl:HashOpfamily Mdid="0.20754.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.0.0.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.20754.1.0"/>
+          <dxl:Opfamily Mdid="0.20763.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.20775.1.0" Name="atab_old_hash" Rows="3.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.20775.1.0" Name="atab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.20778.1.0" Name="btab_old_hash" Rows="4.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.20778.1.0" Name="btab_old_hash" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="b" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.20778.1.0.0" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.333333" DistinctValues="1.333333">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.20775.1.0" TableName="atab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.20778.1.0" TableName="btab_old_hash">
+            <dxl:Columns>
+              <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.20752.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="12">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000704" Rows="4.800000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="b">
+            <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000561" Rows="4.800000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="b">
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="|=|" OperatorMdid="0.20752.1.0">
+              <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="4.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="b">
+                <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.20754.1.0">
+                <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="4.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="8" Alias="b">
+                  <dxl:Ident ColId="8" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.20778.1.0" TableName="btab_old_hash">
+                <dxl:Columns>
+                  <dxl:Column ColId="8" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000039" Rows="3.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.20754.1.0">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="3.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.20775.1.0" TableName="atab_old_hash">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
+++ b/data/dxl/minidump/JoinOptimizationLevelGreedyNonPartTblInnerJoin.mdp
@@ -2992,7 +2992,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -3108,7 +3108,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -3156,7 +3156,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/JoinOptimizationLevelQueryNonPartTblInnerJoin.mdp
+++ b/data/dxl/minidump/JoinOptimizationLevelQueryNonPartTblInnerJoin.mdp
@@ -3012,7 +3012,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3059,7 +3059,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3107,7 +3107,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -3155,7 +3155,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/JoinTinterval.mdp
+++ b/data/dxl/minidump/JoinTinterval.mdp
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+	<dxl:Comment><![CDATA[
+    CREATE TABLE TINTERVAL_TBL (f1  tinterval);
+    NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+
+    SELECT '' AS five, t1.f1, t2.f1
+       FROM TINTERVAL_TBL t1, TINTERVAL_TBL t2
+       WHERE t1.f1 && t2.f1 and
+             t1.f1 = t2.f1
+       ORDER BY t1.f1, t2.f1;
+    
+	]]>
+	</dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.704.1.0;704.1.0" Name="tinterval" BinaryCoercible="true" SourceTypeId="0.704.1.0" DestinationTypeId="0.704.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.811.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.704.1.0"/>
+        <dxl:RightType Mdid="0.704.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.784.1.0"/>
+        <dxl:Commutator Mdid="0.811.1.0"/>
+        <dxl:InverseOp Mdid="0.812.1.0"/>
+        <dxl:HashOpfamily Mdid="0.7119.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7119.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.2234.1.0"/>
+          <dxl:Opfamily Mdid="0.7119.1.0"/>
+          <dxl:Opfamily Mdid="0.12943.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.20910.1.0" Name="tinterval_tbl" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:GPDBScalarOp Mdid="0.813.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.704.1.0"/>
+        <dxl:RightType Mdid="0.704.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.786.1.0"/>
+        <dxl:Commutator Mdid="0.814.1.0"/>
+        <dxl:InverseOp Mdid="0.816.1.0"/>
+        <dxl:HashOpfamily Mdid="0.0.0.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.0.0.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.2234.1.0"/>
+          <dxl:Opfamily Mdid="0.12943.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="0.20910.1.0" Name="tinterval_tbl" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="f1" Attno="1" Mdid="0.704.1.0" Nullable="true" ColWidth="12">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.574.1.0" Name="&amp;&amp;" ComparisonType="Other" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.704.1.0"/>
+        <dxl:RightType Mdid="0.704.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.265.1.0"/>
+        <dxl:Commutator Mdid="0.574.1.0"/>
+        <dxl:HashOpfamily Mdid="0.0.0.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.0.0.0"/>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.704.1.0" Name="tinterval" IsRedistributable="false" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="12" PassByValue="false">
+        <dxl:LegacyDistrOpfamily Mdid="0.7119.1.0"/>
+        <dxl:EqualityOp Mdid="0.811.1.0"/>
+        <dxl:InequalityOp Mdid="0.812.1.0"/>
+        <dxl:LessThanOp Mdid="0.813.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.815.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.814.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.816.1.0"/>
+        <dxl:ComparisonOp Mdid="0.381.1.0"/>
+        <dxl:ArrayType Mdid="0.1025.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.705.1.0" Name="unknown" IsRedistributable="false" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-2" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.0.0.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.20910.1.0.0" Name="f1" Width="12.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="17" ColName="five" TypeMdid="0.705.1.0"/>
+        <dxl:Ident ColId="1" ColName="f1" TypeMdid="0.704.1.0"/>
+        <dxl:Ident ColId="9" ColName="f1" TypeMdid="0.704.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalLimit>
+        <dxl:SortingColumnList>
+          <dxl:SortingColumn ColId="1" SortOperatorMdid="0.813.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          <dxl:SortingColumn ColId="9" SortOperatorMdid="0.813.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+        </dxl:SortingColumnList>
+        <dxl:LimitCount/>
+        <dxl:LimitOffset/>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="17" Alias="five">
+              <dxl:ConstValue TypeMdid="0.705.1.0" Value="AA=="/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalJoin JoinType="Inner">
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.20910.1.0" TableName="tinterval_tbl">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="f1" TypeMdid="0.704.1.0" ColWidth="12"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="0.20910.1.0" TableName="tinterval_tbl">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="f1" TypeMdid="0.704.1.0" ColWidth="12"/>
+                  <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+            <dxl:And>
+              <dxl:Comparison ComparisonOperator="&amp;&amp;" OperatorMdid="0.574.1.0">
+                <dxl:Ident ColId="1" ColName="f1" TypeMdid="0.704.1.0"/>
+                <dxl:Ident ColId="9" ColName="f1" TypeMdid="0.704.1.0"/>
+              </dxl:Comparison>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.811.1.0">
+                <dxl:Ident ColId="1" ColName="f1" TypeMdid="0.704.1.0"/>
+                <dxl:Ident ColId="9" ColName="f1" TypeMdid="0.704.1.0"/>
+              </dxl:Comparison>
+            </dxl:And>
+          </dxl:LogicalJoin>
+        </dxl:LogicalProject>
+      </dxl:LogicalLimit>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="54">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000771" Rows="1.000000" Width="32"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="16" Alias="five">
+            <dxl:ConstValue TypeMdid="0.705.1.0" Value="AA=="/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="0" Alias="f1">
+            <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="f1">
+            <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000739" Rows="1.000000" Width="24"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="f1">
+              <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="f1">
+              <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.813.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            <dxl:SortingColumn ColId="8" SortOperatorMdid="0.813.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000650" Rows="1.000000" Width="24"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="f1">
+                <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="f1">
+                <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.813.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="8" SortOperatorMdid="0.813.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000650" Rows="1.000000" Width="24"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="f1">
+                  <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="f1">
+                  <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:Comparison ComparisonOperator="&amp;&amp;" OperatorMdid="0.574.1.0">
+                  <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+                  <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+                </dxl:Comparison>
+              </dxl:JoinFilter>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.811.1.0">
+                  <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+                  <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="f1">
+                    <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.7119.1.0">
+                    <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="f1">
+                      <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.704.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.20910.1.0" TableName="tinterval_tbl">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="f1" TypeMdid="0.704.1.0" ColWidth="12"/>
+                      <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+              <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="f1">
+                    <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr Opfamily="0.7119.1.0">
+                    <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="8" Alias="f1">
+                      <dxl:Ident ColId="8" ColName="f1" TypeMdid="0.704.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.20910.1.0" TableName="tinterval_tbl">
+                    <dxl:Columns>
+                      <dxl:Column ColId="8" Attno="1" ColName="f1" TypeMdid="0.704.1.0" ColWidth="12"/>
+                      <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:RedistributeMotion>
+            </dxl:HashJoin>
+          </dxl:Sort>
+        </dxl:GatherMotion>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
+++ b/data/dxl/minidump/Join_OuterChild_DistUniversal.mdp
@@ -319,7 +319,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.16.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="" TypeMdid="0.16.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
+++ b/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
@@ -359,13 +359,13 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:OpExpr>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -412,13 +412,13 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:OpExpr>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="d" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
@@ -496,10 +496,10 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
@@ -485,7 +485,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
@@ -428,10 +428,10 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
@@ -447,10 +447,10 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -346,13 +346,13 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:OpExpr>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
@@ -341,13 +341,13 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                 </dxl:OpExpr>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
@@ -497,7 +497,7 @@ set optimizer_enable_hashjoin = off;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
+++ b/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
@@ -345,7 +345,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>

--- a/data/dxl/minidump/LOJ-With-Agg.mdp
+++ b/data/dxl/minidump/LOJ-With-Agg.mdp
@@ -356,7 +356,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ_bb_mpph.mdp
+++ b/data/dxl/minidump/LOJ_bb_mpph.mdp
@@ -5909,7 +5909,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.1042.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0" TypeModifier="29"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -416,7 +416,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/LeftJoin-With-Coalesce.mdp
+++ b/data/dxl/minidump/LeftJoin-With-Coalesce.mdp
@@ -753,7 +753,7 @@ where coalesce(t2.fname, t3.fname) is not null;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="26" ColName="fname" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -12012,7 +12012,7 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="343" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>

--- a/data/dxl/minidump/MDQA-SameDQAColumn.mdp
+++ b/data/dxl/minidump/MDQA-SameDQAColumn.mdp
@@ -445,7 +445,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/MDQAs-Union.mdp
+++ b/data/dxl/minidump/MDQAs-Union.mdp
@@ -1008,7 +1008,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -1181,7 +1181,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/minidump/MDQAs1.mdp
+++ b/data/dxl/minidump/MDQAs1.mdp
@@ -723,7 +723,7 @@ SQL:
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/minidump/MS-UnionAll-1.mdp
+++ b/data/dxl/minidump/MS-UnionAll-1.mdp
@@ -3156,10 +3156,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="28" ColName="bookname" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="12" ColName="measurename" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/MS-UnionAll-2.mdp
+++ b/data/dxl/minidump/MS-UnionAll-2.mdp
@@ -3156,10 +3156,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="28" ColName="bookname" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="12" ColName="measurename" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/MS-UnionAll-4.mdp
+++ b/data/dxl/minidump/MS-UnionAll-4.mdp
@@ -2919,10 +2919,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="28" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="12" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3140,10 +3140,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="61" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="45" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3361,10 +3361,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="94" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="78" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3582,10 +3582,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="127" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="111" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3803,10 +3803,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="160" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="144" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4024,10 +4024,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="193" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="177" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4245,10 +4245,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="226" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="210" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4466,10 +4466,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="259" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="243" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4687,10 +4687,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="292" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="276" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4908,10 +4908,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="325" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="309" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -5129,10 +5129,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="358" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="342" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -5350,10 +5350,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="391" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="375" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -5571,10 +5571,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="424" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="408" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/MS-UnionAll-5.mdp
+++ b/data/dxl/minidump/MS-UnionAll-5.mdp
@@ -928,10 +928,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="28" ColName="bookname" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="12" ColName="measurename" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/MS-UnionAll-6.mdp
+++ b/data/dxl/minidump/MS-UnionAll-6.mdp
@@ -923,10 +923,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="28" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="12" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -1166,10 +1166,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="61" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="45" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -1409,10 +1409,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="94" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="78" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/MS-UnionAll-7.mdp
+++ b/data/dxl/minidump/MS-UnionAll-7.mdp
@@ -923,10 +923,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="28" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="12" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -1166,10 +1166,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="61" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="45" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -1409,10 +1409,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="94" ColName="bookname" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="78" ColName="measurename" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
+++ b/data/dxl/minidump/ManyTextUnionsInSubquery.mdp
@@ -632,7 +632,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="20" ColName="i" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -965,7 +965,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/MinCardinalityNaryJoin.mdp
+++ b/data/dxl/minidump/MinCardinalityNaryJoin.mdp
@@ -13547,46 +13547,46 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="3" ColName="ccd" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="4" ColName="ctd" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="396" ColName="ptd" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="12" ColName="bgt_c" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.21.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="1" ColName="fl_yr" TypeMdid="0.21.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="102" ColName="hr_su_div" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="103" ColName="hr_div" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="51" ColName="rs_type_lvl_1" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="170" ColName="wi_class" TypeMdid="0.1043.1.0" TypeModifier="259"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="407" ColName="pgm" TypeMdid="0.1043.1.0" TypeModifier="259"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="14" ColName="rs_agm_code" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="146" ColName="ccc_lvl5_d" TypeMdid="0.1043.1.0" TypeModifier="104"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="363" ColName="tfr_type" TypeMdid="0.1043.1.0" TypeModifier="259"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="376" ColName="twea" TypeMdid="0.1043.1.0" TypeModifier="259"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/MissingBoolColStats.mdp
+++ b/data/dxl/minidump/MissingBoolColStats.mdp
@@ -247,7 +247,7 @@ select b from foo_bool group by b;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.16.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.16.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
+++ b/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
@@ -646,10 +646,10 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
-                      <dxl:HashExpr TypeMdid="0.1043.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="2" ColName="k" TypeMdid="0.1043.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/minidump/MultiColumnAggWithDefaultOpfamilies.mdp
+++ b/data/dxl/minidump/MultiColumnAggWithDefaultOpfamilies.mdp
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+	<dxl:Comment><![CDATA[
+		create table foo (x1 int, x2 int);
+		create table bar (x1 int, x2 int)
+
+		select foo.x1, bar.x1 from foo, bar group by (foo.x1, bar.x1);
+	]]>
+	</dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.20901.1.0.0" Name="x1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.20901.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.20901.1.0" Name="foo" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="x1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.20904.1.0" Name="bar" Rows="0.000000" EmptyRelation="true"/>
+      <dxl:Relation Mdid="0.20904.1.0" Name="bar" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="x1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="x2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:HashOpfamily Mdid="0.0.0.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.0.0.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.12738.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.20904.1.0.0" Name="x1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="x1" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="x1" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="1"/>
+          <dxl:GroupingColumn ColId="10"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList/>
+        <dxl:LogicalJoin JoinType="Inner">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.20901.1.0" TableName="foo">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="x2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.20904.1.0" TableName="bar">
+              <dxl:Columns>
+                <dxl:Column ColId="10" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="11" Attno="2" ColName="x2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+        </dxl:LogicalJoin>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="12">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.319073" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="x1">
+            <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="x1">
+            <dxl:Ident ColId="9" ColName="x1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.319043" Rows="1.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="0"/>
+            <dxl:GroupingColumn ColId="9"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="x1">
+              <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="x1">
+              <dxl:Ident ColId="9" ColName="x1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.319033" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="x1">
+                <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="x1">
+                <dxl:Ident ColId="9" ColName="x1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.319033" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="x1">
+                  <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="x1">
+                  <dxl:Ident ColId="9" ColName="x1" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000243" Rows="3.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="x1">
+                    <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="x1">
+                      <dxl:Ident ColId="0" ColName="x1" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="0.20901.1.0" TableName="foo">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="x1">
+                    <dxl:Ident ColId="9" ColName="x1" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="0.20904.1.0" TableName="bar">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="x1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:NestedLoopJoin>
+          </dxl:Sort>
+        </dxl:Aggregate>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp
+++ b/data/dxl/minidump/MultipleUpdateWithJoinOnDistCol.mdp
@@ -378,7 +378,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/NLJ-InEqDistCol-EqNonDistCol-Redistribute.mdp
+++ b/data/dxl/minidump/NLJ-InEqDistCol-EqNonDistCol-Redistribute.mdp
@@ -378,7 +378,7 @@ explain select * from a1,b1 where a1.a != b1.a and a1.a = b1.b;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
+++ b/data/dxl/minidump/NOT-IN-NotNullBoth.mdp
@@ -326,7 +326,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="t2" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/data/dxl/minidump/Nested-Setops-2.mdp
@@ -697,7 +697,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.1043.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="13" ColName="name" TypeMdid="0.1043.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -848,7 +848,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.1043.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="35" ColName="name" TypeMdid="0.1043.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -1000,7 +1000,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.1043.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="57" ColName="name" TypeMdid="0.1043.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/NoHashAggWithoutPrelimFunc.mdp
+++ b/data/dxl/minidump/NoHashAggWithoutPrelimFunc.mdp
@@ -2050,7 +2050,7 @@ select product_id,concat('#attribute_'||attribute_id::varchar||':'||attribute) a
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="product_id" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/NoMissingStatsAskingForSystemColFOJ.mdp
+++ b/data/dxl/minidump/NoMissingStatsAskingForSystemColFOJ.mdp
@@ -907,7 +907,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -985,7 +985,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/minidump/NoRedistributeOnAppend.mdp
+++ b/data/dxl/minidump/NoRedistributeOnAppend.mdp
@@ -543,7 +543,7 @@ GROUP BY b;
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="48" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -656,7 +656,7 @@ GROUP BY b;
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="58" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -823,7 +823,7 @@ GROUP BY b;
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="77" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/minidump/OneSegmentGather.mdp
+++ b/data/dxl/minidump/OneSegmentGather.mdp
@@ -533,7 +533,7 @@ WHERE filter_col = 'TEST'
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="join_col" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -580,7 +580,7 @@ WHERE filter_col = 'TEST'
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="3" ColName="join_col" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
+++ b/data/dxl/minidump/PartTbl-AggWithExistentialSubquery.mdp
@@ -584,25 +584,25 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.1700.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1700.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.1042.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.27.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.26.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.16.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="24" ColName="ColRef_0024" TypeMdid="0.16.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -773,7 +773,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.1042.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="2" ColName="e" TypeMdid="0.1042.1.0" TypeModifier="5"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>
@@ -893,7 +893,7 @@
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
                               <dxl:HashExprList>
-                                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="13" ColName="c" TypeMdid="0.1042.1.0" TypeModifier="5"/>
                                 </dxl:HashExpr>
                               </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
+++ b/data/dxl/minidump/PartTbl-MultiWayJoin.mdp
@@ -485,7 +485,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -525,7 +525,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -583,7 +583,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -623,7 +623,7 @@ explain select count(*) from r_p, s c, s d, s e where r_p.a = c.c and r_p.a = d.
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-MultipleEqPredicates.mdp
+++ b/data/dxl/minidump/PartTbl-MultipleEqPredicates.mdp
@@ -5141,7 +5141,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="72" ColName="quarter_desc" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -5465,7 +5465,7 @@
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
                               <dxl:HashExprList>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="34" ColName="month_number" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
                               </dxl:HashExprList>
@@ -5601,7 +5601,7 @@
                                         <dxl:Filter/>
                                         <dxl:SortingColumnList/>
                                         <dxl:HashExprList>
-                                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                                          <dxl:HashExpr>
                                             <dxl:Ident ColId="49" ColName="?column?" TypeMdid="0.23.1.0"/>
                                           </dxl:HashExpr>
                                         </dxl:HashExprList>
@@ -5678,7 +5678,7 @@
                                       <dxl:Filter/>
                                       <dxl:SortingColumnList/>
                                       <dxl:HashExprList>
-                                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                                        <dxl:HashExpr>
                                           <dxl:Ident ColId="53" ColName="?column?" TypeMdid="0.23.1.0"/>
                                         </dxl:HashExpr>
                                       </dxl:HashExprList>
@@ -5721,7 +5721,7 @@
                                   <dxl:Filter/>
                                   <dxl:SortingColumnList/>
                                   <dxl:HashExprList>
-                                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                                    <dxl:HashExpr>
                                       <dxl:Ident ColId="55" ColName="?column?" TypeMdid="0.23.1.0"/>
                                     </dxl:HashExpr>
                                   </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
+++ b/data/dxl/minidump/PartTbl-WindowFuncNoDisjunctPredPushDown.mdp
@@ -418,10 +418,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1082.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="12" ColName="date" TypeMdid="0.1082.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="13" ColName="region" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
+++ b/data/dxl/minidump/PartTbl-WindowFuncPartialPredPushDown.mdp
@@ -467,7 +467,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1082.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
+++ b/data/dxl/minidump/PartTbl-WindowFuncPredPushDown.mdp
@@ -453,10 +453,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1082.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="13" ColName="date" TypeMdid="0.1082.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="15" ColName="region" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
+++ b/data/dxl/minidump/PartTbl-WindowFuncSinglePredPushDown.mdp
@@ -399,10 +399,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1082.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="12" ColName="date" TypeMdid="0.1082.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="13" ColName="region" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/ProjectCountStarWithOuterRefs.mdp
+++ b/data/dxl/minidump/ProjectCountStarWithOuterRefs.mdp
@@ -825,7 +825,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -882,7 +882,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>

--- a/data/dxl/minidump/Push-Subplan-Below-Union.mdp
+++ b/data/dxl/minidump/Push-Subplan-Below-Union.mdp
@@ -978,25 +978,25 @@ union
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="35" ColName="population" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="36" ColName="num_cities" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.25.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="37" ColName="district" TypeMdid="0.25.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.1042.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="38" ColName="countrycode" TypeMdid="0.1042.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.25.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="39" ColName="name" TypeMdid="0.25.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.25.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="93" ColName="name" TypeMdid="0.25.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="96" ColName="population" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -433,10 +433,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="17" ColName="max" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -574,7 +574,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>

--- a/data/dxl/minidump/PushGbBelowNaryUnion-2.mdp
+++ b/data/dxl/minidump/PushGbBelowNaryUnion-2.mdp
@@ -1727,7 +1727,7 @@ select id from uav1 union select val from uav2 union select id from uav4;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/PushGbBelowUnion.mdp
+++ b/data/dxl/minidump/PushGbBelowUnion.mdp
@@ -746,7 +746,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="9" ColName="one" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -822,7 +822,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="19" ColName="one" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/PushGbBelowUnionAll.mdp
+++ b/data/dxl/minidump/PushGbBelowUnionAll.mdp
@@ -761,7 +761,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="10" ColName="four" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -863,7 +863,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="22" ColName="three" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -426,7 +426,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/QueryMismatchedDistribution.mdp
+++ b/data/dxl/minidump/QueryMismatchedDistribution.mdp
@@ -324,7 +324,7 @@ explain select i, count(j) from pt2 group by i;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
+++ b/data/dxl/minidump/ReplicatedJoinHashDistributedTable.mdp
@@ -1499,7 +1499,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1546,7 +1546,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
+++ b/data/dxl/minidump/ReplicatedJoinRandomDistributedTable.mdp
@@ -1101,7 +1101,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1148,7 +1148,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
+++ b/data/dxl/minidump/ReplicatedLOJHashDistributedTable.mdp
@@ -1499,7 +1499,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1546,7 +1546,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
+++ b/data/dxl/minidump/ReplicatedLOJRandomDistributedTable.mdp
@@ -1101,7 +1101,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1148,7 +1148,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/ReplicatedTableCTE.mdp
+++ b/data/dxl/minidump/ReplicatedTableCTE.mdp
@@ -1505,7 +1505,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -1552,7 +1552,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/Rollup.mdp
+++ b/data/dxl/minidump/Rollup.mdp
@@ -3066,10 +3066,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="49" ColName="i_item_id" TypeMdid="0.1042.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="50" ColName="ca_county" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -3177,7 +3177,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.1042.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="99" ColName="i_item_id" TypeMdid="0.1042.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
+++ b/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
@@ -1499,7 +1499,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/SelfJoinDampedPredJoinCardinality.mdp
+++ b/data/dxl/minidump/SelfJoinDampedPredJoinCardinality.mdp
@@ -3693,10 +3693,10 @@ where foo.a=bar.a and bar.b=jazz.b and foo.c=jazz.c;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -3814,10 +3814,10 @@ where foo.a=bar.a and bar.b=jazz.b and foo.c=jazz.c;
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="22" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/SemiJoin2InnerJoin.mdp
+++ b/data/dxl/minidump/SemiJoin2InnerJoin.mdp
@@ -612,10 +612,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.27.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/SixWayDPv2.mdp
+++ b/data/dxl/minidump/SixWayDPv2.mdp
@@ -664,7 +664,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="37" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -733,7 +733,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -790,7 +790,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -835,7 +835,7 @@
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>

--- a/data/dxl/minidump/SortOverStreamAgg.mdp
+++ b/data/dxl/minidump/SortOverStreamAgg.mdp
@@ -2170,7 +2170,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.1700.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="19" ColName="year_id" TypeMdid="0.1700.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/SpoolShouldInvalidateUnresolvedDynamicScans.mdp
+++ b/data/dxl/minidump/SpoolShouldInvalidateUnresolvedDynamicScans.mdp
@@ -826,7 +826,7 @@ And instead have a plan like
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="19" ColName="d" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
+++ b/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
@@ -540,10 +540,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.27.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/SubqEnforceSubplan.mdp
+++ b/data/dxl/minidump/SubqEnforceSubplan.mdp
@@ -318,7 +318,7 @@ explain select * from foo,bar where b = (select min(b) from bar where a = b);
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="25" ColName="ColRef_0025" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -802,10 +802,10 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.27.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -865,10 +865,10 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.27.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -1005,10 +1005,10 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.27.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                     </dxl:HashExpr>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/Switch-With-Subquery.mdp
+++ b/data/dxl/minidump/Switch-With-Subquery.mdp
@@ -486,7 +486,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -548,7 +548,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="10" ColName="j" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
+++ b/data/dxl/minidump/TPCH-Partitioned-256GB.mdp
@@ -4021,7 +4021,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="32" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
@@ -4194,7 +4194,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="31" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/TPCH-Q5.mdp
+++ b/data/dxl/minidump/TPCH-Q5.mdp
@@ -6565,7 +6565,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -6716,7 +6716,7 @@
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -6758,7 +6758,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
+++ b/data/dxl/minidump/ThreeStageAgg-DistinctOnComputedCol.mdp
@@ -339,7 +339,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
+++ b/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
@@ -329,7 +329,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
+++ b/data/dxl/minidump/ThreeStageAgg-DistinctOnSameNonDistrCol.mdp
@@ -322,7 +322,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg-GbMultipleCol-DistinctOnDistrCol.mdp
+++ b/data/dxl/minidump/ThreeStageAgg-GbMultipleCol-DistinctOnDistrCol.mdp
@@ -341,10 +341,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctComputedCol.mdp
+++ b/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctComputedCol.mdp
@@ -306,7 +306,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctNonDistrCol.mdp
+++ b/data/dxl/minidump/ThreeStageAgg-ScalarAgg-DistinctNonDistrCol.mdp
@@ -304,7 +304,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/ThreeStageAgg.mdp
+++ b/data/dxl/minidump/ThreeStageAgg.mdp
@@ -329,7 +329,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -20624,13 +20624,13 @@ select  i_item_id
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="i_item_id" TypeMdid="0.1042.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="4" ColName="i_item_desc" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1700.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="5" ColName="i_current_price" TypeMdid="0.1700.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -20694,10 +20694,10 @@ select  i_item_id
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="30" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="30" ColName="inv_item_sk" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -20937,10 +20937,10 @@ select  i_item_id
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="0" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="90" ColName="cs_item_sk" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -15061,10 +15061,10 @@ with results as
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.1042.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="89" ColName="s_state" TypeMdid="0.1042.1.0"/>
                         </dxl:HashExpr>
-                        <dxl:HashExpr TypeMdid="0.1043.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="88" ColName="s_county" TypeMdid="0.1043.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -15391,7 +15391,7 @@ with results as
                                             <dxl:Filter/>
                                             <dxl:SortingColumnList/>
                                             <dxl:HashExprList>
-                                              <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                              <dxl:HashExpr>
                                                 <dxl:Ident ColId="155" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                               </dxl:HashExpr>
                                             </dxl:HashExprList>
@@ -15720,10 +15720,10 @@ with results as
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
-                        <dxl:HashExpr TypeMdid="0.1042.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="1477" ColName="?column?" TypeMdid="0.1042.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -15840,22 +15840,22 @@ with results as
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
                               <dxl:HashExprList>
-                                <dxl:HashExpr TypeMdid="0.1700.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="842" ColName="sum" TypeMdid="0.1700.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="843" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.1043.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="844" ColName="s_county" TypeMdid="0.1043.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="845" ColName="g_state" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="846" ColName="g_county" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="847" ColName="lochierarchy" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
                               </dxl:HashExprList>
@@ -16025,7 +16025,7 @@ with results as
                                         <dxl:Filter/>
                                         <dxl:SortingColumnList/>
                                         <dxl:HashExprList>
-                                          <dxl:HashExpr TypeMdid="0.1042.1.0">
+                                          <dxl:HashExpr>
                                             <dxl:Ident ColId="1053" ColName="s_state" TypeMdid="0.1042.1.0"/>
                                           </dxl:HashExpr>
                                         </dxl:HashExprList>

--- a/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
+++ b/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
@@ -1009,7 +1009,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="19" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -1053,7 +1053,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="28" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/UDA-AnyArray.mdp
+++ b/data/dxl/minidump/UDA-AnyArray.mdp
@@ -340,7 +340,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
+++ b/data/dxl/minidump/Union-NOT-Plus-OR-Constraint.mdp
@@ -340,7 +340,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="2" ColName="f3" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -414,7 +414,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.21.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="0" ColName="f1" TypeMdid="0.21.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
@@ -474,7 +474,7 @@ explain SELECT a.f3 FROM tb a JOIN tb b ON a.f1 = b.f1 AND NOT ( a.f2 = 0 OR a.f
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.21.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="10" ColName="f1" TypeMdid="0.21.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/minidump/Union-On-HJNs.mdp
+++ b/data/dxl/minidump/Union-On-HJNs.mdp
@@ -881,7 +881,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -965,7 +965,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -1121,7 +1121,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -1214,7 +1214,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -2255,7 +2255,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -2339,7 +2339,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -2495,7 +2495,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -2588,7 +2588,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/minidump/Union-Over-UnionAll.mdp
+++ b/data/dxl/minidump/Union-Over-UnionAll.mdp
@@ -354,7 +354,7 @@ select a from foo_hashed union all select b from foo_hashed union select 1 from 
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/UnionAll.mdp
+++ b/data/dxl/minidump/UnionAll.mdp
@@ -8937,7 +8937,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="3" ColName="cs_bill_customer_sk" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -445,7 +445,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="13" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -536,7 +536,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="27" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/UnionWithOuterRefs.mdp
+++ b/data/dxl/minidump/UnionWithOuterRefs.mdp
@@ -849,7 +849,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="19" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateCardinalityAssert.mdp
+++ b/data/dxl/minidump/UpdateCardinalityAssert.mdp
@@ -351,7 +351,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
+++ b/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
@@ -399,7 +399,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateDistrKey.mdp
+++ b/data/dxl/minidump/UpdateDistrKey.mdp
@@ -346,7 +346,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.700.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.700.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -333,7 +333,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateNoCardinalityAssert.mdp
+++ b/data/dxl/minidump/UpdateNoCardinalityAssert.mdp
@@ -467,7 +467,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateNotNullCols.mdp
+++ b/data/dxl/minidump/UpdateNotNullCols.mdp
@@ -404,7 +404,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdatePartTable.mdp
+++ b/data/dxl/minidump/UpdatePartTable.mdp
@@ -333,7 +333,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateUniqueConstraint.mdp
+++ b/data/dxl/minidump/UpdateUniqueConstraint.mdp
@@ -299,7 +299,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="0" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateVolatileFunction.mdp
+++ b/data/dxl/minidump/UpdateVolatileFunction.mdp
@@ -487,7 +487,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateWithOids.mdp
+++ b/data/dxl/minidump/UpdateWithOids.mdp
@@ -291,7 +291,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdateZeroRows.mdp
+++ b/data/dxl/minidump/UpdateZeroRows.mdp
@@ -496,7 +496,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="x" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdatingDistributionColumn.mdp
+++ b/data/dxl/minidump/UpdatingDistributionColumn.mdp
@@ -346,7 +346,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.1043.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.1043.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/UpdatingMultipleColumn.mdp
+++ b/data/dxl/minidump/UpdatingMultipleColumn.mdp
@@ -660,7 +660,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/VolatileFunctionsBelowScalarAgg.mdp
+++ b/data/dxl/minidump/VolatileFunctionsBelowScalarAgg.mdp
@@ -294,7 +294,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.25.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="3" ColName="f1" TypeMdid="0.25.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
+++ b/data/dxl/minidump/WinFunc-Redistribute-Sort-CTE-Producer.mdp
@@ -534,7 +534,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -888,7 +888,7 @@ with v as (select * from t1) select  row_number() over(partition by v1.b), rank(
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="52" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>

--- a/data/dxl/minidump/retail_28.mdp
+++ b/data/dxl/minidump/retail_28.mdp
@@ -4376,10 +4376,10 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.25.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="35" ColName="ship_month" TypeMdid="0.25.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="6" ColName="item_shipment_status_code" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/minidump/window-count-gpdb6.mdp
+++ b/data/dxl/minidump/window-count-gpdb6.mdp
@@ -340,7 +340,7 @@ explain select b,c, count(c) over (partition by b) from (select * from foo) s;
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/parse_tests/q20-DistinctFrom-HJ.xml
+++ b/data/dxl/parse_tests/q20-DistinctFrom-HJ.xml
@@ -61,7 +61,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="5" ColName="b" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/parse_tests/q44-Window.xml
+++ b/data/dxl/parse_tests/q44-Window.xml
@@ -87,7 +87,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/parse_tests/q45-WindowWithFraming.xml
+++ b/data/dxl/parse_tests/q45-WindowWithFraming.xml
@@ -76,7 +76,7 @@
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
-              <dxl:HashExpr TypeMdid="0.23.1.0">
+              <dxl:HashExpr>
                 <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>

--- a/data/dxl/parse_tests/q5-HJ-RM.xml
+++ b/data/dxl/parse_tests/q5-HJ-RM.xml
@@ -64,7 +64,7 @@
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:HashExprList>
-            <dxl:HashExpr TypeMdid="0.23.1.0">
+            <dxl:HashExpr>
               <dxl:Ident ColId="2" ColName="B" TypeMdid="0.23.1.0"/>
             </dxl:HashExpr>
           </dxl:HashExprList>

--- a/data/dxl/parse_tests/q57-DMLDelete.xml
+++ b/data/dxl/parse_tests/q57-DMLDelete.xml
@@ -49,7 +49,7 @@
         <dxl:Filter/>
         <dxl:SortingColumnList/>
         <dxl:HashExprList>
-          <dxl:HashExpr TypeMdid="0.27.1.0">
+          <dxl:HashExpr>
             <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
           </dxl:HashExpr>
         </dxl:HashExprList>

--- a/data/dxl/tpch/q1-partitioned.mdp
+++ b/data/dxl/tpch/q1-partitioned.mdp
@@ -701,10 +701,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="8" ColName="l_returnflag" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="l_linestatus" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/tpch/q1.mdp
+++ b/data/dxl/tpch/q1.mdp
@@ -1661,10 +1661,10 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="8" ColName="l_returnflag" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="9" ColName="l_linestatus" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/tpch/q10.mdp
+++ b/data/dxl/tpch/q10.mdp
@@ -3226,7 +3226,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/tpch/q12.mdp
+++ b/data/dxl/tpch/q12.mdp
@@ -2193,7 +2193,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="30" ColName="l_shipmode" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/tpch/q13.mdp
+++ b/data/dxl/tpch/q13.mdp
@@ -1481,7 +1481,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.20.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="31" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -1579,7 +1579,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/tpch/q14.mdp
+++ b/data/dxl/tpch/q14.mdp
@@ -2234,7 +2234,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="1" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>

--- a/data/dxl/tpch/q15.mdp
+++ b/data/dxl/tpch/q15.mdp
@@ -2239,7 +2239,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="40" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -2408,7 +2408,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="16" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -2468,7 +2468,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="16" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/tpch/q16.mdp
+++ b/data/dxl/tpch/q16.mdp
@@ -2153,13 +2153,13 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="15" ColName="p_brand" TypeMdid="0.1042.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.1043.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="16" ColName="p_type" TypeMdid="0.1043.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="17" ColName="p_size" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/tpch/q17.mdp
+++ b/data/dxl/tpch/q17.mdp
@@ -2200,7 +2200,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="40" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>

--- a/data/dxl/tpch/q18.mdp
+++ b/data/dxl/tpch/q18.mdp
@@ -3007,7 +3007,7 @@
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
-                      <dxl:HashExpr TypeMdid="0.23.1.0">
+                      <dxl:HashExpr>
                         <dxl:Ident ColId="15" ColName="o_orderkey" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
@@ -3094,7 +3094,7 @@
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="16" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/tpch/q2.mdp
+++ b/data/dxl/tpch/q2.mdp
@@ -3719,7 +3719,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="0" ColName="p_partkey" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>
@@ -4239,7 +4239,7 @@
                                 <dxl:Filter/>
                                 <dxl:SortingColumnList/>
                                 <dxl:HashExprList>
-                                  <dxl:HashExpr TypeMdid="0.23.1.0">
+                                  <dxl:HashExpr>
                                     <dxl:Ident ColId="31" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                                   </dxl:HashExpr>
                                 </dxl:HashExprList>

--- a/data/dxl/tpch/q20.mdp
+++ b/data/dxl/tpch/q20.mdp
@@ -3570,7 +3570,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.23.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="3" ColName="s_nationkey" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -3647,7 +3647,7 @@
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
-                    <dxl:HashExpr TypeMdid="0.23.1.0">
+                    <dxl:HashExpr>
                       <dxl:Ident ColId="26" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
@@ -3792,7 +3792,7 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
-                        <dxl:HashExpr TypeMdid="0.23.1.0">
+                        <dxl:HashExpr>
                           <dxl:Ident ColId="54" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
@@ -3873,10 +3873,10 @@
                               <dxl:Filter/>
                               <dxl:SortingColumnList/>
                               <dxl:HashExprList>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="54" ColName="l_partkey" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
-                                <dxl:HashExpr TypeMdid="0.23.1.0">
+                                <dxl:HashExpr>
                                   <dxl:Ident ColId="55" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                                 </dxl:HashExpr>
                               </dxl:HashExprList>

--- a/data/dxl/tpch/q21.mdp
+++ b/data/dxl/tpch/q21.mdp
@@ -3125,7 +3125,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="1" ColName="s_name" TypeMdid="0.1042.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/tpch/q22.mdp
+++ b/data/dxl/tpch/q22.mdp
@@ -1620,7 +1620,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.25.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="47" ColName="cntrycode" TypeMdid="0.25.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
@@ -1764,7 +1764,7 @@
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
-                          <dxl:HashExpr TypeMdid="0.23.1.0">
+                          <dxl:HashExpr>
                             <dxl:Ident ColId="32" ColName="o_custkey" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>

--- a/data/dxl/tpch/q4.mdp
+++ b/data/dxl/tpch/q4.mdp
@@ -2140,7 +2140,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="5" ColName="o_orderpriority" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/tpch/q5.mdp
+++ b/data/dxl/tpch/q5.mdp
@@ -3667,7 +3667,7 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/tpch/q7.mdp
+++ b/data/dxl/tpch/q7.mdp
@@ -3680,13 +3680,13 @@
               <dxl:Filter/>
               <dxl:SortingColumnList/>
               <dxl:HashExprList>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="69" ColName="n_name" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.1042.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="80" ColName="n_name" TypeMdid="0.1042.1.0"/>
                 </dxl:HashExpr>
-                <dxl:HashExpr TypeMdid="0.701.1.0">
+                <dxl:HashExpr>
                   <dxl:Ident ColId="90" ColName="l_year" TypeMdid="0.701.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>

--- a/data/dxl/tpch/q8.mdp
+++ b/data/dxl/tpch/q8.mdp
@@ -4430,7 +4430,7 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.701.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="116" ColName="o_year" TypeMdid="0.701.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>

--- a/data/dxl/tpch/q9.mdp
+++ b/data/dxl/tpch/q9.mdp
@@ -4226,10 +4226,10 @@
                 <dxl:Filter/>
                 <dxl:SortingColumnList/>
                 <dxl:HashExprList>
-                  <dxl:HashExpr TypeMdid="0.1042.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="82" ColName="n_name" TypeMdid="0.1042.1.0"/>
                   </dxl:HashExpr>
-                  <dxl:HashExpr TypeMdid="0.701.1.0">
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="92" ColName="o_year" TypeMdid="0.701.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
@@ -4431,7 +4431,7 @@
                             <dxl:Filter/>
                             <dxl:SortingColumnList/>
                             <dxl:HashExprList>
-                              <dxl:HashExpr TypeMdid="0.23.1.0">
+                              <dxl:HashExpr>
                                 <dxl:Ident ColId="32" ColName="l_suppkey" TypeMdid="0.23.1.0"/>
                               </dxl:HashExpr>
                             </dxl:HashExprList>
@@ -4696,7 +4696,7 @@
                           <dxl:Filter/>
                           <dxl:SortingColumnList/>
                           <dxl:HashExprList>
-                            <dxl:HashExpr TypeMdid="0.23.1.0">
+                            <dxl:HashExpr>
                               <dxl:Ident ColId="54" ColName="ps_suppkey" TypeMdid="0.23.1.0"/>
                             </dxl:HashExpr>
                           </dxl:HashExprList>

--- a/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
+++ b/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
@@ -35,6 +35,8 @@ namespace gpopt
 
 			// array of distribution expressions
 			CExpressionArray *m_pdrgpexpr;
+
+			IMdIdArray *m_opfamilies;
 			
 			// are NULLS consistently distributed
 			BOOL m_fNullsColocated;
@@ -78,14 +80,31 @@ namespace gpopt
 		public:
 		
 			// ctor
-			CDistributionSpecHashed(CExpressionArray *pdrgpexpr, BOOL fNullsColocated);
+			CDistributionSpecHashed(CExpressionArray *pdrgpexpr,
+									BOOL fNullsColocated,
+									IMdIdArray *opfamilies=NULL);
 			
 			// ctor
-			CDistributionSpecHashed(CExpressionArray *pdrgpexpr, BOOL fNullsColocated, CDistributionSpecHashed *pdshashedEquiv);
+			CDistributionSpecHashed(CExpressionArray *pdrgpexpr,
+									BOOL fNullsColocated,
+									CDistributionSpecHashed *pdshashedEquiv,
+									IMdIdArray *opfamilies=NULL
+									);
+
+			static CDistributionSpecHashed* MakeHashedDistrSpec
+				(
+				CMemoryPool *mp,
+				CExpressionArray *pdrgpexpr,
+				BOOL fNullsColocated,
+				CDistributionSpecHashed *pdshashedEquiv,
+				IMdIdArray *opfamilies
+				);
 
 			// dtor
 			virtual 
 			~CDistributionSpecHashed();
+
+			void PopulateDefaultOpfamilies();
 			
 			// distribution type accessor
 			virtual 
@@ -116,6 +135,11 @@ namespace gpopt
 			CDistributionSpecHashed *PdshashedEquiv() const
 			{
 				return m_pdshashedEquiv;
+			}
+
+			IMdIdArray *Opfamilies() const
+			{
+				return m_opfamilies;
 			}
 
 			// columns used by distribution expressions

--- a/libgpopt/include/gpopt/base/CUtils.h
+++ b/libgpopt/include/gpopt/base/CUtils.h
@@ -1104,6 +1104,12 @@ namespace gpopt
 			BOOL Equals(const CExpressionArrays *exprs_arr, const CExpressionArrays *other_exprs_arr);
 
 			static
+			BOOL Equals(const IMdIdArray *mdids, const IMdIdArray *other_mdids);
+
+			static
+			BOOL Equals(const IMDId *mdid, const IMDId *other_mdid);
+
+			static
 			BOOL CanRemoveInferredPredicates(COperator::EOperatorId op_id);
 
 			static

--- a/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -65,6 +65,9 @@ namespace gpopt
 
 			// distribution columns for hash distribution
 			CColumnDescriptorArray *m_pdrgpcoldescDist;
+
+			// Opfamily used for hash distribution
+			IMdIdArray *m_distr_opfamilies;
 						
 			// if true, we need to consider a hash distributed table as random
 			// there are two possible scenarios:
@@ -116,7 +119,7 @@ namespace gpopt
 			void AddColumn(CColumnDescriptor *);
 			
 			// add the column at the specified position to the list of distribution columns
-			void AddDistributionColumn(ULONG ulPos);
+			void AddDistributionColumn(ULONG ulPos, IMDId *opfamily);
 
 			// add the column at the specified position to the list of partition columns
 			void AddPartitionColumn(ULONG ulPos);
@@ -159,6 +162,12 @@ namespace gpopt
 			const CColumnDescriptorArray *PdrgpcoldescDist() const
 			{
 				return m_pdrgpcoldescDist;
+			}
+
+			// distribution column descriptors accessor
+			const IMdIdArray *DistrOpfamilies() const
+			{
+				return m_distr_opfamilies;
 			}
 			
 			// partition column indexes accessor

--- a/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalFullMergeJoin.h
@@ -28,7 +28,8 @@ namespace gpopt
 			explicit
 			CPhysicalFullMergeJoin(CMemoryPool *mp,
 								   CExpressionArray *outer_merge_clauses,
-								   CExpressionArray *inner_merge_clauses);
+								   CExpressionArray *inner_merge_clauses,
+								   IMdIdArray *hash_opfamilies = NULL);
 
 			// dtor
 			virtual

--- a/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalHashJoin.h
@@ -42,6 +42,9 @@ namespace gpopt
 			// that are extracted from the hashing condition
 			CExpressionArray *m_pdrgpexprInnerKeys;
 
+			// Hash op families of the operators used in the join conditions
+			IMdIdArray *m_hash_opfamilies;
+
 			// array redistribute request sent to the first hash join child
 			CDistributionSpecArray *m_pdrgpdsRedistributeRequests;
 
@@ -123,7 +126,8 @@ namespace gpopt
 				(
 				CMemoryPool *mp,
 				CExpressionArray *pdrgpexprOuterKeys,
-				CExpressionArray *pdrgpexprInnerKeys
+				CExpressionArray *pdrgpexprInnerKeys,
+				IMdIdArray *hash_opfamilies = NULL
 				);
 
 			// dtor

--- a/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalInnerHashJoin.h
@@ -52,7 +52,8 @@ namespace gpopt
 				(
 				CMemoryPool *mp,
 				CExpressionArray *pdrgpexprOuterKeys,
-				CExpressionArray *pdrgpexprInnerKeys
+				CExpressionArray *pdrgpexprInnerKeys,
+				IMdIdArray *hash_opfamilies = NULL
 				);
 
 			// dtor

--- a/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoin.h
@@ -40,7 +40,8 @@ namespace gpopt
 				(
 				CMemoryPool *mp,
 				CExpressionArray *pdrgpexprOuterKeys,
-				CExpressionArray *pdrgpexprInnerKeys
+				CExpressionArray *pdrgpexprInnerKeys,
+				IMdIdArray *hash_opfamilies = NULL
 				);
 
 			// dtor

--- a/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalLeftAntiSemiHashJoinNotIn.h
@@ -36,7 +36,7 @@ namespace gpopt
 		public:
 
 			// ctor
-			CPhysicalLeftAntiSemiHashJoinNotIn(CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys, CExpressionArray *pdrgpexprInnerKeys);
+			CPhysicalLeftAntiSemiHashJoinNotIn(CMemoryPool *mp, CExpressionArray *pdrgpexprOuterKeys, CExpressionArray *pdrgpexprInnerKeys, IMdIdArray *hash_opfamilies = NULL);
 
 			// ident accessors
 			virtual

--- a/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalLeftOuterHashJoin.h
@@ -40,7 +40,8 @@ namespace gpopt
 				(
 				CMemoryPool *mp,
 				CExpressionArray *pdrgpexprOuterKeys,
-				CExpressionArray *pdrgpexprInnerKeys
+				CExpressionArray *pdrgpexprInnerKeys,
+				IMdIdArray *hash_opfamilies = NULL
 				);
 
 			// dtor

--- a/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalLeftSemiHashJoin.h
@@ -40,7 +40,8 @@ namespace gpopt
 				(
 				CMemoryPool *mp,
 				CExpressionArray *pdrgpexprOuterKeys,
-				CExpressionArray *pdrgpexprInnerKeys
+				CExpressionArray *pdrgpexprInnerKeys,
+				IMdIdArray *hash_opfamilies = NULL
 				);
 
 			// dtor

--- a/libgpopt/include/gpopt/operators/CPhysicalUnionAll.h
+++ b/libgpopt/include/gpopt/operators/CPhysicalUnionAll.h
@@ -31,7 +31,9 @@ namespace gpopt
 			CColRefSetArray *m_pdrgpcrsInput;
 
 			// array of child hashed distributions -- used locally for distribution derivation
-			CDistributionSpecArray *const m_pdrgpds;
+			CDistributionSpecArray *m_pdrgpds;
+
+			void PopulateDistrSpecs(CMemoryPool *mp, CColRefArray *pdrgpcrOutput, CColRef2dArray *pdrgpdrgpcrInput);
 
 			// map given array of scalar ident expressions to positions of UnionAll input columns in the given child;
 			ULongPtrArray *PdrgpulMap(CMemoryPool *mp, CExpressionArray *pdrgpexpr, ULONG child_index) const;

--- a/libgpopt/include/gpopt/search/CGroup.h
+++ b/libgpopt/include/gpopt/search/CGroup.h
@@ -190,6 +190,9 @@ namespace gpopt
 			// join keys for inner child (only for scalar groups) (used by hash & merge joins)
 			CExpressionArray *m_pdrgpexprJoinKeysInner;
 
+			// join op families (only for scalar groups) (used by hash & merge joins)
+			IMdIdArray *m_join_opfamilies;
+
 			// list of group expressions
 			CList<CGroupExpression> m_listGExprs;
 
@@ -272,7 +275,9 @@ namespace gpopt
 			void SetState(EState estNewState);
 
 			// set hash join keys
-			void SetJoinKeys(CExpressionArray *pdrgpexprOuter, CExpressionArray *pdrgpexprInner);
+			void SetJoinKeys(CExpressionArray *pdrgpexprOuter,
+							 CExpressionArray *pdrgpexprInner,
+							 IMdIdArray * join_opfamilies);
 
 			// insert new group expression
 			void Insert(CGroupExpression *pgexpr);
@@ -400,6 +405,12 @@ namespace gpopt
 			CExpressionArray *PdrgpexprJoinKeysInner() const
 			{
 				return m_pdrgpexprJoinKeysInner;
+			}
+
+			// join op families
+			IMdIdArray *JoinOpfamilies() const
+			{
+				return m_join_opfamilies;
 			}
 
 			// return cached scalar expression

--- a/libgpopt/include/gpopt/search/CGroupProxy.h
+++ b/libgpopt/include/gpopt/search/CGroupProxy.h
@@ -71,10 +71,11 @@ namespace gpopt
 			void SetJoinKeys
 				(
 				CExpressionArray *pdrgpexprOuter,
-				CExpressionArray *pdrgpexprInner
+				CExpressionArray *pdrgpexprInner,
+				IMdIdArray *join_opfamilies
 				)
 			{
-				m_pgroup->SetJoinKeys(pdrgpexprOuter, pdrgpexprInner);
+				m_pgroup->SetJoinKeys(pdrgpexprOuter, pdrgpexprInner, join_opfamilies);
 			}
 
 			// insert group expression

--- a/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorDXLToExpr.h
@@ -429,9 +429,6 @@ namespace gpopt
 				GPOS_ASSERT(NULL != m_pdrgpmdname);
 				return m_pdrgpmdname;
 			}
-
-			// checks for presense of citext op non-citext predicates.
-			bool ContainsHeterogenousCitextPredicate(CExpression *expr);
 	};
 }
 

--- a/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
+++ b/libgpopt/include/gpopt/translate/CTranslatorExprToDXL.h
@@ -694,7 +694,7 @@ namespace gpopt
 			CDXLNode *GetSortColListDXL(CExpression *pexprMotion);
 
 			// create a DXL hash expr list from an array of hash columns
-			CDXLNode *PdxlnHashExprList(const CExpressionArray *pdrgpexpr);
+			CDXLNode *PdxlnHashExprList(const CExpressionArray *pdrgpexpr, const IMdIdArray *opfamilies);
 			
 			// create a DXL filter node with the given scalar expression
 			CDXLNode *PdxlnFilter(CDXLNode *pdxlnCond);

--- a/libgpopt/src/base/CUtils.cpp
+++ b/libgpopt/src/base/CUtils.cpp
@@ -5254,6 +5254,59 @@ CUtils::Equals
 	return equal;
 }
 
+BOOL
+CUtils::Equals
+	(
+	const IMdIdArray *mdids,
+	const IMdIdArray *other_mdids
+	)
+{
+	GPOS_CHECK_STACK_SIZE;
+
+	// NULL arrays are equal
+	if (NULL == mdids || NULL == other_mdids)
+	{
+		return NULL == mdids && NULL == other_mdids;
+	}
+
+	// do pointer comparision
+	if (mdids == other_mdids)
+	{
+		return true;
+	}
+
+	// if the size is not equal, the two arrays are not equal
+	if (mdids->Size() != other_mdids->Size())
+	{
+		return false;
+	}
+
+	// if all the elements are equal, then both the arrays are equal
+	for (ULONG id = 0; id < mdids->Size(); id++)
+	{
+		if (!CUtils::Equals((*mdids)[id], (*other_mdids)[id]))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+BOOL
+CUtils::Equals
+	(
+	const IMDId *mdid,
+	const IMDId *other_mdid
+	)
+{
+	if (mdid == NULL ^ other_mdid == NULL)
+	{
+		return false;
+	}
+
+	return (mdid == other_mdid) || mdid->Equals(other_mdid);
+}
+
 // operators from which the inferred predicates can be removed
 // NB: currently, only inner join is included, but we can add more later.
 BOOL

--- a/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -51,6 +51,7 @@ CTableDescriptor::CTableDescriptor
 	m_rel_distr_policy(rel_distr_policy),
 	m_erelstoragetype(erelstoragetype),
 	m_pdrgpcoldescDist(NULL),
+	m_distr_opfamilies(NULL),
 	m_convert_hash_to_random(convert_hash_to_random),
 	m_pdrgpulPart(NULL),
 	m_pdrgpbsKeys(NULL),
@@ -65,6 +66,10 @@ CTableDescriptor::CTableDescriptor
 	m_pdrgpcoldescDist = GPOS_NEW(m_mp) CColumnDescriptorArray(m_mp);
 	m_pdrgpulPart = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 	m_pdrgpbsKeys = GPOS_NEW(m_mp) CBitSetArray(m_mp);
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		m_distr_opfamilies = GPOS_NEW(m_mp) IMdIdArray(m_mp);
+	}
 }
 
 
@@ -84,6 +89,7 @@ CTableDescriptor::~CTableDescriptor()
 	m_pdrgpcoldescDist->Release();
 	m_pdrgpulPart->Release();
 	m_pdrgpbsKeys->Release();
+	CRefCount::SafeRelease(m_distr_opfamilies);
 }
 
 
@@ -199,12 +205,22 @@ CTableDescriptor::AddColumn
 void
 CTableDescriptor::AddDistributionColumn
 	(
-	ULONG ulPos
+	ULONG ulPos,
+	IMDId *opfamily
 	)
 {
 	CColumnDescriptor *pcoldesc = (*m_pdrgpcoldesc)[ulPos];
 	pcoldesc->AddRef();
 	m_pdrgpcoldescDist->Append(pcoldesc);
+
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		GPOS_ASSERT(NULL != opfamily && opfamily->IsValid());
+		opfamily->AddRef();
+		m_distr_opfamilies->Append(opfamily);
+
+		GPOS_ASSERT(m_pdrgpcoldescDist->Size() == m_distr_opfamilies->Size());
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/libgpopt/src/operators/CPhysical.cpp
+++ b/libgpopt/src/operators/CPhysical.cpp
@@ -310,7 +310,21 @@ CPhysical::PdsCompute
 			CExpressionArray *pdrgpexpr = CUtils::PdrgpexprScalarIdents(mp, colref_array);
 			colref_array->Release();
 
-			pds = GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexpr, true /*fNullsColocated*/);
+			IMdIdArray *opfamilies = NULL;
+			if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+			{
+				opfamilies = GPOS_NEW(mp) IMdIdArray(mp);
+				for (ULONG ul = 0; ul < size; ul++)
+				{
+					IMDId *opfamily = (*ptabdesc->DistrOpfamilies())[ul];
+					GPOS_ASSERT(NULL != opfamily && opfamily->IsValid());
+					opfamily->AddRef();
+					opfamilies->Append(opfamily);
+				}
+				GPOS_ASSERT(opfamilies->Size() == pdrgpexpr->Size());
+			}
+
+			pds = GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexpr, true /*fNullsColocated*/, opfamilies);
 			break;
 		}
 

--- a/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -372,17 +372,22 @@ CPhysicalFilter::PdsDerive
 
 			CExpressionArray *pdrgpexprOriginal = pdshashedOriginal->Pdrgpexpr();
 			pdrgpexprOriginal->AddRef();
+			IMdIdArray *opfamiliesOriginal = pdshashedOriginal->Opfamilies();
+			if (NULL != opfamiliesOriginal)
+			{
+				opfamiliesOriginal->AddRef();
+			}
 
 			CDistributionSpecHashed *pdsResult;
 			if (NULL == pdshashedComplete)
 			{
 				// could not complete the spec, return the original without any equiv spec
-				pdsResult = GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexprOriginal, pdshashedOriginal->FNullsColocated());
+				pdsResult = GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexprOriginal, pdshashedOriginal->FNullsColocated(), opfamiliesOriginal);
 			}
 			else
 			{
 				// return the original with the completed equiv spec
-				pdsResult = GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexprOriginal, pdshashedOriginal->FNullsColocated(), pdshashedComplete);
+				pdsResult = GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexprOriginal, pdshashedOriginal->FNullsColocated(), pdshashedComplete, opfamiliesOriginal);
 			}
 
 			// in any case, returned distribution spec must be complete!

--- a/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalFullMergeJoin.cpp
@@ -32,7 +32,8 @@ CPhysicalFullMergeJoin::CPhysicalFullMergeJoin
 	(
 	CMemoryPool *mp,
 	CExpressionArray *outer_merge_clauses,
-	CExpressionArray *inner_merge_clauses
+	CExpressionArray *inner_merge_clauses,
+	IMdIdArray *
 	)
 	:
 	CPhysicalJoin(mp),
@@ -156,6 +157,13 @@ CPhysicalFullMergeJoin::PosRequired
 
 		// Make sure that the corresponding properties (mergeStrategies, mergeNullsFirst)
 		// in CTranslatorDXLToPlStmt::TranslateDXLMergeJoin() match.
+		//
+		// NB: The operator used for sorting here is the '<' operator in the
+		// default btree opfamily of the column's type. For this to work correctly,
+		// the '=' operator of the merge join clauses must also belong to the same
+		// opfamily, which in this case, is the default of the type.
+		// See FMergeJoinCompatible() where predicates using a different opfamily
+		// are rejected from merge clauses.
 		gpmd::IMDId *mdid = colref->RetrieveType()->GetMdidForCmpType(IMDType::EcmptL);
 		mdid->AddRef();
 		os->Append(mdid, colref, COrderSpec::EntLast);

--- a/libgpopt/src/operators/CPhysicalInnerHashJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalInnerHashJoin.cpp
@@ -31,10 +31,11 @@ CPhysicalInnerHashJoin::CPhysicalInnerHashJoin
 	(
 	CMemoryPool *mp,
 	CExpressionArray *pdrgpexprOuterKeys,
-	CExpressionArray *pdrgpexprInnerKeys
+	CExpressionArray *pdrgpexprInnerKeys,
+	IMdIdArray *hash_opfamilies
 	)
 	:
-	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys)
+	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys, hash_opfamilies)
 {
 }
 
@@ -78,10 +79,15 @@ CPhysicalInnerHashJoin::PdshashedCreateMatching
 	// NB: The matching spec is added at the beginning.
 	pdshashedMatching->Pdrgpexpr()->AddRef();
 	pdshashed->AddRef();
+	if (NULL != pdshashedMatching->Opfamilies())
+	{
+		pdshashedMatching->Opfamilies()->AddRef();
+	}
 	CDistributionSpecHashed *pdsHashedMatchingEquivalents = GPOS_NEW(mp) CDistributionSpecHashed(
 												pdshashedMatching->Pdrgpexpr(),
 												pdshashedMatching->FNullsColocated(),
-												pdshashed // matching distribution spec is equivalent to passed distribution spec
+												pdshashed, // matching distribution spec is equivalent to passed distribution spec
+												pdshashedMatching->Opfamilies()
 												);
 	pdshashedMatching->Release();
 	return pdsHashedMatchingEquivalents;

--- a/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoin.cpp
@@ -30,10 +30,11 @@ CPhysicalLeftAntiSemiHashJoin::CPhysicalLeftAntiSemiHashJoin
 	(
 	CMemoryPool *mp,
 	CExpressionArray *pdrgpexprOuterKeys,
-	CExpressionArray *pdrgpexprInnerKeys
+	CExpressionArray *pdrgpexprInnerKeys,
+	IMdIdArray *hash_opfamilies
 	)
 	:
-	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys)
+	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys, hash_opfamilies)
 {
 }
 

--- a/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoinNotIn.cpp
+++ b/libgpopt/src/operators/CPhysicalLeftAntiSemiHashJoinNotIn.cpp
@@ -29,10 +29,11 @@ CPhysicalLeftAntiSemiHashJoinNotIn::CPhysicalLeftAntiSemiHashJoinNotIn
 	(
 	CMemoryPool *mp,
 	CExpressionArray *pdrgpexprOuterKeys,
-	CExpressionArray *pdrgpexprInnerKeys
+	CExpressionArray *pdrgpexprInnerKeys,
+	IMdIdArray *hash_opfamilies
 	)
 	:
-	CPhysicalLeftAntiSemiHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys)
+	CPhysicalLeftAntiSemiHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys, hash_opfamilies)
 {
 }
 

--- a/libgpopt/src/operators/CPhysicalLeftOuterHashJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalLeftOuterHashJoin.cpp
@@ -30,10 +30,11 @@ CPhysicalLeftOuterHashJoin::CPhysicalLeftOuterHashJoin
 	(
 	CMemoryPool *mp,
 	CExpressionArray *pdrgpexprOuterKeys,
-	CExpressionArray *pdrgpexprInnerKeys
+	CExpressionArray *pdrgpexprInnerKeys,
+	IMdIdArray *hash_opfamilies
 	)
 	:
-	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys)
+	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys, hash_opfamilies)
 {
 }
 

--- a/libgpopt/src/operators/CPhysicalLeftSemiHashJoin.cpp
+++ b/libgpopt/src/operators/CPhysicalLeftSemiHashJoin.cpp
@@ -30,10 +30,11 @@ CPhysicalLeftSemiHashJoin::CPhysicalLeftSemiHashJoin
 	(
 	CMemoryPool *mp,
 	CExpressionArray *pdrgpexprOuterKeys,
-	CExpressionArray *pdrgpexprInnerKeys
+	CExpressionArray *pdrgpexprInnerKeys,
+	IMdIdArray *hash_opfamilies
 	)
 	:
-	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys)
+	CPhysicalHashJoin(mp, pdrgpexprOuterKeys, pdrgpexprInnerKeys, hash_opfamilies)
 {
 }
 

--- a/libgpopt/src/operators/CPhysicalScan.cpp
+++ b/libgpopt/src/operators/CPhysicalScan.cpp
@@ -205,10 +205,15 @@ CPhysicalScan::PdsDerive
 		{
 			CExpressionArray *pdrgpexprHashed = pdshashed->Pdrgpexpr();
 			pdrgpexprHashed->AddRef();
+			if (NULL != pdshashed->Opfamilies())
+			{
+				pdshashed->Opfamilies()->AddRef();
+			}
 			CDistributionSpecHashed *pdshashedResult =
 				GPOS_NEW(mp) CDistributionSpecHashed(pdrgpexprHashed,
 													 pdshashed->FNullsColocated(),
-													 pdshashedEquiv);
+													 pdshashedEquiv,
+													 pdshashed->Opfamilies());
 
 			return pdshashedResult;
 		}

--- a/libgpopt/src/xforms/CXformUtils.cpp
+++ b/libgpopt/src/xforms/CXformUtils.cpp
@@ -2551,7 +2551,8 @@ CXformUtils::LookupJoinKeys
 	CMemoryPool *mp,
 	CExpression *pexpr,
 	CExpressionArray **ppdrgpexprOuter,
-	CExpressionArray **ppdrgpexprInner
+	CExpressionArray **ppdrgpexprInner,
+	IMdIdArray **join_opfamilies
 	)
 {
 	GPOS_ASSERT(NULL != ppdrgpexprOuter);
@@ -2559,6 +2560,8 @@ CXformUtils::LookupJoinKeys
 
 	*ppdrgpexprOuter = NULL;
 	*ppdrgpexprInner = NULL;
+	*join_opfamilies = NULL;
+
 	CGroupExpression *pgexprScalarOrigin = (*pexpr)[2]->Pgexpr();
 	if (NULL == pgexprScalarOrigin)
 	{
@@ -2576,6 +2579,12 @@ CXformUtils::LookupJoinKeys
 	}
 
 	GPOS_ASSERT(NULL != pgroupScalar->PdrgpexprJoinKeysInner());
+
+	*join_opfamilies = pgroupScalar->JoinOpfamilies();
+	if (NULL != *join_opfamilies)
+	{
+		(*join_opfamilies)->AddRef();
+	}
 
 	// extract used columns by hash join keys
 	CColRefSet *pcrsUsedOuter = CUtils::PcrsExtractColumns(mp, pgroupScalar->PdrgpexprJoinKeysOuter());
@@ -2620,7 +2629,8 @@ CXformUtils::CacheJoinKeys
 	(
 	CExpression *pexpr,
 	CExpressionArray *pdrgpexprOuter,
-	CExpressionArray *pdrgpexprInner
+	CExpressionArray *pdrgpexprInner,
+	IMdIdArray *join_opfamilies
 	)
 {
 	GPOS_ASSERT(NULL != pdrgpexprOuter);
@@ -2633,7 +2643,7 @@ CXformUtils::CacheJoinKeys
 
 		{	// scope of group proxy
 			CGroupProxy gp(pgroupScalar);
-			gp.SetJoinKeys(pdrgpexprOuter, pdrgpexprInner);
+			gp.SetJoinKeys(pdrgpexprOuter, pdrgpexprInner, join_opfamilies);
 		}
 	}
 }

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalCTAS.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalCTAS.h
@@ -59,6 +59,9 @@ namespace gpdxl
 
 			// list of distribution column positions		
 			ULongPtrArray *m_distr_column_pos_array;
+
+			// list of distribution column opfamilies
+			IMdIdArray *m_distr_opfamilies;
 			
 			// is this a temporary table
 			BOOL m_is_temp_table;
@@ -92,6 +95,7 @@ namespace gpdxl
 				CDXLCtasStorageOptions *dxl_ctas_storage_option,
 				IMDRelation::Ereldistrpolicy rel_distr_policy,
 				ULongPtrArray *distr_column_pos_array,
+				IMdIdArray *distr_opfamilies,
 				BOOL fTemporary, 
 				BOOL fHasOids, 
 				IMDRelation::Erelstoragetype rel_storage_type,
@@ -149,6 +153,12 @@ namespace gpdxl
 			ULongPtrArray *GetDistrColPosArray() const
 			{
 				return m_distr_column_pos_array;
+			}
+
+			// distribution column opfamilies
+			IMdIdArray *GetDistrOpfamilies() const
+			{
+				return m_distr_opfamilies;
 			}
 		
 			// source column ids

--- a/libnaucrates/include/naucrates/dxl/operators/CDXLScalarHashExpr.h
+++ b/libnaucrates/include/naucrates/dxl/operators/CDXLScalarHashExpr.h
@@ -35,8 +35,8 @@ namespace gpdxl
 	{
 		private:
 		
-			// catalog Oid of the expressions's data type 
-			IMDId *m_mdid_type;
+			// catalog Oid of the distribution opfamily
+			IMDId *m_mdid_opfamily;
 			
 			// private copy ctor
 			CDXLScalarHashExpr(CDXLScalarHashExpr&);
@@ -54,7 +54,7 @@ namespace gpdxl
 			// name of the operator
 			const CWStringConst *GetOpNameStr() const;
 			
-			IMDId *MdidType() const;
+			IMDId *MdidOpfamily() const;
 			
 			// serialize operator in DXL format
 			virtual

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalCTAS.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalCTAS.h
@@ -63,6 +63,9 @@ namespace gpdxl
 			
 			// storage type
 			IMDRelation::Erelstoragetype m_rel_storage_type;
+
+			// distribution opfamilies parse handler
+			CParseHandlerBase *m_opfamilies_parse_handler;
 		
 			// private copy ctor
 			CParseHandlerLogicalCTAS(const CParseHandlerLogicalCTAS &);

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBScalarOp.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDGPDBScalarOp.h
@@ -62,6 +62,9 @@ namespace gpdxl
 			// does operator return NULL on NULL input?
 			BOOL m_returns_null_on_null_input;
 
+			IMDId *m_mdid_hash_opfamily;
+			IMDId *m_mdid_legacy_hash_opfamily;
+
 			// private copy ctor
 			CParseHandlerMDGPDBScalarOp(const CParseHandlerMDGPDBScalarOp &);
 			

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelation.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelation.h
@@ -78,7 +78,10 @@ namespace gpdxl
 
 			// part constraint
 			CMDPartConstraintGPDB *m_part_constraint;
-			
+
+			// distribution opfamilies parse handler
+			CParseHandlerBase *m_opfamilies_parse_handler;
+
 			// levels that include default partitions
 			ULongPtrArray *m_level_with_default_part_array;
 

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationCtas.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationCtas.h
@@ -67,6 +67,9 @@ namespace gpdxl
 				CParseHandlerManager *parse_handler_mgr,
 				CParseHandlerBase *parse_handler_root
 				);
+
+			// distribution opfamilies parse handler
+			CParseHandlerBase *m_opfamilies_parse_handler;
 	};
 }
 

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationExternal.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDRelationExternal.h
@@ -45,6 +45,9 @@ namespace gpdxl
 			// format error table mdid
 			IMDId *m_mdid_fmt_err_table;
 
+			// distribution opfamilies parse handler
+			CParseHandlerBase *m_opfamilies_parse_handler;
+
 			// private copy ctor
 			CParseHandlerMDRelationExternal(const CParseHandlerMDRelationExternal &);
 

--- a/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
+++ b/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
@@ -47,6 +47,12 @@ namespace gpdxl
 			
 			// id and version of the type
 			IMDId *m_mdid;
+
+			// default distribution (hash) opfamily
+			IMDId *m_distr_opfamily;
+
+			// default legacy distribution (hash) opfamily
+			IMDId *m_legacy_distr_opfamily;
 			
 			// type name
 			CMDName *m_mdname;

--- a/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -472,6 +472,9 @@ namespace gpdxl
 		EdxltokenRelDistrRandom,
 		EdxltokenRelDistrReplicated,
 		EdxltokenConvertHashToRandom,
+
+		EdxltokenRelDistrOpfamilies,
+		EdxltokenRelDistrOpfamily,
 		
 		EdxltokenExtRelRejLimit,
 		EdxltokenExtRelRejLimitInRows,
@@ -528,6 +531,8 @@ namespace gpdxl
 		EdxltokenMDTypeFixedLength,
 		EdxltokenMDTypeLength,
 		EdxltokenMDTypeByValue,
+		EdxltokenMDTypeDistrOpfamily,
+		EdxltokenMDTypeLegacyDistrOpfamily,
 		EdxltokenMDTypeEqOp,
 		EdxltokenMDTypeNEqOp,
 		EdxltokenMDTypeLTOp,
@@ -555,6 +560,8 @@ namespace gpdxl
 		EdxltokenGPDBScalarOpLTOpId,
 		EdxltokenGPDBScalarOpGTOpId,
 		EdxltokenGPDBScalarOpCmpType,
+		EdxltokenGPDBScalarOpHashOpfamily,
+		EdxltokenGPDBScalarOpLegacyHashOpfamily,
 		
 		EdxltokenCmpEq, 
 		EdxltokenCmpNeq,	

--- a/libnaucrates/include/naucrates/md/CGPDBTypeHelper.h
+++ b/libnaucrates/include/naucrates/md/CGPDBTypeHelper.h
@@ -56,6 +56,9 @@ namespace gpmd
 
                 xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeByValue), mdtype->IsPassedByValue());
 
+                mdtype->SerializeMDIdAsElem(xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeDistrOpfamily), mdtype->m_distr_opfamily);
+                mdtype->SerializeMDIdAsElem(xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeLegacyDistrOpfamily), mdtype->m_legacy_distr_opfamily);
+
                 mdtype->SerializeMDIdAsElem(xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeEqOp), mdtype->GetMdidForCmpType(IMDType::EcmptEq));
                 mdtype->SerializeMDIdAsElem(xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeNEqOp), mdtype->GetMdidForCmpType(IMDType::EcmptNEq));
                 mdtype->SerializeMDIdAsElem(xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeLTOp), mdtype->GetMdidForCmpType(IMDType::EcmptL));

--- a/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
@@ -76,6 +76,9 @@ namespace gpmd
 
 			// indices of distribution columns
 			ULongPtrArray *m_distr_col_array;
+
+			// distribution opfamilies
+			IMdIdArray *m_distr_opfamilies;
 			
 			// array of key sets
 			ULongPtr2dArray *m_keyset_array;
@@ -117,6 +120,7 @@ namespace gpmd
 				Ereldistrpolicy rel_distr_policy,
 							CMDColumnArray *mdcol_array,
 				ULongPtrArray *distr_col_array,
+				IMdIdArray *distr_opfamilies,
 				ULongPtr2dArray *keyset_array,
 				CDXLCtasStorageOptions *dxl_ctas_storage_options,
 				IntPtrArray *vartypemod_array
@@ -221,6 +225,9 @@ namespace gpmd
 			// retrieve the column at the given position in the distribution columns list for the relation
 			virtual
 			const IMDColumn *GetDistrColAt(ULONG pos) const;
+
+			virtual
+			IMDId *GetDistrOpfamilyAt(ULONG pos) const;
 
 			// number of indices
 			virtual

--- a/libnaucrates/include/naucrates/md/CMDRelationExternalGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationExternalGPDB.h
@@ -66,6 +66,8 @@ namespace gpmd
 			// indices of distribution columns
 			ULongPtrArray *m_distr_col_array;
 
+			IMdIdArray *m_distr_opfamilies;
+
 			// do we need to consider a hash distributed table as random distributed
 			BOOL m_convert_hash_to_random;
 
@@ -123,6 +125,7 @@ namespace gpmd
 				Ereldistrpolicy rel_distr_policy,
 								CMDColumnArray *mdcol_array,
 				ULongPtrArray *distr_col_array,
+				IMdIdArray *distr_opfamilies,
 				BOOL convert_hash_to_random,
 				ULongPtr2dArray *keyset_array,
 								CMDIndexInfoArray *md_index_info_array,
@@ -215,6 +218,9 @@ namespace gpmd
 			// retrieve the column at the given position in the distribution columns list for the relation
 			virtual
 			const IMDColumn *GetDistrColAt(ULONG pos) const;
+
+			virtual
+			IMDId *GetDistrOpfamilyAt(ULONG pos) const;
 
 			// number of indices
 			virtual

--- a/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
@@ -74,6 +74,8 @@ namespace gpmd
 			
 			// indices of distribution columns
 			ULongPtrArray *m_distr_col_array;
+
+			IMdIdArray *m_distr_opfamilies;
 			
 			// do we need to consider a hash distributed table as random distributed
 			BOOL m_convert_hash_to_random;
@@ -137,6 +139,7 @@ namespace gpmd
 				Ereldistrpolicy rel_distr_policy,
 						CMDColumnArray *mdcol_array,
 				ULongPtrArray *distr_col_array,
+				IMdIdArray *distr_opfamilies,
 				ULongPtrArray *partition_cols_array,
 				CharPtrArray *str_part_types_array,
 				ULONG num_of_partitions,
@@ -231,6 +234,9 @@ namespace gpmd
 			// retrieve the column at the given position in the distribution columns list for the relation
 			virtual 
 			const IMDColumn *GetDistrColAt(ULONG pos) const;
+
+			virtual
+			IMDId *GetDistrOpfamilyAt(ULONG pos) const;
 			
 			// return true if a hash distributed table needs to be considered as random
 			virtual 

--- a/libnaucrates/include/naucrates/md/CMDScalarOpGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDScalarOpGPDB.h
@@ -73,7 +73,13 @@ namespace gpmd
 			BOOL m_returns_null_on_null_input;
 			
 			// operator classes this operator belongs to
-		IMdIdArray *m_mdid_opfamilies_array;
+			IMdIdArray *m_mdid_opfamilies_array;
+
+			// compatible hash op family
+			IMDId *m_mdid_hash_opfamily;
+
+			// compatible legacy hash op family using legacy (cdbhash) opclass
+			IMDId *m_mdid_legacy_hash_opfamily;
 
 			CMDScalarOpGPDB(const CMDScalarOpGPDB &);
 			
@@ -93,7 +99,9 @@ namespace gpmd
 				IMDId *m_mdid_inverse_opr,
 				IMDType::ECmpType cmp_type,
 				BOOL returns_null_on_null_input,
-				IMdIdArray *mdid_opfamilies_array
+				IMdIdArray *mdid_opfamilies_array,
+				IMDId *m_mdid_hash_opfamily,
+				IMDId *mdid_legacy_hash_opfamily
 				);
 			
 			~CMDScalarOpGPDB();
@@ -162,6 +170,10 @@ namespace gpmd
 			// operator class at given position
 			virtual
 			IMDId *OpfamilyMdidAt(ULONG pos) const;
+
+			// compatible hash opfamily
+			virtual
+			IMDId *HashOpfamilyMdid() const;
 			
 #ifdef GPOS_DEBUG
 			// debug print of the type in the provided stream

--- a/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h
@@ -18,8 +18,11 @@
 
 #include "naucrates/md/IMDTypeBool.h"
 #include "naucrates/base/IDatumBool.h"
+#include "naucrates/md/CGPDBTypeHelper.h"
 
 #define GPDB_BOOL_OID OID(16)
+#define GPDB_BOOL_OPFAMILY OID(2222)
+#define GPDB_BOOL_LEGACY_OPFAMILY OID(7124)
 #define GPDB_BOOL_LENGTH 1
 #define GPDB_BOOL_EQ_OP OID(91)
 #define GPDB_BOOL_NEQ_OP OID(85)
@@ -57,6 +60,8 @@ namespace gpmd
 	//---------------------------------------------------------------------------
 	class CMDTypeBoolGPDB : public IMDTypeBool
 	{
+		friend class CGPDBTypeHelper<CMDTypeBoolGPDB>;
+
 	private:
 	
 		// memory pool
@@ -64,6 +69,8 @@ namespace gpmd
 		
 		// type id
 		IMDId *m_mdid;
+		IMDId *m_distr_opfamily;
+		IMDId *m_legacy_distr_opfamily;
 		
 		// mdids of different operators
 		IMDId *m_mdid_op_eq;
@@ -122,6 +129,9 @@ namespace gpmd
 		// type id
 		virtual 
 		IMDId *MDId() const;
+
+		IMDId *
+		GetDistrOpfamilyMdid() const;
 		
 		// type name
 		virtual 

--- a/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -18,6 +18,7 @@
 
 #include "naucrates/md/IMDTypeGeneric.h"
 #include "naucrates/md/CMDIdGPDB.h"
+#include "naucrates/md/CGPDBTypeHelper.h"
 
 // some metadata ids for types that don't have their specific header files (yet)
 // keep this in sync with Postgres file pg_operator.h
@@ -48,7 +49,9 @@ namespace gpmd
 	//
 	//---------------------------------------------------------------------------
 	class CMDTypeGenericGPDB : public IMDTypeGeneric
-	{		
+	{
+		friend class CGPDBTypeHelper<CMDTypeGenericGPDB>;
+
 		private:
 			// memory pool
 			CMemoryPool *m_mp;
@@ -73,6 +76,10 @@ namespace gpmd
 			
 		// is type passed by value or by reference
 			BOOL m_is_passed_by_value;
+
+			IMDId *m_distr_opfamily;
+
+			IMDId *m_legacy_distr_opfamily;
 			
 			// id of equality operator for type
 			IMDId *m_mdid_op_eq;
@@ -148,6 +155,8 @@ namespace gpmd
 				BOOL is_fixed_length,
 				ULONG length, 
 				BOOL is_passed_by_value,
+				IMDId *mdid_distr_opfamily,
+				IMDId *mdid_legacy_distr_opfamily,
 				IMDId *mdid_op_eq,
 				IMDId *mdid_op_neq,
 				IMDId *mdid_op_lt,
@@ -263,6 +272,9 @@ namespace gpmd
 			{
 				return m_mdid_type_array;
 			}
+
+			virtual
+			IMDId *GetDistrOpfamilyMdid() const;
 			
 			// serialize object in DXL format
 			virtual 

--- a/libnaucrates/include/naucrates/md/CMDTypeInt2GPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDTypeInt2GPDB.h
@@ -17,8 +17,11 @@
 #include "gpos/base.h"
 
 #include "naucrates/md/IMDTypeInt2.h"
+#include "naucrates/md/CGPDBTypeHelper.h"
 
 #define GPDB_INT2_OID OID(21)
+#define GPDB_INT2_OPFAMILY OID(1977)
+#define GPDB_INT2_LEGACY_OPFAMILY OID(7100)
 #define GPDB_INT2_LENGTH 2
 #define GPDB_INT2_EQ_OP OID(94)
 #define GPDB_INT2_NEQ_OP OID(519)
@@ -63,6 +66,7 @@ namespace gpmd
 	//---------------------------------------------------------------------------
 	class CMDTypeInt2GPDB : public IMDTypeInt2
 	{
+		friend class CGPDBTypeHelper<CMDTypeInt2GPDB>;
 		private:
 		
 			// memory pool
@@ -70,6 +74,8 @@ namespace gpmd
 			
 			// type id
 			IMDId *m_mdid;
+			IMDId *m_distr_opfamily;
+			IMDId *m_legacy_distr_opfamily;
 			
 			// mdids of different operators
 			IMDId *m_mdid_op_eq;
@@ -128,11 +134,14 @@ namespace gpmd
 			{
 				return m_dxl_str;
 			}
-			
+
 			// accessor of metadata id
 			virtual 
 			IMDId *MDId() const;
-			
+
+			virtual
+			IMDId *GetDistrOpfamilyMdid() const;
+
 			// accessor of type name
 			virtual 
 			CMDName Mdname() const;

--- a/libnaucrates/include/naucrates/md/CMDTypeInt4GPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDTypeInt4GPDB.h
@@ -17,8 +17,11 @@
 #include "gpos/base.h"
 
 #include "naucrates/md/IMDTypeInt4.h"
+#include "naucrates/md/CGPDBTypeHelper.h"
 
 #define GPDB_INT4_OID OID(23)
+#define GPDB_INT4_OPFAMILY OID(1977)
+#define GPDB_INT4_LEGACY_OPFAMILY OID(7100)
 #define GPDB_INT4_LENGTH 4
 #define GPDB_INT4_EQ_OP OID(96)
 #define GPDB_INT4_NEQ_OP OID(518)
@@ -63,6 +66,7 @@ namespace gpmd
 	//---------------------------------------------------------------------------
 	class CMDTypeInt4GPDB : public IMDTypeInt4
 	{
+		friend class CGPDBTypeHelper<CMDTypeInt4GPDB>;
 		private:
 		
 			// memory pool
@@ -70,6 +74,8 @@ namespace gpmd
 			
 			// type id
 			IMDId *m_mdid;
+			IMDId *m_distr_opfamily;
+			IMDId *m_legacy_distr_opfamily;
 			
 			// mdids of different operators
 			IMDId *m_mdid_op_eq;
@@ -131,6 +137,9 @@ namespace gpmd
 			
 			virtual 
 			IMDId *MDId() const;
+
+			IMDId *
+			GetDistrOpfamilyMdid() const;
 			
 			virtual 
 			CMDName Mdname() const;

--- a/libnaucrates/include/naucrates/md/CMDTypeInt8GPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDTypeInt8GPDB.h
@@ -17,8 +17,11 @@
 #include "gpos/base.h"
 
 #include "naucrates/md/IMDTypeInt8.h"
+#include "naucrates/md/CGPDBTypeHelper.h"
 
 #define GPDB_INT8_OID OID(20)
+#define GPDB_INT8_OPFAMILY OID(1977)
+#define GPDB_INT8_LEGACY_OPFAMILY OID(7100)
 #define GPDB_INT8_LENGTH 8
 #define GPDB_INT8_EQ_OP OID(410)
 #define GPDB_INT8_NEQ_OP OID(411)
@@ -65,6 +68,7 @@ namespace gpmd
 	//---------------------------------------------------------------------------
 	class CMDTypeInt8GPDB : public IMDTypeInt8
 	{
+		friend class CGPDBTypeHelper<CMDTypeInt8GPDB>;
 	private:
 
 		// memory pool
@@ -72,6 +76,8 @@ namespace gpmd
 		
 		// type id
 		IMDId *m_mdid;
+		IMDId *m_distr_opfamily;
+		IMDId *m_legacy_distr_opfamily;
 		
 		// mdids of different operators
 		IMDId *m_mdid_op_eq;
@@ -132,6 +138,9 @@ namespace gpmd
 		// type id
 		virtual 
 		IMDId *MDId() const;
+
+		virtual
+		IMDId *GetDistrOpfamilyMdid() const;
 		
 		// type name
 		virtual 

--- a/libnaucrates/include/naucrates/md/CMDTypeOidGPDB.h
+++ b/libnaucrates/include/naucrates/md/CMDTypeOidGPDB.h
@@ -15,8 +15,11 @@
 #include "gpos/base.h"
 
 #include "naucrates/md/IMDTypeOid.h"
+#include "naucrates/md/CGPDBTypeHelper.h"
 
 #define GPDB_OID_OID OID(26)
+#define GPDB_OID_OPFAMILY OID(1990)
+#define GPDB_OID_LEGACY_OPFAMILY OID(7109)
 #define GPDB_OID_LENGTH 4
 #define GPDB_OID_EQ_OP OID(607)
 #define GPDB_OID_NEQ_OP OID(608)
@@ -62,6 +65,7 @@ namespace gpmd
 	//---------------------------------------------------------------------------
 	class CMDTypeOidGPDB : public IMDTypeOid
 	{
+		friend class CGPDBTypeHelper<CMDTypeOidGPDB>;
 		private:
 
 			// memory pool
@@ -69,6 +73,8 @@ namespace gpmd
 
 			// type id
 			IMDId *m_mdid;
+			IMDId *m_distr_opfamily;
+			IMDId *m_legacy_distr_opfamily;
 
 			// mdids of different comparison operators
 			IMDId *m_mdid_op_eq;
@@ -128,6 +134,9 @@ namespace gpmd
 
 			virtual
 			IMDId *MDId() const;
+
+			IMDId *
+			GetDistrOpfamilyMdid() const;
 
 			virtual
 			CMDName Mdname() const;

--- a/libnaucrates/include/naucrates/md/IMDCacheObject.h
+++ b/libnaucrates/include/naucrates/md/IMDCacheObject.h
@@ -46,7 +46,7 @@ namespace gpmd
 	//---------------------------------------------------------------------------
 	class IMDCacheObject : public IMDInterface
 	{	
-		protected:
+		public:
 			// Serialize a list of metadata id elements using pstrTokenList
 			// as the root XML element for the list, and each metadata id is
 			// serialized in the form of a pstrTokenListItem element.
@@ -62,8 +62,7 @@ namespace gpmd
 				const CWStringConst *strTokenList,
 				const CWStringConst *strTokenListItem
 				);
-		
-		public:
+
 			// type of md object
 			enum Emdtype
 			{

--- a/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -155,6 +155,9 @@ namespace gpmd
 			// retrieve the column at the given position in the distribution key for the relation
 			virtual 
 			const IMDColumn *GetDistrColAt(ULONG pos) const = 0;
+
+			virtual
+			IMDId *GetDistrOpfamilyAt(ULONG pos) const = 0;
 			
 			// return true if a hash distributed table needs to be considered as random
 			virtual 

--- a/libnaucrates/include/naucrates/md/IMDScalarOp.h
+++ b/libnaucrates/include/naucrates/md/IMDScalarOp.h
@@ -89,6 +89,11 @@ namespace gpmd
 			// operator class at given position
 			virtual
 			IMDId *OpfamilyMdidAt(ULONG pos) const = 0;
+
+			// compatible hash opfamily
+			virtual
+			IMDId *HashOpfamilyMdid() const = 0;
+
 	};
 }
 

--- a/libnaucrates/include/naucrates/md/IMDType.h
+++ b/libnaucrates/include/naucrates/md/IMDType.h
@@ -89,6 +89,9 @@ namespace gpmd
 			{
 				return EmdtType;
 			}
+
+			virtual
+			IMDId *GetDistrOpfamilyMdid() const = 0;
 			
 			// md id of cache object
 			virtual 

--- a/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -200,6 +200,12 @@ namespace gpos
 		// Consider non-equality predicates in Dynamic partition selection
 		EopttraceAllowGeneralPredicatesforDPE = 103037,
 
+		// Support Opfamilies in distribution specs
+		EopttraceConsiderOpfamiliesForDistribution = 103038,
+
+		// Use legacy (cdbhash) opfamilies for compatibility
+		EopttraceUseLegacyOpfamilies = 103039,
+
 		///////////////////////////////////////////////////////
 		///////////////////// statistics flags ////////////////
 		//////////////////////////////////////////////////////

--- a/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -38,6 +38,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 	Ereldistrpolicy rel_distr_policy,
 										 CMDColumnArray *mdcol_array,
 	ULongPtrArray *distr_col_array,
+	IMdIdArray *distr_opfamiles,
 	ULongPtr2dArray *keyset_array,
 	CDXLCtasStorageOptions *dxl_ctas_storage_options,
 	IntPtrArray *vartypemod_array
@@ -53,6 +54,7 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB
 	m_rel_distr_policy(rel_distr_policy),
 	m_md_col_array(mdcol_array),
 	m_distr_col_array(distr_col_array),
+	m_distr_opfamilies(distr_opfamiles),
 	m_keyset_array(keyset_array),
 	m_system_columns(0),
 	m_nondrop_col_pos_array(NULL),
@@ -294,6 +296,19 @@ CMDRelationCtasGPDB::GetDistrColAt
 	return GetMdCol(distr_key_pos);
 }
 
+IMDId *
+CMDRelationCtasGPDB::GetDistrOpfamilyAt(ULONG pos) const
+{
+	if (m_distr_opfamilies == NULL)
+	{
+		GPOS_RAISE(CException::ExmaInvalid, CException::ExmiInvalid,
+				   GPOS_WSZ_LIT("GetDistrOpfamilyAt() returning NULL."));
+	}
+
+	GPOS_ASSERT(pos < m_distr_opfamilies->Size());
+	return (*m_distr_opfamilies)[pos];
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDRelationCtasGPDB::Serialize
@@ -355,6 +370,15 @@ CMDRelationCtasGPDB::Serialize
 						CDXLTokens::GetDXLTokenStr(EdxltokenColumns));
 
 	m_dxl_ctas_storage_option->Serialize(xml_serializer);
+
+	// serialize distribution opfamilies
+	if (EreldistrHash == m_rel_distr_policy && NULL != m_distr_opfamilies)
+	{
+		SerializeMDIdList(xml_serializer, m_distr_opfamilies,
+						  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamilies),
+						  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamily));
+	}
+
 	xml_serializer->CloseElement(CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 						CDXLTokens::GetDXLTokenStr(EdxltokenRelationCTAS));
 }

--- a/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -36,18 +36,19 @@ CMDRelationGPDB::CMDRelationGPDB
 	BOOL fTemporary,
 	Erelstoragetype rel_storage_type,
 	Ereldistrpolicy rel_distr_policy,
-								 CMDColumnArray *mdcol_array,
+	CMDColumnArray *mdcol_array,
 	ULongPtrArray *distr_col_array,
+	IMdIdArray *distr_opfamilies,
 	ULongPtrArray *partition_cols_array,
 	CharPtrArray *str_part_types_array,
 	ULONG num_of_partitions,
 	BOOL convert_hash_to_random,
 	ULongPtr2dArray *keyset_array,
-								 CMDIndexInfoArray *md_index_info_array,
-								 IMdIdArray *mdid_triggers_array,
-								 IMdIdArray *mdid_check_constraint_array,
- 	IMDPartConstraint *mdpart_constraint,
- 	BOOL has_oids
+	CMDIndexInfoArray *md_index_info_array,
+	IMdIdArray *mdid_triggers_array,
+	IMdIdArray *mdid_check_constraint_array,
+	IMDPartConstraint *mdpart_constraint,
+	BOOL has_oids
 	)
 	:
 	m_mp(mp),
@@ -59,6 +60,7 @@ CMDRelationGPDB::CMDRelationGPDB
 	m_md_col_array(mdcol_array),
 	m_dropped_cols(0),
 	m_distr_col_array(distr_col_array),
+	m_distr_opfamilies(distr_opfamilies),
 	m_convert_hash_to_random(convert_hash_to_random),
 	m_partition_cols_array(partition_cols_array),
 	m_str_part_types_array(str_part_types_array),
@@ -82,6 +84,7 @@ CMDRelationGPDB::CMDRelationGPDB
 	GPOS_ASSERT_IMP(convert_hash_to_random,
 			IMDRelation::EreldistrHash == rel_distr_policy &&
 			"Converting hash distributed table to random only possible for hash distributed tables");
+	GPOS_ASSERT(NULL == distr_opfamilies || distr_opfamilies->Size() == m_distr_col_array->Size());
 	
 	m_colpos_nondrop_colpos_map = GPOS_NEW(m_mp) UlongToUlongMap(m_mp);
 	m_attrno_nondrop_col_pos_map = GPOS_NEW(m_mp) IntToUlongMap(m_mp);
@@ -139,6 +142,7 @@ CMDRelationGPDB::~CMDRelationGPDB()
 	m_mdid->Release();
 	m_md_col_array->Release();
 	CRefCount::SafeRelease(m_distr_col_array);
+	CRefCount::SafeRelease(m_distr_opfamilies);
 	CRefCount::SafeRelease(m_partition_cols_array);
 	CRefCount::SafeRelease(m_str_part_types_array);
 	CRefCount::SafeRelease(m_keyset_array);
@@ -563,6 +567,19 @@ CMDRelationGPDB::GetDistrColAt
 	return GetMdCol(distr_key_pos);
 }
 
+IMDId *
+CMDRelationGPDB::GetDistrOpfamilyAt(ULONG pos) const
+{
+	if (m_distr_opfamilies == NULL)
+	{
+		GPOS_RAISE(CException::ExmaInvalid, CException::ExmiInvalid,
+				   GPOS_WSZ_LIT("GetDistrOpfamilyAt() returning NULL."));
+	}
+
+	GPOS_ASSERT(pos < m_distr_opfamilies->Size());
+	return (*m_distr_opfamilies)[pos];
+}
+
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDRelationGPDB::ConvertHashToRandom
@@ -792,6 +809,14 @@ CMDRelationGPDB::Serialize
 	SerializeMDIdList(xml_serializer, m_mdid_check_constraint_array,
 						CDXLTokens::GetDXLTokenStr(EdxltokenCheckConstraints),
 						CDXLTokens::GetDXLTokenStr(EdxltokenCheckConstraint));
+
+	// serialize operator class information, if present
+	if (EreldistrHash == m_rel_distr_policy && NULL != m_distr_opfamilies)
+	{
+		SerializeMDIdList(xml_serializer, m_distr_opfamilies,
+						  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamilies),
+						  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamily));
+	}
 
 	// serialize part constraint
 	if (NULL != m_mdpart_constraint)

--- a/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
+++ b/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
@@ -13,7 +13,6 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDTypeBoolGPDB.h"
-#include "naucrates/md/CGPDBTypeHelper.h"
 
 #include "naucrates/dxl/operators/CDXLScalarConstValue.h"
 #include "naucrates/dxl/operators/CDXLDatumBool.h"
@@ -49,6 +48,16 @@ CMDTypeBoolGPDB::CMDTypeBoolGPDB
 	m_mp(mp)
 {
 	m_mdid = GPOS_NEW(mp) CMDIdGPDB(GPDB_BOOL_OID);
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		m_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_BOOL_OPFAMILY);
+		m_legacy_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_BOOL_LEGACY_OPFAMILY);
+	}
+	else
+	{
+		m_distr_opfamily = NULL;
+		m_legacy_distr_opfamily = NULL;
+	}
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(GPDB_BOOL_EQ_OP);
 	m_mdid_op_neq = GPOS_NEW(mp) CMDIdGPDB(GPDB_BOOL_NEQ_OP);
 	m_mdid_op_lt = GPOS_NEW(mp) CMDIdGPDB(GPDB_BOOL_LT_OP);
@@ -83,6 +92,8 @@ CMDTypeBoolGPDB::CMDTypeBoolGPDB
 CMDTypeBoolGPDB::~CMDTypeBoolGPDB()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -201,6 +212,19 @@ IMDId *
 CMDTypeBoolGPDB::MDId() const
 {
 	return m_mdid;
+}
+
+IMDId *
+CMDTypeBoolGPDB::GetDistrOpfamilyMdid() const
+{
+	if (GPOS_FTRACE(EopttraceUseLegacyOpfamilies))
+	{
+		return m_legacy_distr_opfamily;
+	}
+	else
+	{
+		return m_distr_opfamily;
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -14,7 +14,6 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDTypeGenericGPDB.h"
-#include "naucrates/md/CGPDBTypeHelper.h"
 
 #include "naucrates/base/CDatumGenericGPDB.h"
 #include "naucrates/statistics/CStatsPredUtils.h"
@@ -56,6 +55,8 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB
 	BOOL is_fixed_length,
 	ULONG length, 
 	BOOL is_passed_by_value,
+	IMDId *mdid_distr_opfamily,
+	IMDId *mdid_legacy_distr_opfamily,
 	IMDId *mdid_op_eq,
 	IMDId *mdid_op_neq,
 	IMDId *mdid_op_lt,
@@ -84,6 +85,8 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB
 	m_is_fixed_length(is_fixed_length),
 	m_length(length),
 	m_is_passed_by_value(is_passed_by_value),
+	m_distr_opfamily(mdid_distr_opfamily),
+	m_legacy_distr_opfamily(mdid_legacy_distr_opfamily),
 	m_mdid_op_eq(mdid_op_eq),
 	m_mdid_op_neq(mdid_op_neq),
 	m_mdid_op_lt(mdid_op_lt),
@@ -124,6 +127,8 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB
 CMDTypeGenericGPDB::~CMDTypeGenericGPDB()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -609,6 +614,19 @@ CMDTypeGenericGPDB::IsNetworkRelatedType
 	return mdid->Equals(&CMDIdGPDB::m_mdid_inet)
 			|| mdid->Equals(&CMDIdGPDB::m_mdid_cidr)
 			|| mdid->Equals(&CMDIdGPDB::m_mdid_macaddr);
+}
+
+IMDId *
+CMDTypeGenericGPDB::GetDistrOpfamilyMdid() const
+{
+	if (GPOS_FTRACE(EopttraceUseLegacyOpfamilies))
+	{
+		return m_legacy_distr_opfamily;
+	}
+	else
+	{
+		return m_distr_opfamily;
+	}
 }
 
 #ifdef GPOS_DEBUG

--- a/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
+++ b/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
@@ -13,7 +13,6 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDTypeInt2GPDB.h"
-#include "naucrates/md/CGPDBTypeHelper.h"
 
 #include "naucrates/dxl/operators/CDXLScalarConstValue.h"
 #include "naucrates/dxl/operators/CDXLDatum.h"
@@ -48,6 +47,16 @@ CMDTypeInt2GPDB::CMDTypeInt2GPDB
 	m_mp(mp)
 {
 	m_mdid = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT2_OID);
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		m_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT2_OPFAMILY);
+		m_legacy_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT2_LEGACY_OPFAMILY);
+	}
+	else
+	{
+		m_distr_opfamily = NULL;
+		m_legacy_distr_opfamily = NULL;
+	}
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT2_EQ_OP);
 	m_mdid_op_neq = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT2_NEQ_OP);
 	m_mdid_op_lt = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT2_LT_OP);
@@ -80,6 +89,8 @@ CMDTypeInt2GPDB::CMDTypeInt2GPDB
 CMDTypeInt2GPDB::~CMDTypeInt2GPDB()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -131,6 +142,19 @@ IMDId *
 CMDTypeInt2GPDB::MDId() const
 {
 	return m_mdid;
+}
+
+IMDId *
+CMDTypeInt2GPDB::GetDistrOpfamilyMdid() const
+{
+	if (GPOS_FTRACE(EopttraceUseLegacyOpfamilies))
+	{
+		return m_legacy_distr_opfamily;
+	}
+	else
+	{
+		return m_distr_opfamily;
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
+++ b/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
@@ -13,7 +13,6 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDTypeInt4GPDB.h"
-#include "naucrates/md/CGPDBTypeHelper.h"
 
 #include "naucrates/dxl/operators/CDXLScalarConstValue.h"
 #include "naucrates/dxl/operators/CDXLDatum.h"
@@ -48,6 +47,16 @@ CMDTypeInt4GPDB::CMDTypeInt4GPDB
 	m_mp(mp)
 {
 	m_mdid = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4_OID);
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		m_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4_OPFAMILY);
+		m_legacy_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4_LEGACY_OPFAMILY);
+	}
+	else
+	{
+		m_distr_opfamily = NULL;
+		m_legacy_distr_opfamily = NULL;
+	}
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4_EQ_OP);
 	m_mdid_op_neq = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4_NEQ_OP);
 	m_mdid_op_lt = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT4_LT_OP);
@@ -80,6 +89,8 @@ CMDTypeInt4GPDB::CMDTypeInt4GPDB
 CMDTypeInt4GPDB::~CMDTypeInt4GPDB()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -118,7 +129,6 @@ CMDTypeInt4GPDB::CreateInt4Datum
 	return GPOS_NEW(mp) CDatumInt4GPDB(m_mdid->Sysid(), value, is_null);
 }
 
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDTypeInt4GPDB::MDId
@@ -131,6 +141,19 @@ IMDId *
 CMDTypeInt4GPDB::MDId() const
 {
 	return m_mdid;
+}
+
+IMDId *
+CMDTypeInt4GPDB::GetDistrOpfamilyMdid() const
+{
+	if (GPOS_FTRACE(EopttraceUseLegacyOpfamilies))
+	{
+		return m_legacy_distr_opfamily;
+	}
+	else
+	{
+		return m_distr_opfamily;
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
+++ b/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
@@ -19,7 +19,6 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDTypeInt8GPDB.h"
-#include "naucrates/md/CGPDBTypeHelper.h"
 
 #include "naucrates/dxl/operators/CDXLScalarConstValue.h"
 #include "naucrates/dxl/operators/CDXLDatum.h"
@@ -54,6 +53,16 @@ CMDTypeInt8GPDB::CMDTypeInt8GPDB
 	m_mp(mp)
 {
 	m_mdid = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_OID);
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		m_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_OPFAMILY);
+		m_legacy_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_LEGACY_OPFAMILY);
+	}
+	else
+	{
+		m_distr_opfamily = NULL;
+		m_legacy_distr_opfamily = NULL;
+	}
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_EQ_OP);
 	m_mdid_op_neq = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_NEQ_OP);
 	m_mdid_op_lt = GPOS_NEW(mp) CMDIdGPDB(GPDB_INT8_LT_OP);
@@ -87,6 +96,8 @@ CMDTypeInt8GPDB::CMDTypeInt8GPDB
 CMDTypeInt8GPDB::~CMDTypeInt8GPDB()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -138,6 +149,19 @@ IMDId *
 CMDTypeInt8GPDB::MDId() const
 {
 	return m_mdid;
+}
+
+IMDId *
+CMDTypeInt8GPDB::GetDistrOpfamilyMdid() const
+{
+	if (GPOS_FTRACE(EopttraceUseLegacyOpfamilies))
+	{
+		return m_legacy_distr_opfamily;
+	}
+	else
+	{
+		return m_distr_opfamily;
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/md/CMDTypeOidGPDB.cpp
+++ b/libnaucrates/src/md/CMDTypeOidGPDB.cpp
@@ -13,7 +13,6 @@
 #include "gpos/string/CWStringDynamic.h"
 
 #include "naucrates/md/CMDTypeOidGPDB.h"
-#include "naucrates/md/CGPDBTypeHelper.h"
 
 #include "naucrates/dxl/operators/CDXLScalarConstValue.h"
 #include "naucrates/dxl/operators/CDXLDatum.h"
@@ -48,6 +47,16 @@ CMDTypeOidGPDB::CMDTypeOidGPDB
 	m_mp(mp)
 {
 	m_mdid = GPOS_NEW(mp) CMDIdGPDB(GPDB_OID_OID);
+	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution))
+	{
+		m_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_OID_OPFAMILY);
+		m_legacy_distr_opfamily = GPOS_NEW(mp) CMDIdGPDB(GPDB_OID_LEGACY_OPFAMILY);
+	}
+	else
+	{
+		m_distr_opfamily = NULL;
+		m_legacy_distr_opfamily = NULL;
+	}
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(GPDB_OID_EQ_OP);
 	m_mdid_op_neq = GPOS_NEW(mp) CMDIdGPDB(GPDB_OID_NEQ_OP);
 	m_mdid_op_lt = GPOS_NEW(mp) CMDIdGPDB(GPDB_OID_LT_OP);
@@ -81,6 +90,8 @@ CMDTypeOidGPDB::CMDTypeOidGPDB
 CMDTypeOidGPDB::~CMDTypeOidGPDB()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -132,6 +143,19 @@ IMDId *
 CMDTypeOidGPDB::MDId() const
 {
 	return m_mdid;
+}
+
+IMDId *
+CMDTypeOidGPDB::GetDistrOpfamilyMdid() const
+{
+	if (GPOS_FTRACE(EopttraceUseLegacyOpfamilies))
+	{
+		return m_legacy_distr_opfamily;
+	}
+	else
+	{
+		return m_distr_opfamily;
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/operators/CDXLLogicalCTAS.cpp
+++ b/libnaucrates/src/operators/CDXLLogicalCTAS.cpp
@@ -39,6 +39,7 @@ CDXLLogicalCTAS::CDXLLogicalCTAS
 	CDXLCtasStorageOptions *dxl_ctas_storage_options,
 	IMDRelation::Ereldistrpolicy rel_distr_policy,
 	ULongPtrArray *distr_column_pos_array,
+	IMdIdArray *distr_opfamilies,
 	BOOL is_temporary,
 	BOOL has_oids,
 	IMDRelation::Erelstoragetype rel_storage_type,
@@ -54,6 +55,7 @@ CDXLLogicalCTAS::CDXLLogicalCTAS
 	m_dxl_ctas_storage_option(dxl_ctas_storage_options),
 	m_rel_distr_policy(rel_distr_policy),
 	m_distr_column_pos_array(distr_column_pos_array),
+	m_distr_opfamilies(distr_opfamilies),
 	m_is_temp_table(is_temporary),
 	m_has_oids(has_oids),
 	m_rel_storage_type(rel_storage_type),
@@ -70,6 +72,7 @@ CDXLLogicalCTAS::CDXLLogicalCTAS
 	GPOS_ASSERT(dxl_col_descr_array->Size() == vartypemod_array->Size());
 	GPOS_ASSERT(IMDRelation::ErelstorageSentinel > rel_storage_type);
 	GPOS_ASSERT(IMDRelation::EreldistrSentinel > rel_distr_policy);
+	GPOS_ASSERT(NULL == m_distr_opfamilies || m_distr_opfamilies->Size() == m_distr_column_pos_array->Size());
 }
 
 //---------------------------------------------------------------------------
@@ -221,6 +224,13 @@ CDXLLogicalCTAS::SerializeToDXL
 	xml_serializer->CloseElement(CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), CDXLTokens::GetDXLTokenStr(EdxltokenColumns));
 
 	m_dxl_ctas_storage_option->Serialize(xml_serializer);
+
+	if (IMDRelation::EreldistrHash == m_rel_distr_policy && NULL != m_distr_opfamilies)
+	{
+		IMDCacheObject::SerializeMDIdList(xml_serializer, m_distr_opfamilies,
+										  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamilies),
+										  CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrOpfamily));
+	}
 	
 	// serialize arguments
 	dxlnode->SerializeChildrenToDXL(xml_serializer);

--- a/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1480,8 +1480,10 @@ CDXLOperatorFactory::MakeDXLHashExpr
 							(
 							dxl_memory_manager,
 							attrs,
-							EdxltokenTypeId,
-							EdxltokenScalarHashExpr
+							EdxltokenOpfamily,
+							EdxltokenScalarHashExpr,
+							true /* is_optional */,
+							NULL /* default_val */
 							);
 
 	return GPOS_NEW(mp) CDXLScalarHashExpr(mp, mdid_type);

--- a/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
+++ b/libnaucrates/src/parser/CParseHandlerMDGPDBScalarOp.cpp
@@ -51,7 +51,9 @@ CParseHandlerMDGPDBScalarOp::CParseHandlerMDGPDBScalarOp
 	m_mdid_commute_opr(NULL),
 	m_mdid_inverse_opr(NULL),
 	m_comparision_type(IMDType::EcmptOther),
-	m_returns_null_on_null_input(false)
+	m_returns_null_on_null_input(false),
+	m_mdid_hash_opfamily(NULL),
+	m_mdid_legacy_hash_opfamily(NULL)
 {
 }
 
@@ -207,6 +209,32 @@ CParseHandlerMDGPDBScalarOp::StartElement
 		this->Append(opfamilies_list_parse_handler);
 		opfamilies_list_parse_handler->startElement(element_uri, element_local_name, element_qname, attrs);
 	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpHashOpfamily), element_local_name))
+	{
+		// parse inverse operator id
+		GPOS_ASSERT(NULL != m_mdname);
+
+		m_mdid_hash_opfamily = CDXLOperatorFactory::ExtractConvertAttrValueToMdId
+													(
+													m_parse_handler_mgr->GetDXLMemoryManager(),
+													attrs,
+													EdxltokenMdid,
+													EdxltokenGPDBScalarOpHashOpfamily
+													);
+	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpLegacyHashOpfamily), element_local_name))
+	{
+		// parse inverse operator id
+		GPOS_ASSERT(NULL != m_mdname);
+
+		m_mdid_legacy_hash_opfamily = CDXLOperatorFactory::ExtractConvertAttrValueToMdId
+													(
+													m_parse_handler_mgr->GetDXLMemoryManager(),
+													attrs,
+													EdxltokenMdid,
+													EdxltokenGPDBScalarOpLegacyHashOpfamily
+													);
+	}
 	else
 	{
 		CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(m_parse_handler_mgr->GetDXLMemoryManager(), element_local_name);
@@ -249,7 +277,7 @@ CParseHandlerMDGPDBScalarOp::EndElement
 		{
 			mdid_opfamilies_array = GPOS_NEW(m_mp) IMdIdArray(m_mp);
 		}
-		m_imd_obj = GPOS_NEW(m_mp) CMDScalarOpGPDB
+			m_imd_obj = GPOS_NEW(m_mp) CMDScalarOpGPDB
 				(
 				m_mp,
 				m_mdid,
@@ -262,7 +290,9 @@ CParseHandlerMDGPDBScalarOp::EndElement
 				m_mdid_inverse_opr,
 				m_comparision_type,
 				m_returns_null_on_null_input,
-				mdid_opfamilies_array
+				mdid_opfamilies_array,
+				m_mdid_hash_opfamily,
+				m_mdid_legacy_hash_opfamily
 				)
 				;
 		
@@ -297,7 +327,9 @@ CParseHandlerMDGPDBScalarOp::IsSupportedChildElem
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpResultTypeId), xml_str) ||
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpFuncId), xml_str) ||
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpCommOpId), xml_str) ||
-			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpInverseOpId), xml_str));
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpInverseOpId), xml_str) ||
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpHashOpfamily), xml_str) ||
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenGPDBScalarOpLegacyHashOpfamily), xml_str));
 }
 
 // EOF

--- a/libnaucrates/src/parser/CParseHandlerMDType.cpp
+++ b/libnaucrates/src/parser/CParseHandlerMDType.cpp
@@ -46,6 +46,8 @@ CParseHandlerMDType::CParseHandlerMDType
 	:
 	CParseHandlerMetadataObject(mp, parse_handler_mgr, parse_handler_root),
 	m_mdid(NULL),
+	m_distr_opfamily(NULL),
+	m_legacy_distr_opfamily(NULL),
 	m_mdname(NULL),
 	m_mdid_eq_op(NULL),
 	m_mdid_neq_op(NULL),
@@ -85,6 +87,8 @@ CParseHandlerMDType::CParseHandlerMDType
 CParseHandlerMDType::~CParseHandlerMDType()
 {
 	m_mdid->Release();
+	CRefCount::SafeRelease(m_distr_opfamily);
+	CRefCount::SafeRelease(m_legacy_distr_opfamily);
 	m_mdid_eq_op->Release();
 	m_mdid_neq_op->Release();
 	m_mdid_lt_op->Release();
@@ -275,6 +279,8 @@ CParseHandlerMDType::ParseMdid
 		{EdxltokenMDTypeAggAvg, &m_mdid_avg_op},
 		{EdxltokenMDTypeAggSum, &m_mdid_sum_op},
 		{EdxltokenMDTypeAggCount, &m_mdid_count_op},
+		{EdxltokenMDTypeDistrOpfamily, &m_distr_opfamily},
+		{EdxltokenMDTypeLegacyDistrOpfamily, &m_legacy_distr_opfamily},
 	};
 	
 	Edxltoken token_type = EdxltokenSentinel;
@@ -432,6 +438,14 @@ CParseHandlerMDType::EndElement
 
 			default:
 				m_mdid->AddRef();
+				if (NULL != m_distr_opfamily)
+				{
+					m_distr_opfamily->AddRef();
+				}
+				if (NULL != m_legacy_distr_opfamily)
+				{
+					m_legacy_distr_opfamily->AddRef();
+				}
 				m_mdid_eq_op->AddRef();
 				m_mdid_neq_op->AddRef();
 				m_mdid_lt_op->AddRef();
@@ -464,6 +478,8 @@ CParseHandlerMDType::EndElement
 										m_istype_fixed_Length,
 										length,
 										m_type_passed_by_value,
+										m_distr_opfamily,
+										m_legacy_distr_opfamily,
 										m_mdid_eq_op,
 										m_mdid_neq_op,
 										m_mdid_lt_op,

--- a/libnaucrates/src/parser/CParseHandlerMetadataIdList.cpp
+++ b/libnaucrates/src/parser/CParseHandlerMetadataIdList.cpp
@@ -121,6 +121,14 @@ CParseHandlerMetadataIdList::StartElement
 		IMDId *mdid = CDXLOperatorFactory::ExtractConvertAttrValueToMdId(m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenMdid, EdxltokenOpfamily);
 		m_mdid_array->Append(mdid);
 	}
+	else if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamily), element_local_name))
+	{
+		// opclass metadata id: array must be initialized already
+		GPOS_ASSERT(NULL != m_mdid_array);
+
+		IMDId *mdid = CDXLOperatorFactory::ExtractConvertAttrValueToMdId(m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenMdid, EdxltokenRelDistrOpfamily);
+		m_mdid_array->Append(mdid);
+	}
 	else
 	{
 		CWStringDynamic *str = CDXLUtils::CreateDynamicStringFromXMLChArray(m_parse_handler_mgr->GetDXLMemoryManager(), element_local_name);
@@ -147,7 +155,8 @@ CParseHandlerMetadataIdList::EndElement
 	if (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenTriggers), element_local_name) ||
 		0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenPartitions), element_local_name)||
 		0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenCheckConstraints), element_local_name) ||
-		0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenOpfamilies), element_local_name))
+		0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenOpfamilies), element_local_name) ||
+		0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies), element_local_name))
 	{
 		// end the index or partition metadata id list
 		GPOS_ASSERT(NULL != m_mdid_array);
@@ -180,7 +189,8 @@ CParseHandlerMetadataIdList::FSupportedElem
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenTrigger), xml_str)  ||
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenPartition), xml_str)  ||
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenCheckConstraint), xml_str)  ||
-			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenOpfamily), xml_str));
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenOpfamily), xml_str) ||
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamily), xml_str));
 }
 
 //---------------------------------------------------------------------------
@@ -200,7 +210,8 @@ CParseHandlerMetadataIdList::FSupportedListType
 	return (0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenTriggers), xml_str)  ||
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenPartitions), xml_str)  ||
 			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenCheckConstraints), xml_str)  ||
-			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenOpfamilies), xml_str));
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenOpfamilies), xml_str) ||
+			0 == XMLString::compareString(CDXLTokens::XmlstrToken(EdxltokenRelDistrOpfamilies), xml_str));
 }
 
 //---------------------------------------------------------------------------

--- a/libnaucrates/src/xml/dxltokens.cpp
+++ b/libnaucrates/src/xml/dxltokens.cpp
@@ -505,6 +505,9 @@ CDXLTokens::Init
 			{EdxltokenRelDistrRandom, GPOS_WSZ_LIT("Random")},
 			{EdxltokenRelDistrReplicated, GPOS_WSZ_LIT("Replicated")},
 			{EdxltokenConvertHashToRandom, GPOS_WSZ_LIT("ConvertHashToRandom")},
+
+			{EdxltokenRelDistrOpfamilies, GPOS_WSZ_LIT("DistrOpfamilies")},
+			{EdxltokenRelDistrOpfamily, GPOS_WSZ_LIT("DistrOpfamily")},
 			
 			{EdxltokenExtRelRejLimit, GPOS_WSZ_LIT("RejectLimit")},
 			{EdxltokenExtRelRejLimitInRows, GPOS_WSZ_LIT("RejectLimitInRows")},
@@ -568,6 +571,8 @@ CDXLTokens::Init
 			{EdxltokenMDTypeFixedLength, GPOS_WSZ_LIT("IsFixedLength")},
 			{EdxltokenMDTypeLength, GPOS_WSZ_LIT("Length")},
 			{EdxltokenMDTypeByValue, GPOS_WSZ_LIT("PassByValue")},
+			{EdxltokenMDTypeDistrOpfamily, GPOS_WSZ_LIT("DistrOpfamily")},
+			{EdxltokenMDTypeLegacyDistrOpfamily, GPOS_WSZ_LIT("LegacyDistrOpfamily")},
 			{EdxltokenMDTypeEqOp, GPOS_WSZ_LIT("EqualityOp")},
 			{EdxltokenMDTypeNEqOp, GPOS_WSZ_LIT("InequalityOp")},
 			{EdxltokenMDTypeLTOp, GPOS_WSZ_LIT("LessThanOp")},
@@ -595,6 +600,8 @@ CDXLTokens::Init
 			{EdxltokenGPDBScalarOpLTOpId, GPOS_WSZ_LIT("LessThanMergeOp")},
 			{EdxltokenGPDBScalarOpGTOpId, GPOS_WSZ_LIT("GreaterThanMergeOp")},
 			{EdxltokenGPDBScalarOpCmpType, GPOS_WSZ_LIT("ComparisonType")},
+			{EdxltokenGPDBScalarOpHashOpfamily, GPOS_WSZ_LIT("HashOpfamily")},
+			{EdxltokenGPDBScalarOpLegacyHashOpfamily, GPOS_WSZ_LIT("LegacyHashOpfamily")},
 			
 			{EdxltokenCmpEq, GPOS_WSZ_LIT("Eq")}, 
 			{EdxltokenCmpNeq, GPOS_WSZ_LIT("NEq")},	

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -295,7 +295,13 @@ CDqaTest:
 DqaHavingMax DqaMax DqaMin DqaSubqueryMax DqaNoRedistribute;
 
 CMCVCardinalityTest:
-BpCharMCVCardinalityEquals BpCharMCVCardinalityGreaterThan TextMCVCardinalityEquals TextMCVCardinalityGreaterThan VarcharMCVCardinalityEquals VarcharMCVCardinalityGreaterThan Citext-Cardinality Name-Cardinality Char-Cardinality 
+BpCharMCVCardinalityEquals BpCharMCVCardinalityGreaterThan TextMCVCardinalityEquals TextMCVCardinalityGreaterThan VarcharMCVCardinalityEquals VarcharMCVCardinalityGreaterThan Citext-Cardinality Name-Cardinality Char-Cardinality;
+
+COpfamiliesTest:
+JoinCitextVarchar JoinDefaultOpfamiliesUsingNonDefaultOpfamilyOp
+MultiColumnAggWithDefaultOpfamilies JoinTinterval FullJoin-NonDefaultOpfamily
+JoinAbsEqWithoutOpfamilies 3WayJoinUsingOperatorsOfNonDefaultOpfamily
+
 ")
 
 set(mdp_dir "../data/dxl/minidump/")


### PR DESCRIPTION
This PR is Part 2 of the split from the previous WIP PR: #559.

Part 1 captures the Refactor commits & large MDP changes.
Part 2 captures the core commits to support opfamilies in ORCA.

All rebased now & ready to review! Please review this commit by commit - they are rather self-contained.

GPDB PR: https://github.com/greenplum-db/gpdb/pull/9401

FAQs

### How does this work?
  1. For hash joins, capture the opfamily of each hash joinable operator. Use that to create hash distribution spec requests for either side of the join.
  2. Scan operators derive a distribution spec based on opfamily (corresponding to the opclass) of each distribution column.
  3. If there is a mismatch between distribution spec requested/derived, add a Motion Redistribute node using the distribution function from the requested hash opfamily.

### What new information is captured from GPDB?
  1. Opfamily of each distribution column for every GPDB tables, external tables, CTAS tables.
    1. Needed for basic functionality.
  2. Compatible hash opfamily for each scalar operator.
    1. This finds the first hash opfamily that contains the operator.
    2. Needed for basic functionality.
  3. Default distribution (hash) opfamily of every type.
    1. Maybe NULL for some types.
    2. Needed for certain operators (e.g HashAgg) that request distribution spec that cannot be inferred in any other way: cannot derive it, cannot get it from any scalar op etc.
  4. Legacy opfamilies for types & scalar operators.
    1. Needed for supporting tables distributed by legacy opclasses.

### Did you add any traceflags? What are they for?
  1. EopttraceConsiderOpfamiliesForDistribution:
    1. GPDB6 enables this by default.
    2. If this is off, opfamilies is ignored and set to NULL.
    3. This should mimic behavior before this PR. Ctest MDPs are run this way.
  2. EopttraceUseLegacyOpfamilies:
    1. Set if ANY distribution col in the query uses a legacy opfamily/opclass.
    2. The MDCache captures both legacy and new opfamilies.
    3. Code returns legacy opfamilies instead of the default when this is set
### Assumptions made in the PR:
  1. In the distribution spec,
    1. Opfamilies arrays must be populated (if EopttraceConsiderOpfamiliesForDistribution is set) or NULL (if unset)
    2. Opfamilies array must not contain a NULL element.
  2. In PdsCopyWithRemappedColumns(), remapping columns will not change opfamily
  3. Gp\_use\_legacy\_hashops GUC is irrelevant in this effort.5
  4. When determining equiv classes, only consider operators that apply on the default opfamilies of the left type. (Needed for some CDistributionSpecHashed matching functions)

### What work is left?
  [ ] Add any missing assertions, throw exceptions & add tests! So highlight this if you see it!
  [ ] Refactor to use a factory method for CDistributionSpecHashed.