### PR TITLE
Convert ORCA pipelines to use Vault variables

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -99,118 +99,118 @@ resources:
 - name: bin_xerces_centos5
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_xerces_centos5.tar.gz
 
 - name: bin_xerces_ubuntu18
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_xerces_ubuntu18.tar.gz
 
 - name: bin_orca_ubuntu18_debug
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_ubuntu18_debug.tar.gz
 
 - name: bin_orca_ubuntu18_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_ubuntu18_release.tar.gz
 
 - name: bin_orca_centos5_debug
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos5_debug.tar.gz
 
 - name: bin_orca_centos5_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos5_release.tar.gz
 
 - name: bin_orca_centos6_debug
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos6_debug.tar.gz
 
 - name: bin_orca_centos6_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos6_release.tar.gz
 
 - name: bin_orca_centos7_debug
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos7_debug.tar.gz
 
 - name: bin_orca_centos7_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos7_release.tar.gz
 
 - name: regression_diffs
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: regression.diffs
 
 - name: regression_out
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: regression.out
 
 - name: bin_gpdb_centos6
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{bucket-name}}
     region_name: {{aws-region}}
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_gpdb_with_orca_centos6.tar.gz
 
 ########

--- a/concourse/pr_pipeline.yml
+++ b/concourse/pr_pipeline.yml
@@ -9,7 +9,7 @@ resources:
     type: pull_request
     source:
       repo: greenplum-db/gporca
-      access_token: {{gporcabot_access_token}}
+      access_token: ((qp/gporcabot_access_token))
       ignore_paths:
       - README.md
       - LICENSE
@@ -29,10 +29,10 @@ resources:
   - name: bin_xerces_centos5
     type: s3
     source:
-      access_key_id: {{s3_access_key_id}}
+      access_key_id: ((qp/s3_access_key_id))
       bucket: {{bucket-name}}
       region_name: {{aws-region}}
-      secret_access_key: {{s3_secret_access_key}}
+      secret_access_key: ((qp/s3_secret_access_key))
       versioned_file: bin_xerces_centos5.tar.gz
 
   - name: centos5-build

--- a/concourse/test_explain_pipeline.yml
+++ b/concourse/test_explain_pipeline.yml
@@ -9,7 +9,7 @@ resources:
   type: git
   source:
     branch: {{branch_name}}
-    private_key: {{slack-trigger-git-key}}
+    private_key: ((qp/slack-trigger-git-key))
     uri: {{slack-trigger-git-remote}}
 - name: orca_main_src  # used for yml task files
   type: git
@@ -35,18 +35,18 @@ resources:
 - name: bin_gpdb_centos6
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_gpdb_with_orca_centos6.tar.gz
 - name: bin_gpdb_baseline_centos6
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_gpdb_baseline_with_orca_centos6.tar.gz
 - name: gpdb_main_src  # used for yml task files
   type: git
@@ -68,82 +68,82 @@ resources:
 - name: gpdb_tarball
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: gpdb_src.tar.gz
 - name: gpdb_baseline_tarball
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: gpdb_baseline_src.tar.gz
 - name: bin_orca_centos5_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos5_release.tar.gz
 - name: bin_orca_baseline_centos5_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_baseline_centos5_release.tar.gz
 - name: bin_xerces_centos5
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_xerces_centos5.tar.gz
 - name: orca_tarball
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: orca_src.tar.gz
 - name: explain_test_suite
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: {{explain_workload_tar}}
 - name: explain_output
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: explain_output.tar.gz
 - name: explain_output_baseline
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: explain_output_baseline.tar.gz
 - name: explain_test_results
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: {{explain_workload_results}}
 
 resource_types: []

--- a/concourse/test_orca_pipeline.yml
+++ b/concourse/test_orca_pipeline.yml
@@ -4,15 +4,15 @@ resources:
   type: git
   source:
     branch: master
-    private_key: {{slack-trigger-git-key}}
+    private_key: ((qp/slack-trigger-git-key))
     uri: {{slack-trigger-git-remote}}
 - name: regression_diffs
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: regression.diffs
 - name: orca_main_src
   type: git
@@ -32,18 +32,18 @@ resources:
 - name: regression_out
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: regression.out
 - name: bin_gpdb_centos6
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_gpdb_with_orca_centos6.tar.gz
 - name: gpdb_main_src
   type: git
@@ -58,42 +58,42 @@ resources:
 - name: gpdb_tarball
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: gpdb_src.tar.gz
 - name: bin_orca_centos5_debug
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos5_debug.tar.gz
 - name: bin_orca_centos5_release
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_orca_centos5_release.tar.gz
 - name: bin_xerces_centos5
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: bin_xerces_centos5.tar.gz
 - name: orca_tarball
   type: s3
   source:
-    access_key_id: {{s3_access_key_id}}
+    access_key_id: ((qp/s3_access_key_id))
     bucket: {{gporca-concourse-bucket-dev}}
     region_name: us-west-2
-    secret_access_key: {{s3_secret_access_key}}
+    secret_access_key: ((qp/s3_secret_access_key))
     versioned_file: orca_src.tar.gz
 - name: centos5-build
   type: registry-image


### PR DESCRIPTION
Updated and deployed pipelines:
- https://qpa.ci.gpdb.pivotal.io/teams/main/pipelines/gporca
- https://qpa.ci.gpdb.pivotal.io/teams/main/pipelines/gporca_pr.yml
- https://qpa.ci.gpdb.pivotal.io/teams/main/pipelines/ds_explain_5X
- https://qpa.ci.gpdb.pivotal.io/teams/main/pipelines/index_explain_5X
- https://qpa.ci.gpdb.pivotal.io/teams/main/pipelines/gporca-dev