### PR TITLE
Introduce traceflag for histogram based scale factor calculation

### DIFF
--- a/data/dxl/minidump/HistogramBasedScaleFactor.mdp
+++ b/data/dxl/minidump/HistogramBasedScaleFactor.mdp
@@ -1,0 +1,2056 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+ <dxl:Comment><![CDATA[
+
+  Objective: without traceflag 104008, optimizer_dpe_stats has no 
+  effect on the cardinality of outer table in presence of a 
+  dynamic partition selection. 
+  
+  create table part_fact (id int, rank int)
+  distributed by (id)
+  partition by range (rank)
+  ( start (1) end (100) every (10), 
+    default partition extra ); 
+    
+  create table dim (a int, b int);
+
+  insert into part_fact select i, i%110 from generate_series(1,1000000)i;
+  insert into dim select i,i from generate_series(-1000,1000)i;
+  set optimizer_dpe_stats to on;
+
+  -- set traceflag 104008
+
+  explain select * from part_fact, dim where rank = b and a >50;
+
+  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..932.91 rows=470422 width=16)
+   ->  Hash Join  (cost=0.00..904.86 rows=156808 width=16)
+         Hash Cond: (part_fact.rank = dim.b)
+         ->  Dynamic Seq Scan on part_fact (dynamic scan id: 1)  (cost=0.00..434.28 rows=156808 width=8)
+         ->  Hash  (cost=100.00..100.00 rows=34 width=4)
+               ->  Partition Selector for part_fact (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.18 rows=950 width=8)
+                           ->  Seq Scan on dim  (cost=0.00..431.04 rows=317 width=8)
+                                 Filter: (a > 50)
+  
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
+      <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103022,103027,103029,104002,104003,104004,104005,104008,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.174866.1.0" Name="dim" Rows="2001.000000" EmptyRelation="false"/>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Relation Mdid="0.174866.1.0" Name="dim" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.174866.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.174866.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-1000"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="-20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="-20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="20.010000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2118.1.0"/>
+        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.174819.1.0.1" Name="rank" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="0"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="13"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="13"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="14"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="14"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="15"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="15"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="16"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="16"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="17"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="17"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="18"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="18"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="19"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="23"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="23"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="24"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="24"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="25"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="25"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="26"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="26"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="27"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="27"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="28"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="28"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="29"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="29"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="31"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="31"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="33"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="33"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="34"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="34"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="35"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="35"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="36"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="36"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="37"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="37"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="38"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="38"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="39"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="39"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="41"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="41"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="44"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="44"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="45"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="45"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="46"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="46"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="47"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="47"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="48"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="48"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="49"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="49"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="51"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="51"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="53"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="53"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="55"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="55"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="56"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="56"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="57"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="57"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="58"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="58"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="59"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="59"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="61"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="61"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="62"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="62"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="64"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="64"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="66"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="66"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="67"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="67"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="68"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="68"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="69"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="69"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="71"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="71"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="72"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="72"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="74"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="74"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="75"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="75"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="76"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="76"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="78"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="78"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="79"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="79"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="81"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="81"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="82"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="82"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="84"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="84"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="85"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="85"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="86"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="86"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="88"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="88"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="89"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="89"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="91"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="91"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="92"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="92"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="94"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="94"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="95"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="95"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="96"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="96"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="97"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="97"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="98"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="98"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="101"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="101"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="103"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="103"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="104"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="104"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="105"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="105"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="106"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="106"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="107"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="107"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="108"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="1.100000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="108"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="109"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.174819.1.0.0" Name="id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11324"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11324"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="22102"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="22102"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="32883"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="32883"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="42890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="42890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="52908"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="52908"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="63137"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="63137"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="73368"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="73368"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="83376"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="83376"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="93385"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="93385"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="103720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="103720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="113738"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="113738"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="123300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="123300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="132913"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="132913"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="143214"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="143214"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="153551"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="153551"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="163676"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="163676"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="173352"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="173352"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="183361"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="183361"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="193705"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="193705"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="204597"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="204597"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="214714"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="214714"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="224501"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="224501"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="233860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="233860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="244305"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="244305"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="255302"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="255302"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="265091"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="265091"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="274670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="274670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="284787"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="284787"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="294901"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="294901"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="304915"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="304915"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="314567"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="314567"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="324492"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="324492"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="334727"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="334727"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="344622"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="344622"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="355079"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="355079"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="364976"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="364976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="374329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="374329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="384444"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="384444"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="394233"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="394233"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="404578"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="404578"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="414329"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="414329"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="424814"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="424814"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="434715"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="434715"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="444682"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="444682"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="455132"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="455132"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="464922"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="464922"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="475268"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="475268"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="484840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="484840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="494887"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="494887"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="505775"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="505775"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="515569"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="515569"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="525250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="525250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="535257"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="535257"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="545119"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="545119"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="555122"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="555122"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="565683"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="565683"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="575255"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="575255"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="585087"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="585087"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="594659"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="594659"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="604331"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="604331"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="614566"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="614566"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="624575"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="624575"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="634589"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="634589"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="644370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="644370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="653941"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="653941"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="663911"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="663911"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="673960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="673960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="683754"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="683754"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="694205"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="694205"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="704211"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="704211"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="712976"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="712976"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="723202"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="723202"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="733541"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="733541"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="743009"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="743009"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="753124"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="753124"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="763580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="763580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="772599"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="772599"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="782382"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="782382"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="792527"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="792527"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="802209"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="802209"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="812548"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="812548"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="822551"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="822551"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="832900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="832900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="843121"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="843121"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="852258"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="852258"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="862138"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="862138"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="872034"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="872034"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="881829"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="881829"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="891726"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="891726"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="901737"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="901737"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="911200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="911200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="921600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="921600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930997"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930997"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940897"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940897"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="951237"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="951237"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960804"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960804"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970959"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970959"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980412"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980412"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990589"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="8940.530000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990589"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.174819.1.0" Name="part_fact" Rows="1000000.000000" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.174819.1.0" Name="part_fact" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="11">
+        <dxl:Columns>
+          <dxl:Column Name="id" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="rank" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true"/>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="id" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="rank" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.174819.1.0" TableName="part_fact">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="rank" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="0.174866.1.0" TableName="dim">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="rank" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+          </dxl:Comparison>
+        </dxl:And>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="932.909998" Rows="470421.456818" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="id">
+            <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="rank">
+            <dxl:Ident ColId="1" ColName="rank" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="b">
+            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="904.860335" Rows="470421.456818" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="id">
+              <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="rank">
+              <dxl:Ident ColId="1" ColName="rank" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="rank" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:DynamicTableScan PartIndexId="1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="434.277269" Rows="470421.456818" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="id">
+                <dxl:Ident ColId="0" ColName="id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="rank">
+                <dxl:Ident ColId="1" ColName="rank" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="0.174819.1.0" TableName="part_fact">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="rank" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:DynamicTableScan>
+          <dxl:PartitionSelector RelationMdid="0.174819.1.0" PartitionLevels="1" ScanId="1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartEqFilters>
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:PartEqFilters>
+            <dxl:PartFilters>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:PartFilters>
+            <dxl:ResidualFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ResidualFilter>
+            <dxl:PropagationExpression>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:PropagationExpression>
+            <dxl:PrintableFilter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="1" ColName="rank" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:PrintableFilter>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.176559" Rows="2848.423500" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.040594" Rows="949.474500" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="a">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="b">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="50"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.174866.1.0" TableName="dim">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:PartitionSelector>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -227,6 +227,10 @@ namespace gpos
 
 		// Use calibrated bitmap index cost model
 		EopttraceCalibratedBitmapIndexCostModel = 104007,
+
+		// Use scale_factor derived from histogram buckets
+		// see CBucket::MakeBucketIntersect()
+		EopttraceComputeScaleFactorFromHistogramBuckets = 104008,
 		///////////////////////////////////////////////////////
 		/////////// constant expression evaluator flags ///////
 		///////////////////////////////////////////////////////

--- a/libnaucrates/src/statistics/CHistogram.cpp
+++ b/libnaucrates/src/statistics/CHistogram.cpp
@@ -740,7 +740,9 @@ CHistogram::MakeJoinHistogramNormalize
 	// TODO: legacy code, apply the Ramakrishnan and Gehrke method again on the entire table,
 	// ignoring the computation we did on each histogram bucket in
 	// CBucket::MakeBucketIntersect()
-	if (!CJoinStatsProcessor::ComputeScaleFactorFromHistogramBuckets())
+	if (!CJoinStatsProcessor::ComputeScaleFactorFromHistogramBuckets() &&
+		!GPOS_FTRACE(EopttraceComputeScaleFactorFromHistogramBuckets)
+	   )
 	{
 		*scale_factor = std::max
 							(

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -140,7 +140,7 @@ OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP OverlappingHomogenousIndexe
 SingleColumnHomogenousIndexOnRoot-AO SingleColumnHomogenousIndexOnRoot-HEAP;
 
 CStatsTest:
-Stat-Derivation-Leaf-Pattern MissingBoolColStats JoinColWithOnlyNDV UnsupportedStatsPredicate;
+HistogramBasedScaleFactor Stat-Derivation-Leaf-Pattern MissingBoolColStats JoinColWithOnlyNDV UnsupportedStatsPredicate;
 
 CICGMiscTest:
 BroadcastSkewedHashjoin OrderByNullsFirst ConvertHashToRandomSelect ConvertHashToRandomInsert HJN-DeeperOuter CTAS CTAS-Random CheckAsUser


### PR DESCRIPTION
In MakeJoinHistogramNormalize, we apply the Ramakrishnan and Gehrke method
again on the entire table,ignoring the computation we did on each histogram
bucket in CBucket::MakeBucketIntersect(). Introduce a traceflag that let's us
use histogram based scale factor calculation.